### PR TITLE
chore(release): add metadata baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+This file is the baseline for automated release management via Release Please.
+Subsequent entries should be generated from release automation.

--- a/app.json
+++ b/app.json
@@ -9,7 +9,8 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "buildNumber": "1"
     },
     "android": {
       "adaptiveIcon": {
@@ -20,7 +21,8 @@
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
-      "package": "com.sensoriumit.auraxis"
+      "package": "com.sensoriumit.auraxis",
+      "versionCode": 1
     },
     "web": {
       "output": "static",


### PR DESCRIPTION
## Summary\n- add `android.versionCode` and `ios.buildNumber` to `app.json`\n- add initial `CHANGELOG.md` baseline for release automation\n- reduce concrete metadata gaps reported by the platform release governance doctor\n\n## Validation\n- parsed `app.json` and confirmed `android.versionCode=1` and `ios.buildNumber=1`\n- verified `CHANGELOG.md` exists at repo root\n