### PR TITLE
fix(ci): detect dependabot pr author correctly

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -22,7 +22,10 @@ jobs:
       contents: write
       pull-requests: write
     if: |
-      github.actor == 'dependabot[bot]' &&
+      (
+        github.event.pull_request.user.login == 'dependabot[bot]' ||
+        github.event.pull_request.user.login == 'app/dependabot'
+      ) &&
       contains(github.event.pull_request.labels.*.name, 'auto-merge')
     steps:
       - name: Fetch Dependabot metadata


### PR DESCRIPTION
Corrige o workflow de auto-merge do Dependabot para usar o autor do PR em vez do actor do evento. Isso cobre PRs criados por  e também eventos , onde o actor passa a ser quem aplicou a label.