### PR TITLE
chore(app): align mobile contracts and api governance

### DIFF
--- a/.context/handoffs/APP5-mobile-foundation.md
+++ b/.context/handoffs/APP5-mobile-foundation.md
@@ -62,3 +62,69 @@
 - sincronizar o baseline de contratos OpenAPI do app com o estado mais recente da `auraxis-api`;
 - abrir o próximo slice do app para `auth + bootstrap + plans/paywall`, agora já sobre `route guards`, `apiContractMap`, `queryKeys`, `theme/motion` e `shared/forms`;
 - usar `shared/testing/test-providers.tsx` como base para os testes das próximas telas e hooks visuais.
+
+---
+
+## Update - APP FND-01
+
+### O que foi feito
+- sincronizei o snapshot OpenAPI do app com a `auraxis-api` local via [`scripts/contracts-sync-local-api.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/scripts/contracts-sync-local-api.cjs), atualizando:
+  - [`contracts/openapi.snapshot.json`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/contracts/openapi.snapshot.json)
+  - [`shared/types/generated/openapi.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/shared/types/generated/openapi.ts)
+- ampliei o catálogo e o mapa canônico de contratos em:
+  - [`shared/contracts/api-endpoint-catalog.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/shared/contracts/api-endpoint-catalog.ts)
+  - [`shared/contracts/api-contract-map.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/shared/contracts/api-contract-map.ts)
+- adicionei o domínio canônico de `entitlements` em [`features/entitlements`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/features/entitlements) e conectei query keys em [`core/query/query-keys.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/core/query/query-keys.ts);
+- removi consumo ativo de rotas soltas ou libs legadas dos fluxos já em uso, migrando para services/contratos canônicos em:
+  - [`features/dashboard/services/dashboard-service.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/features/dashboard/services/dashboard-service.ts)
+  - [`features/alerts/services/alerts-service.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/features/alerts/services/alerts-service.ts)
+  - [`hooks/queries/use-alerts-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-alerts-query.ts)
+  - [`hooks/queries/use-alert-preferences-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-alert-preferences-query.ts)
+  - [`hooks/queries/use-dashboard-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-dashboard-query.ts)
+  - [`hooks/queries/use-entitlement-check-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-entitlement-check-query.ts)
+  - [`hooks/queries/use-entitlement-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-entitlement-query.ts)
+  - [`hooks/queries/use-subscription-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-subscription-query.ts)
+  - [`hooks/queries/use-wallet-query.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/queries/use-wallet-query.ts)
+  - [`hooks/mutations/use-delete-alert-mutation.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/mutations/use-delete-alert-mutation.ts)
+  - [`hooks/mutations/use-mark-read-mutation.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/mutations/use-mark-read-mutation.ts)
+  - [`hooks/mutations/use-update-preference-mutation.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/hooks/mutations/use-update-preference-mutation.ts)
+- movi a configuração de URLs web para a trilha compartilhada em [`shared/config/web-urls.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/shared/config/web-urls.ts), mantendo [`lib/web-urls.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/lib/web-urls.ts) só como compatibilidade;
+- adicionei guardrails para falhar cedo localmente:
+  - [`scripts/check-api-contract-governance.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/scripts/check-api-contract-governance.cjs) bloqueia imports ativos de `@/lib/*-api` e strings soltas de endpoint;
+  - [`package.json`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/package.json) agora acopla esse check ao `policy:check` e ao `lint-staged`;
+- alinhei a compatibilidade de `entitlements` para suportar shape moderno e legado em:
+  - [`types/contracts/entitlement.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/types/contracts/entitlement.ts)
+  - [`lib/entitlements-api.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/lib/entitlements-api.ts)
+
+### O que foi validado
+- `npm run contracts:sync:api-local`
+- `npm run policy:check`
+- `npm run contracts:check`
+- `npm run typecheck`
+- `npx jest shared/contracts/api-contract-map.test.ts hooks/queries/use-alerts-query.spec.ts hooks/queries/use-subscription-query.spec.ts lib/web-urls.test.ts lib/entitlements-api.test.ts --runInBand`
+- `npm run quality-check`
+- `git diff --check`
+
+### Riscos pendentes
+- o backend ainda não publica todas as rotas de `alerts` e `subscriptions` no snapshot OpenAPI, então o app mantém uma lista explícita de gaps conhecidos em [`shared/contracts/api-contract-map.test.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/shared/contracts/api-contract-map.test.ts);
+- a camada legada `lib/`, `hooks/` e `stores/` ainda existe, mas agora ficou restrita a compatibilidade. A remoção total entra no próximo bloco;
+- ainda faltam scaffolds canônicos para `transactions`, `shared-entries`, `fiscal`, `profile` e `questionnaire`.
+
+### Proximo passo
+- seguir para `APP FND-02`, fechando shell, sessão, lifecycle, deep links e retorno de checkout;
+- manter o guardrail de contratos ativo para que qualquer novo consumo da API já nasça tipado e preso ao catálogo canônico.
+
+### Addendum - Gitleaks / contract hygiene
+- o PR `#210` revelou um atrito estrutural no CI: exemplos realistas demais de `token`, `refresh_token`, JWT e `X-Request-ID` dentro do snapshot OpenAPI estavam acionando `Gitleaks`;
+- a correção foi feita na raiz do fluxo de contratos:
+  - [`scripts/openapi-secret-hygiene.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/scripts/openapi-secret-hygiene.cjs) sanitiza exemplos sensíveis antes do snapshot ser versionado;
+  - [`scripts/check-openapi-secret-hygiene.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/scripts/check-openapi-secret-hygiene.cjs) falha cedo localmente quando o snapshot ou os tipos gerados carregam exemplos que parecem segredo;
+  - [`scripts/contracts-sync.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/scripts/contracts-sync.cjs) agora escreve apenas o snapshot já sanitizado;
+  - [`scripts/contracts-check.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/scripts/contracts-check.cjs) valida essa higiene como parte do fluxo de contratos;
+  - [`lint-staged.config.js`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/lint-staged.config.js) e [`.husky/pre-push`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/.husky/pre-push) foram endurecidos para executar esse guardrail antes do CI.
+- validação do fix:
+  - `npm run contracts:sync:api-local`
+  - `node scripts/check-openapi-secret-hygiene.cjs`
+  - `npm run policy:check`
+  - `npm run contracts:check`
+  - busca explícita pelos literais reportados pelo Gitleaks (`rg`) retornando vazio em `contracts/openapi.snapshot.json` e `shared/types/generated/openapi.ts`

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,3 +1,9 @@
+echo "🛡 Running policy checks before push..."
+npm run policy:check
+
+echo "🔗 Running contract checks before push..."
+npm run contracts:check
+
 echo "🔍 Running TypeScript check before push..."
 npx tsc --noEmit
 

--- a/app/(private)/assinatura.tsx
+++ b/app/(private)/assinatura.tsx
@@ -5,7 +5,7 @@ import { LoadingSkeleton } from "@/components/ui/loading-skeleton";
 import { ScreenContainer } from "@/components/ui/screen-container";
 import { borderWidths, colorPalette, fontSizes, radii, spacing, typography } from "@/config/design-tokens";
 import { useSubscriptionQuery } from "@/hooks/queries/use-subscription-query";
-import { MANAGE_SUBSCRIPTION_URL } from "@/lib/web-urls";
+import { MANAGE_SUBSCRIPTION_URL } from "@/shared/config/web-urls";
 
 const styles = StyleSheet.create({
   card: {

--- a/app/(public)/login.tsx
+++ b/app/(public)/login.tsx
@@ -13,7 +13,7 @@ import {
 import { borderWidths, colorPalette, fontSizes, radii, spacing, typography } from "@/config/design-tokens";
 import { useLoginForm } from "@/hooks/forms/use-login-form";
 import { useLoginMutation } from "@/hooks/mutations/use-auth-mutations";
-import { PRIVACY_URL, TERMS_URL } from "@/lib/web-urls";
+import { PRIVACY_URL, TERMS_URL } from "@/shared/config/web-urls";
 
 const styles = StyleSheet.create({
   card: {

--- a/contracts/feature-contract-baseline.json
+++ b/contracts/feature-contract-baseline.json
@@ -1,14 +1,9 @@
 {
-  "generatedAt": "2026-03-10T14:34:00.562Z",
+  "generatedAt": "2026-04-07T20:16:11.306Z",
   "source": {
     "owner": "italofelipe",
     "repo": "auraxis-platform",
     "ref": "master"
   },
-  "packs": [
-    {
-      "taskId": "B11",
-      "sha256": "0af9efbee6036b6b21f2ee6160ebb1ee9b866a450c1011d7d2cfa4e48a13c65c"
-    }
-  ]
+  "packs": []
 }

--- a/contracts/openapi.snapshot.json
+++ b/contracts/openapi.snapshot.json
@@ -1,5 +1,822 @@
 {
   "components": {
+    "schemas": {
+      "InstallmentVsCashCalculation": {
+        "properties": {
+          "cash_price": {
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "fees_enabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "fees_upfront": {
+            "default": "0.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "first_payment_delay_days": {
+            "default": 30,
+            "maximum": 3650,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inflation_rate_annual": {
+            "maximum": 1000,
+            "minimum": 0,
+            "type": "number"
+          },
+          "installment_amount": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "installment_count": {
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_total": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_annual": {
+            "default": null,
+            "maximum": 1000,
+            "minimum": 0,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_type": {
+            "default": "manual",
+            "enum": ["manual", "product_default", "inflation_only"],
+            "type": "string"
+          },
+          "scenario_label": {
+            "default": null,
+            "maxLength": 120,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": ["cash_price", "inflation_rate_annual", "installment_count"],
+        "type": "object"
+      },
+      "InstallmentVsCashGoalBridge": {
+        "properties": {
+          "category": {
+            "default": "planned_purchase",
+            "maxLength": 64,
+            "nullable": true,
+            "type": "string"
+          },
+          "current_amount": {
+            "default": "0.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "description": {
+            "default": null,
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "priority": {
+            "default": 3,
+            "maximum": 5,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "selected_option": {
+            "enum": ["cash", "installment"],
+            "type": "string"
+          },
+          "target_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": ["selected_option", "title"],
+        "type": "object"
+      },
+      "InstallmentVsCashPlannedExpenseBridge": {
+        "properties": {
+          "account_id": {
+            "default": null,
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "credit_card_id": {
+            "default": null,
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "default": "BRL",
+            "maxLength": 3,
+            "minLength": 3,
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "maxLength": 300,
+            "nullable": true,
+            "type": "string"
+          },
+          "due_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "first_due_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "observation": {
+            "default": null,
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "selected_option": {
+            "enum": ["cash", "installment"],
+            "type": "string"
+          },
+          "status": {
+            "default": "pending",
+            "enum": ["pending", "paid", "cancelled", "postponed", "overdue"],
+            "type": "string"
+          },
+          "tag_id": {
+            "default": null,
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "upfront_due_date": {
+            "default": null,
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": ["selected_option", "title"],
+        "type": "object"
+      },
+      "InstallmentVsCashSave": {
+        "properties": {
+          "cash_price": {
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "fees_enabled": {
+            "default": false,
+            "type": "boolean"
+          },
+          "fees_upfront": {
+            "default": "0.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "first_payment_delay_days": {
+            "default": 30,
+            "maximum": 3650,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "inflation_rate_annual": {
+            "maximum": 1000,
+            "minimum": 0,
+            "type": "number"
+          },
+          "installment_amount": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "installment_count": {
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_total": {
+            "default": null,
+            "minimum": 0.01,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_annual": {
+            "default": null,
+            "maximum": 1000,
+            "minimum": 0,
+            "nullable": true,
+            "type": "number"
+          },
+          "opportunity_rate_type": {
+            "default": "manual",
+            "enum": ["manual", "product_default", "inflation_only"],
+            "type": "string"
+          },
+          "scenario_label": {
+            "default": null,
+            "maxLength": 120,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "required": ["cash_price", "inflation_rate_annual", "installment_count"],
+        "type": "object"
+      },
+      "TransactionCreate": {
+        "properties": {
+          "account_id": {
+            "description": "ID da conta bancária associada",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "amount": {
+            "description": "Valor da transação",
+            "example": "150.50",
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "created_at": {
+            "description": "Data de criação da transação",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "credit_card_id": {
+            "description": "ID do cartão de crédito associado",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "description": "Código da moeda (ISO 4217)",
+            "example": "BRL",
+            "maxLength": 3,
+            "minLength": 3,
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "description": "Descrição detalhada da transação",
+            "example": "Conta de energia elétrica do mês de janeiro",
+            "maxLength": 300,
+            "nullable": true,
+            "type": "string"
+          },
+          "due_date": {
+            "description": "Data de vencimento da transação",
+            "example": "2024-02-15",
+            "format": "date",
+            "type": "string"
+          },
+          "end_date": {
+            "default": null,
+            "description": "Data de fim (para transações recorrentes)",
+            "example": "2024-12-31",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "ID único da transação (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "installment_count": {
+            "description": "Número de parcelas (apenas se is_installment=True)",
+            "example": 12,
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_group_id": {
+            "description": "ID do grupo de parcelas (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "is_installment": {
+            "description": "Indica se a transação é parcelada",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_recurring": {
+            "description": "Indica se a transação é recorrente",
+            "example": false,
+            "type": "boolean"
+          },
+          "observation": {
+            "default": null,
+            "description": "Observações adicionais sobre a transação",
+            "example": "Pagar até o dia 10 para evitar multa",
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "paid_at": {
+            "description": "Data e hora do pagamento",
+            "example": "2024-02-10T14:30:00Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "start_date": {
+            "default": null,
+            "description": "Data de início (para transações recorrentes)",
+            "example": "2024-01-01",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Status atual da transação",
+            "enum": ["paid", "pending", "cancelled", "postponed", "overdue"],
+            "example": "pending",
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "ID da tag associada à transação",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "description": "Título da transação",
+            "example": "Pagamento da conta de luz",
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Tipo da transação: receita ou despesa",
+            "enum": ["income", "expense"],
+            "example": "expense",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Data da última atualização",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "user_id": {
+            "description": "ID do usuário proprietário da transação",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "required": ["amount", "due_date", "title", "type"],
+        "type": "object"
+      },
+      "TransactionCreate_7d3b606eab": {
+        "properties": {
+          "account_id": {
+            "description": "ID da conta bancária associada",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "amount": {
+            "description": "Valor da transação",
+            "example": "150.50",
+            "minimum": 0.01,
+            "type": "number"
+          },
+          "created_at": {
+            "description": "Data de criação da transação",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "credit_card_id": {
+            "description": "ID do cartão de crédito associado",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "currency": {
+            "description": "Código da moeda (ISO 4217)",
+            "example": "BRL",
+            "maxLength": 3,
+            "minLength": 3,
+            "type": "string"
+          },
+          "description": {
+            "default": null,
+            "description": "Descrição detalhada da transação",
+            "example": "Conta de energia elétrica do mês de janeiro",
+            "maxLength": 300,
+            "nullable": true,
+            "type": "string"
+          },
+          "due_date": {
+            "description": "Data de vencimento da transação",
+            "example": "2024-02-15",
+            "format": "date",
+            "type": "string"
+          },
+          "end_date": {
+            "default": null,
+            "description": "Data de fim (para transações recorrentes)",
+            "example": "2024-12-31",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "id": {
+            "description": "ID único da transação (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "installment_count": {
+            "description": "Número de parcelas (apenas se is_installment=True)",
+            "example": 12,
+            "maximum": 60,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "installment_group_id": {
+            "description": "ID do grupo de parcelas (gerado automaticamente)",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          },
+          "is_installment": {
+            "description": "Indica se a transação é parcelada",
+            "example": false,
+            "type": "boolean"
+          },
+          "is_recurring": {
+            "description": "Indica se a transação é recorrente",
+            "example": false,
+            "type": "boolean"
+          },
+          "observation": {
+            "default": null,
+            "description": "Observações adicionais sobre a transação",
+            "example": "Pagar até o dia 10 para evitar multa",
+            "maxLength": 500,
+            "nullable": true,
+            "type": "string"
+          },
+          "paid_at": {
+            "description": "Data e hora do pagamento",
+            "example": "2024-02-10T14:30:00Z",
+            "format": "date-time",
+            "nullable": true,
+            "type": "string"
+          },
+          "start_date": {
+            "default": null,
+            "description": "Data de início (para transações recorrentes)",
+            "example": "2024-01-01",
+            "format": "date",
+            "nullable": true,
+            "type": "string"
+          },
+          "status": {
+            "description": "Status atual da transação",
+            "enum": ["paid", "pending", "cancelled", "postponed", "overdue"],
+            "example": "pending",
+            "type": "string"
+          },
+          "tag_id": {
+            "description": "ID da tag associada à transação",
+            "format": "uuid",
+            "nullable": true,
+            "type": "string"
+          },
+          "title": {
+            "description": "Título da transação",
+            "example": "Pagamento da conta de luz",
+            "maxLength": 120,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": {
+            "description": "Tipo da transação: receita ou despesa",
+            "enum": ["income", "expense"],
+            "example": "expense",
+            "type": "string"
+          },
+          "updated_at": {
+            "description": "Data da última atualização",
+            "format": "date-time",
+            "readOnly": true,
+            "type": "string"
+          },
+          "user_id": {
+            "description": "ID do usuário proprietário da transação",
+            "format": "uuid",
+            "readOnly": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "app_schemas_auth_schema_AuthSchema": {
+        "properties": {
+          "captcha_token": {
+            "default": null,
+            "description": "Token Cloudflare Turnstile obtido pelo cliente. Obrigatório quando CAPTCHA está habilitado no servidor.",
+            "example": "captcha-token-example",
+            "nullable": true,
+            "type": "string"
+          },
+          "email": {
+            "description": "Endereço de email do usuário (identificador canônico)",
+            "example": "joao.silva@email.com",
+            "format": "email",
+            "type": "string"
+          },
+          "password": {
+            "description": "Senha do usuário",
+            "example": "minhasenha123",
+            "type": "string"
+          }
+        },
+        "required": ["email", "password"],
+        "type": "object"
+      },
+      "app_schemas_auth_schema_ConfirmEmailSchema": {
+        "properties": {
+          "token": {
+            "description": "Token de confirmacao recebido por email",
+            "example": "example-token",
+            "maxLength": 512,
+            "minLength": 24,
+            "type": "string"
+          }
+        },
+        "required": ["token"],
+        "type": "object"
+      },
+      "app_schemas_auth_schema_ForgotPasswordSchema": {
+        "properties": {
+          "email": {
+            "description": "Email da conta que deseja recuperar acesso",
+            "example": "joao.silva@email.com",
+            "format": "email",
+            "type": "string"
+          }
+        },
+        "required": ["email"],
+        "type": "object"
+      },
+      "app_schemas_auth_schema_ResetPasswordSchema": {
+        "properties": {
+          "new_password": {
+            "description": "Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)",
+            "example": "NovaSenha@123",
+            "pattern": "^(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{10,}$",
+            "type": "string",
+            "writeOnly": true
+          },
+          "token": {
+            "description": "Token de recuperação recebido por email",
+            "example": "example-token",
+            "maxLength": 512,
+            "minLength": 24,
+            "type": "string"
+          }
+        },
+        "required": ["new_password", "token"],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_DeleteAccountSchema": {
+        "properties": {
+          "password": {
+            "description": "Senha atual do usuário para confirmar a exclusão da conta",
+            "example": "MinhaSenha@123",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": ["password"],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
+        "properties": {
+          "answers": {
+            "description": "Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3).",
+            "items": {
+              "maximum": 3,
+              "minimum": 1,
+              "type": "integer"
+            },
+            "maxItems": 5,
+            "minItems": 5,
+            "type": "array"
+          }
+        },
+        "required": ["answers"],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
+        "properties": {
+          "base_date": {
+            "description": "Data base do salário atual",
+            "example": "2022-01-01",
+            "format": "date",
+            "type": "string"
+          },
+          "base_salary": {
+            "description": "Salário base atual",
+            "example": "5000.00",
+            "minimum": "0",
+            "type": "number"
+          },
+          "discounts": {
+            "description": "Descontos aplicáveis",
+            "example": "500.00",
+            "minimum": "0",
+            "type": "number"
+          },
+          "target_real_increase": {
+            "description": "Aumento real desejado (%)",
+            "example": "5.00",
+            "minimum": "0",
+            "type": "number"
+          }
+        },
+        "required": ["base_date", "base_salary", "discounts", "target_real_increase"],
+        "type": "object"
+      },
+      "app_schemas_user_schemas_UserProfileSchema": {
+        "properties": {
+          "birth_date": {
+            "description": "Data de nascimento",
+            "example": "1990-05-15",
+            "format": "date",
+            "type": "string"
+          },
+          "financial_objectives": {
+            "description": "Objetivos financeiros do usuário",
+            "example": "Aposentar cedo",
+            "type": "string"
+          },
+          "gender": {
+            "description": "Gênero do usuário",
+            "enum": ["masculino", "feminino", "outro"],
+            "example": "masculino",
+            "type": "string"
+          },
+          "initial_investment": {
+            "description": "Investimento inicial disponível",
+            "example": "10000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "investment_goal_date": {
+            "description": "Data meta para atingir objetivo de investimento",
+            "example": "2030-12-31",
+            "format": "date",
+            "type": "string"
+          },
+          "investor_profile": {
+            "description": "Perfil do investidor",
+            "enum": ["conservador", "explorador", "entusiasta"],
+            "example": "conservador",
+            "type": "string"
+          },
+          "investor_profile_suggested": {
+            "description": "Perfil de investidor sugerido",
+            "example": "explorador",
+            "maxLength": 32,
+            "nullable": true,
+            "type": "string"
+          },
+          "monthly_expenses": {
+            "description": "Gastos mensais totais",
+            "example": "3000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "monthly_income": {
+            "description": "Renda mensal em reais",
+            "example": "5000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "monthly_income_net": {
+            "description": "Renda líquida mensal em reais",
+            "example": "5000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "monthly_investment": {
+            "description": "Valor mensal para investimentos",
+            "example": "1000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "net_worth": {
+            "description": "Patrimônio líquido atual",
+            "example": "50000.00",
+            "minimum": 0,
+            "type": "number"
+          },
+          "occupation": {
+            "description": "Profissão do usuário",
+            "example": "Engenheiro de Software",
+            "maxLength": 128,
+            "type": "string"
+          },
+          "profile_quiz_score": {
+            "description": "Pontuação do quiz de perfil",
+            "example": 85,
+            "minimum": 0,
+            "nullable": true,
+            "type": "integer"
+          },
+          "state_uf": {
+            "description": "Estado (UF) do usuário",
+            "example": "SP",
+            "maxLength": 2,
+            "minLength": 2,
+            "type": "string"
+          },
+          "taxonomy_version": {
+            "description": "Versão da taxonomia",
+            "example": "v1.0",
+            "maxLength": 16,
+            "nullable": true,
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "app_schemas_user_schemas_UserRegistrationSchema": {
+        "properties": {
+          "captcha_token": {
+            "default": null,
+            "description": "Token Cloudflare Turnstile obtido pelo cliente. Obrigatório quando CAPTCHA está habilitado no servidor.",
+            "example": "captcha-token-example",
+            "nullable": true,
+            "type": "string"
+          },
+          "email": {
+            "description": "Endereço de email único do usuário",
+            "example": "joao.silva@email.com",
+            "format": "email",
+            "type": "string"
+          },
+          "investor_profile": {
+            "description": "Perfil do investidor auto declarado",
+            "enum": ["conservador", "explorador", "entusiasta", null],
+            "example": "conservador",
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "description": "Nome completo do usuário",
+            "example": "João Silva",
+            "maxLength": 128,
+            "minLength": 2,
+            "type": "string"
+          },
+          "password": {
+            "description": "Senha do usuário (mínimo 10 caracteres, contendo ao menos uma letra maiúscula, um número e um símbolo)",
+            "example": "MinhaSenha@123",
+            "pattern": "^(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z0-9]).{10,}$",
+            "type": "string",
+            "writeOnly": true
+          }
+        },
+        "required": ["email", "name", "password"],
+        "type": "object"
+      }
+    },
     "securitySchemes": {
       "BearerAuth": {
         "bearerFormat": "JWT",
@@ -24,54 +841,1831 @@
   },
   "openapi": "3.0.2",
   "paths": {
-    "/auth/login": {
-      "options": {
-        "parameters": [],
-        "responses": {}
-      },
+    "/auth/email/confirm": {
       "post": {
-        "parameters": [],
-        "responses": {}
+        "description": "Confirma a conta do usuario a partir do token enviado por email.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_ConfirmEmailSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Token de confirmacao recebido por email.",
+              "example": {
+                "token": "example-token"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_ConfirmEmailSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Email confirmed successfully."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Email confirmado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Invalid or expired email confirmation token.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Email confirmation failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao confirmar email",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Confirmar conta",
+        "tags": ["Autenticação"]
+      }
+    },
+    "/auth/email/resend": {
+      "post": {
+        "description": "Reenvia o email de confirmacao do usuario autenticado. Requer token JWT valido no header Authorization. A resposta e neutra para evitar enumeracao de contas.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "If an account exists for this email, confirmation instructions were sent."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Solicitação recebida com resposta neutra",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Missing or invalid authorization token",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token JWT ausente ou inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Email confirmation resend failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao reenviar confirmacao",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Reenviar confirmacao de conta",
+        "tags": ["Autenticação"]
+      }
+    },
+    "/auth/login": {
+      "post": {
+        "description": "Autentica o usuário e devolve um token JWT.\n\nHeaders:\n- `X-API-Contract`: opcional; `v2` padroniza o envelope.\n\nPayload:\n- `email` é o identificador obrigatório e canônico de login\n- `password` é obrigatório\n\nSessão:\n- um login bem-sucedido atualiza o `current_jti` do usuário e revoga a sessão JWT anterior\n\nResposta:\n- `data.token`: JWT para chamadas autenticadas\n- `data.user`: dados básicos do usuário autenticado",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_AuthSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Credenciais para login. `email` é o único identificador aceito para autenticação.",
+              "example": {
+                "email": "italo@auraxis.com.br",
+                "password": "MinhaSenha@123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_AuthSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "token": "jwt-example-token",
+                    "user": {
+                      "email": "italo@auraxis.com.br",
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "name": "Italo Chagas"
+                    }
+                  },
+                  "message": "Login successful"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Login realizado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Missing credentials",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Credenciais ausentes ou payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Invalid credentials",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Credenciais inválidas",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "TOO_MANY_ATTEMPTS",
+                  "details": {
+                    "retry_after_seconds": 300
+                  },
+                  "message": "Too many login attempts. Try again later.",
+                  "status_code": 429
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Muitas tentativas de login",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Login failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao efetuar login",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "AUTH_BACKEND_UNAVAILABLE",
+                  "message": "Authentication temporarily unavailable. Try again later.",
+                  "status_code": 503
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Serviço de autenticação temporariamente indisponível",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Autenticar usuário",
+        "tags": ["Autenticação"]
       }
     },
     "/auth/logout": {
-      "options": {
-        "parameters": [],
-        "responses": {}
-      },
       "post": {
-        "parameters": [],
-        "responses": {}
+        "description": "Revoga o JWT atual do usuário autenticado.\n\nDepois dessa chamada, o token utilizado deixa de ser aceito nas rotas protegidas.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Logout successful"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Logout realizado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Revogar sessão atual",
+        "tags": ["Autenticação"]
       }
     },
     "/auth/password/forgot": {
-      "options": {
-        "parameters": [],
-        "responses": {}
-      },
       "post": {
-        "parameters": [],
-        "responses": {}
+        "description": "Solicita recuperação de senha por link. A resposta é sempre neutra para evitar enumeração de contas.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_ForgotPasswordSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Email da conta que deseja recuperar acesso.",
+              "example": {
+                "email": "italo@auraxis.com.br"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_ForgotPasswordSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "If an account exists for this email, recovery instructions were sent."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Solicitação recebida com resposta neutra",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Dados inválidos",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Password reset request failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao solicitar recuperação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "AUTH_BACKEND_UNAVAILABLE",
+                  "message": "Authentication temporarily unavailable. Try again later.",
+                  "status_code": 503
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Serviço de autenticação temporariamente indisponível",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Solicitar recuperação de senha",
+        "tags": ["Autenticação"]
       }
     },
     "/auth/password/reset": {
-      "options": {
-        "parameters": [],
-        "responses": {}
-      },
       "post": {
-        "parameters": [],
-        "responses": {}
+        "description": "Redefine a senha de um usuário a partir de um token de recuperação.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_auth_schema_ResetPasswordSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Token de recuperação e nova senha válida.",
+              "example": {
+                "new_password": "NovaSenha@123",
+                "token": "example-token"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_auth_schema_ResetPasswordSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Password updated successfully"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Senha redefinida com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Token inválido ou expirado",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Password reset failed",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno ao redefinir senha",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Redefinir senha",
+        "tags": ["Autenticação"]
+      }
+    },
+    "/auth/refresh": {
+      "post": {
+        "description": "Emite um novo par de tokens (access + refresh) usando um refresh token válido.\n\nRotation:\n- Cada uso invalida o refresh token anterior (replay attack prevention).\n- O novo refresh token tem TTL de 7 dias a partir da emissão.\n\nHeaders:\n- `Authorization: Bearer <refresh_token>` (obrigatório)\n- `X-API-Contract`: opcional; `v2` padroniza o envelope.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "refresh_token": "refresh-token-example",
+                    "token": "example-token"
+                  },
+                  "message": "Token refreshed"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Tokens renovados com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "TOKEN_INVALID",
+                  "message": "Token invalid or already used",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Refresh token inválido, expirado ou já utilizado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "RATE_LIMIT_EXCEEDED",
+                  "message": "Too many requests",
+                  "status_code": 429
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Muitas requisições de renovação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Renovar access token",
+        "tags": ["Autenticação"]
       }
     },
     "/auth/register": {
-      "options": {
-        "parameters": [],
-        "responses": {}
-      },
       "post": {
+        "description": "Cria uma nova conta no sistema.\n\nPayload:\n- `name`, `email` e `password` são obrigatórios\n- `investor_profile` é opcional no onboarding inicial\n\nDependendo da política de segurança, conflitos de email podem ser neutralizados com uma resposta de aceite para evitar enumeração.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_UserRegistrationSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Dados necessários para criação da conta.",
+              "example": {
+                "email": "italo@auraxis.com.br",
+                "investor_profile": "conservador",
+                "name": "Italo Chagas",
+                "password": "MinhaSenha@123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_UserRegistrationSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "email": "italo@auraxis.com.br",
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "name": "Italo Chagas"
+                    }
+                  },
+                  "message": "User created successfully"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Usuário criado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "CONFLICT",
+                  "message": "Email já registrado",
+                  "status_code": 409
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Email já registrado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Failed to create user",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno do servidor",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Registrar usuário",
+        "tags": ["Autenticação"]
+      }
+    },
+    "/dashboard/overview": {
+      "get": {
+        "description": "Contrato canônico do dashboard financeiro do MVP1. Use esta rota para visão agregada mensal; `/transactions/dashboard` permanece apenas como compatibilidade transitória.",
+        "parameters": [
+          {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "status": {
+                        "paid": 9,
+                        "pending": 5
+                      },
+                      "total_transactions": 14
+                    },
+                    "month": "2026-03",
+                    "top_categories": {
+                      "expense": [
+                        {
+                          "category_name": "Moradia",
+                          "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                          "total_amount": 1800,
+                          "transactions_count": 3
+                        }
+                      ],
+                      "income": [
+                        {
+                          "category_name": "Receitas",
+                          "tag_id": null,
+                          "total_amount": 5000,
+                          "transactions_count": 4
+                        }
+                      ]
+                    },
+                    "totals": {
+                      "balance": 1800,
+                      "expense_total": 3200,
+                      "income_total": 5000
+                    }
+                  },
+                  "message": "Overview do dashboard calculado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Overview do dashboard",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular overview do dashboard",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter overview mensal do dashboard",
+        "tags": ["Dashboard"]
+      }
+    },
+    "/dashboard/trends": {
+      "get": {
+        "description": "Retorna a série histórica de receitas, despesas e saldo para os últimos N meses (apenas transações pagas).",
+        "parameters": [
+          {
+            "description": "Número de meses a incluir (1–24, padrão 6)",
+            "example": 6,
+            "in": "query",
+            "name": "months",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "months": 6,
+                    "series": [
+                      {
+                        "balance": 1800,
+                        "expenses": 3200,
+                        "income": 5000,
+                        "month": "2026-04"
+                      }
+                    ]
+                  },
+                  "message": "Tendências calculadas com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Série de tendências mensais",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "O parâmetro 'months' deve ser um inteiro entre 1 e 24.",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular tendências do dashboard",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Tendências mensais do dashboard",
+        "tags": ["Dashboard"]
+      }
+    },
+    "/entitlements": {
+      "get": {
+        "description": "Lista os entitlements do usuário autenticado.",
         "parameters": [],
-        "responses": {}
+        "responses": {
+          "200": {
+            "description": "Lista de entitlements"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Entitlements"]
+      }
+    },
+    "/entitlements/admin": {
+      "post": {
+        "description": "Concede um entitlement a um usuário. Requer role 'admin'.",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Entitlement concedido"
+          },
+          "400": {
+            "description": "Parâmetros inválidos"
+          },
+          "403": {
+            "description": "Acesso negado — requer role admin"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Entitlements"]
+      }
+    },
+    "/entitlements/admin/{entitlement_id}": {
+      "delete": {
+        "description": "Revoga um entitlement pelo seu UUID. Requer role 'admin'.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "entitlement_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entitlement revogado"
+          },
+          "403": {
+            "description": "Acesso negado — requer role admin"
+          },
+          "404": {
+            "description": "Entitlement não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Entitlements"]
+      }
+    },
+    "/entitlements/check": {
+      "get": {
+        "description": "Verifica se o usuário autenticado possui um entitlement ativo para a feature especificada. Parâmetro obrigatório: ?feature_key=xxx",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "feature_key",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resultado da verificação"
+          },
+          "400": {
+            "description": "Parâmetro feature_key ausente"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Entitlements"]
       }
     },
     "/goals": {
@@ -89,17 +2683,31 @@
       }
     },
     "/goals/simulate": {
-      "options": {
-        "parameters": [],
-        "responses": {}
-      },
       "post": {
+        "description": "Executa simulação de meta sem persistência (what-if), retornando projeção e recomendações acionáveis.",
         "parameters": [],
-        "responses": {}
+        "responses": {
+          "200": {
+            "description": "Simulação calculada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Metas"]
       }
     },
     "/goals/{goal_id}": {
       "delete": {
+        "description": "Remove uma meta específica do usuário autenticado.",
         "parameters": [
           {
             "in": "path",
@@ -108,9 +2716,29 @@
             "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "description": "Meta removida"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Metas"]
       },
       "get": {
+        "description": "Retorna uma meta específica do usuário autenticado.",
         "parameters": [
           {
             "in": "path",
@@ -119,9 +2747,29 @@
             "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "description": "Meta encontrada"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Metas"]
       },
-      "options": {
+      "patch": {
+        "description": "Atualiza parcialmente uma meta específica do usuário autenticado.",
         "parameters": [
           {
             "in": "path",
@@ -130,9 +2778,32 @@
             "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "description": "Meta atualizada"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Metas"]
       },
       "put": {
+        "description": "Alias legado para atualização de metas. Use `PATCH /goals/{goal_id}` como contrato canônico para update parcial.",
         "parameters": [
           {
             "in": "path",
@@ -141,11 +2812,64 @@
             "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "description": "Meta atualizada via compatibilidade legada",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/goals/{goal_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Metas"]
       }
     },
     "/goals/{goal_id}/plan": {
       "get": {
+        "description": "Calcula o plano da meta considerando renda, despesas e capacidade de aporte do usuário.",
         "parameters": [
           {
             "in": "path",
@@ -154,18 +2878,26 @@
             "type": "string"
           }
         ],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [
+        "responses": {
+          "200": {
+            "description": "Planejamento calculado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
           {
-            "in": "path",
-            "name": "goal_id",
-            "required": true,
-            "type": "string"
+            "BearerAuth": []
           }
         ],
-        "responses": {}
+        "tags": ["Metas"]
       }
     },
     "/healthz": {
@@ -177,9 +2909,7 @@
             "description": "Serviço saudável"
           }
         },
-        "tags": [
-          "Health"
-        ]
+        "tags": ["Health"]
       },
       "options": {
         "description": "Endpoint público de liveness para probes de infraestrutura.",
@@ -189,13 +2919,113 @@
             "description": "Serviço saudável"
           }
         },
-        "tags": [
-          "Health"
-        ]
+        "tags": ["Health"]
       }
     },
-    "/transactions": {
-      "delete": {
+    "/ops/metrics": {
+      "get": {
+        "description": "Exporta métricas em formato texto compatível com scrape simples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Payload Prometheus text exposition"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": ["Observability"]
+      },
+      "options": {
+        "description": "Exporta métricas em formato texto compatível com scrape simples.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Payload Prometheus text exposition"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": ["Observability"]
+      }
+    },
+    "/ops/observability": {
+      "get": {
+        "description": "Exporta snapshot JSON de métricas internas para collector externo.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Snapshot JSON de observabilidade"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": ["Observability"]
+      },
+      "options": {
+        "description": "Exporta snapshot JSON de métricas internas para collector externo.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Snapshot JSON de observabilidade"
+          },
+          "401": {
+            "description": "Chave inválida ou ausente"
+          },
+          "404": {
+            "description": "Export desabilitado"
+          }
+        },
+        "tags": ["Observability"]
+      }
+    },
+    "/readiness": {
+      "get": {
+        "description": "Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Todas as dependências saudáveis"
+          },
+          "401": {
+            "description": "Token de autorização ausente ou inválido"
+          },
+          "503": {
+            "description": "Uma ou mais dependências indisponíveis"
+          }
+        },
+        "tags": ["Health"]
+      },
+      "options": {
+        "description": "Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Todas as dependências saudáveis"
+          },
+          "401": {
+            "description": "Token de autorização ausente ou inválido"
+          },
+          "503": {
+            "description": "Uma ou mais dependências indisponíveis"
+          }
+        },
+        "tags": ["Health"]
+      }
+    },
+    "/simulations": {
+      "get": {
         "parameters": [],
         "responses": {}
       },
@@ -206,177 +3036,4723 @@
       "post": {
         "parameters": [],
         "responses": {}
+      }
+    },
+    "/simulations/installment-vs-cash": {
+      "post": {
+        "description": "Recalcula e persiste uma simulação parcelado vs à vista no subdomínio canônico de `simulations`.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashSave"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Simulação salva com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Simulações"]
+      }
+    },
+    "/simulations/installment-vs-cash/calculate": {
+      "post": {
+        "description": "Executa a simulação pública de parcelado vs à vista, retornando comparativo, cronograma e recomendação.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashCalculation"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação calculada com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          }
+        },
+        "security": [],
+        "tags": ["Simulações"]
+      }
+    },
+    "/simulations/installment-vs-cash/save": {
+      "post": {
+        "description": "Alias legado do salvamento parcelado vs à vista. Use `POST /simulations/installment-vs-cash` como contrato canônico.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashSave"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Simulação salva com sucesso via alias legado",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/simulations/installment-vs-cash",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "POST",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Simulações"]
+      }
+    },
+    "/simulations/{simulation_id}": {
+      "delete": {
+        "description": "Remove uma simulação específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação removida"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Simulações"]
       },
-      "put": {
-        "parameters": [],
-        "responses": {}
+      "get": {
+        "description": "Retorna uma simulação específica do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação encontrada"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Simulações"]
+      }
+    },
+    "/simulations/{simulation_id}/goal": {
+      "post": {
+        "description": "Converte uma simulação salva em meta de compra.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashGoalBridge"
+            }
+          },
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Meta criada a partir da simulação"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Entitlement necessário"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Simulações"]
+      }
+    },
+    "/simulations/{simulation_id}/planned-expense": {
+      "post": {
+        "description": "Converte uma simulação salva em despesa planejada.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/InstallmentVsCashPlannedExpenseBridge"
+            }
+          },
+          {
+            "in": "path",
+            "name": "simulation_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Despesa planejada criada a partir da simulação"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Entitlement necessário"
+          },
+          "404": {
+            "description": "Simulação não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Simulações"]
+      }
+    },
+    "/transactions": {
+      "get": {
+        "description": "Lista canônica de transações ativas com filtros, ordenação e paginação.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de transações retornada com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de transações",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar transações",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar transações",
+        "tags": ["Transações"]
+      },
+      "post": {
+        "description": "Cria uma nova transação financeira.\n\nAceita receitas e despesas, com suporte a recorrência e parcelamento.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionCreate"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Payload de criação da transação.",
+              "example": {
+                "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                "amount": "150.00",
+                "description": "Fatura mensal de energia",
+                "due_date": "2026-03-10",
+                "observation": "Pagar antes do dia 10",
+                "status": "pending",
+                "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                "title": "Conta de luz",
+                "type": "expense"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "pending",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação criada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação criada com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao criar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Criar transação",
+        "tags": ["Transações"]
       }
     },
     "/transactions/dashboard": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Compatibilidade transitória para o dashboard mensal. Prefira `GET /dashboard/overview`.",
+        "parameters": [
+          {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "balance": 1800,
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "total_transactions": 14
+                    },
+                    "expense_total": 3200,
+                    "income_total": 5000,
+                    "month": "2026-03"
+                  },
+                  "message": "Dashboard mensal retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Dashboard mensal legado",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/dashboard/overview",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "GET",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular dashboard mensal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter dashboard mensal legado de transações",
+        "tags": ["Transações"]
       }
     },
     "/transactions/deleted": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Lista a lixeira de transações deletadas do usuário.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de transações deletadas"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de transações deletadas",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar transações deletadas",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar transações deletadas",
+        "tags": ["Transações"]
       }
     },
     "/transactions/due-range": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Lista vencimentos (receitas + despesas) por período com paginação, contadores e ordenação por vencimento.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "total_transactions": 14
+                    },
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de vencimentos retornada com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de vencimentos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetros de período inválidos.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar vencimentos",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar vencimentos por período",
+        "tags": ["Transações"]
       }
     },
     "/transactions/expenses": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Compatibilidade transitória para despesas por período. Prefira `GET /transactions?type=expense&start_date=...&end_date=...`.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "counts": {
+                      "expense_transactions": 10,
+                      "income_transactions": 4,
+                      "total_transactions": 14
+                    },
+                    "expenses": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de despesas por período",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de despesas",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/transactions",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "GET",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetros de período inválidos.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar despesas por período",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar despesas por período (compatibilidade)",
+        "tags": ["Transações"]
       }
     },
     "/transactions/list": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Compatibilidade transitória para listagem de transações ativas. Prefira `GET /transactions`.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "items": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Lista de transações retornada com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "pages": 2,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de transações (compatibilidade transitória)",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/transactions",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "GET",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao listar transações",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar transações (compatibilidade /transactions/list)",
+        "tags": ["Transações"]
       }
     },
     "/transactions/restore/{transaction_id}": {
-      "options": {
-        "parameters": [
-          {
-            "in": "path",
-            "name": "transaction_id",
-            "required": true,
-            "type": "string"
-          }
-        ],
-        "responses": {}
-      },
       "patch": {
+        "description": "Restaura uma transação deletada logicamente.",
         "parameters": [
           {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
             "in": "path",
             "name": "transaction_id",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "pending",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação restaurada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação restaurada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao restaurar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Restaurar transação deletada",
+        "tags": ["Transações"]
       }
     },
     "/transactions/summary": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Resumo mensal de receitas, despesas e itens paginados por mês.",
+        "parameters": [
+          {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "expense_total": 3200,
+                    "income_total": 5000,
+                    "month": "2026-03",
+                    "transactions": [
+                      {
+                        "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                        "amount": "150.00",
+                        "bank_name": null,
+                        "created_at": "2026-03-01T10:00:00+00:00",
+                        "credit_card_id": null,
+                        "currency": "BRL",
+                        "description": "Fatura mensal de energia",
+                        "due_date": "2026-03-10",
+                        "end_date": null,
+                        "external_id": null,
+                        "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                        "installment_count": null,
+                        "installment_group_id": null,
+                        "is_installment": false,
+                        "is_recurring": false,
+                        "observation": "Pagar antes do dia 10",
+                        "paid_at": null,
+                        "source": "manual",
+                        "start_date": null,
+                        "status": "pending",
+                        "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                        "title": "Conta de luz",
+                        "type": "expense",
+                        "updated_at": "2026-03-01T10:00:00+00:00"
+                      }
+                    ]
+                  },
+                  "message": "Resumo mensal retornado com sucesso",
+                  "meta": {
+                    "pagination": {
+                      "page": 1,
+                      "per_page": 10,
+                      "total": 14
+                    }
+                  }
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Resumo mensal",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular resumo mensal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter resumo mensal de transações",
+        "tags": ["Transações"]
       }
     },
     "/transactions/{transaction_id}": {
       "delete": {
+        "description": "Realiza soft delete de uma transação do usuário autenticado.",
         "parameters": [
           {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
             "in": "path",
             "name": "transaction_id",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction_id": "cfef66a6-a148-49db-a72f-cc63b6080cf8"
+                  },
+                  "message": "Transação deletada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação deletada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao deletar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remover transação logicamente",
+        "tags": ["Transações"]
       },
-      "options": {
+      "get": {
+        "description": "Retorna o detalhe canônico de uma transação do usuário.",
         "parameters": [
           {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
             "in": "path",
             "name": "transaction_id",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "pending",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Detalhe da transação retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Detalhe da transação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao carregar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter detalhe de transação",
+        "tags": ["Transações"]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente uma transação existente. Este é o contrato canônico de update do MVP1.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+            }
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+            "in": "path",
+            "name": "transaction_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Campos parciais a serem atualizados.",
+              "example": {
+                "paid_at": "2026-03-10T12:00:00+00:00",
+                "status": "paid"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "paid",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação atualizada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação atualizada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao atualizar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Atualizar transação parcialmente",
+        "tags": ["Transações"]
       },
       "put": {
+        "description": "Compatibilidade transitória para update parcial. Prefira `PATCH /transactions/{transaction_id}`.",
         "parameters": [
           {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+            }
+          },
+          {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
             "in": "path",
             "name": "transaction_id",
             "required": true,
             "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
           }
         ],
-        "responses": {}
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Campos parciais a serem atualizados.",
+              "example": {
+                "paid_at": "2026-03-10T12:00:00+00:00",
+                "status": "paid"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/TransactionCreate_7d3b606eab"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction": {
+                      "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                      "amount": "150.00",
+                      "bank_name": null,
+                      "created_at": "2026-03-01T10:00:00+00:00",
+                      "credit_card_id": null,
+                      "currency": "BRL",
+                      "description": "Fatura mensal de energia",
+                      "due_date": "2026-03-10",
+                      "end_date": null,
+                      "external_id": null,
+                      "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                      "installment_count": null,
+                      "installment_group_id": null,
+                      "is_installment": false,
+                      "is_recurring": false,
+                      "observation": "Pagar antes do dia 10",
+                      "paid_at": null,
+                      "source": "manual",
+                      "start_date": null,
+                      "status": "paid",
+                      "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                      "title": "Conta de luz",
+                      "type": "expense",
+                      "updated_at": "2026-03-01T10:00:00+00:00"
+                    }
+                  },
+                  "message": "Transação atualizada com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação atualizada (compatibilidade transitória)",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/transactions/{transaction_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "FORBIDDEN",
+                  "message": "Sem permissão",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Sem permissão",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao atualizar transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Atualizar transação (compatibilidade PUT)",
+        "tags": ["Transações"]
       }
     },
     "/transactions/{transaction_id}/force": {
       "delete": {
+        "description": "Remove permanentemente uma transação já deletada logicamente.",
         "parameters": [
           {
+            "description": "ID da transação",
+            "example": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
             "in": "path",
             "name": "transaction_id",
             "required": true,
             "type": "string"
-          }
-        ],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [
+          },
           {
-            "in": "path",
-            "name": "transaction_id",
-            "required": true,
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
             "type": "string"
           }
         ],
-        "responses": {}
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transaction_id": "cfef66a6-a148-49db-a72f-cc63b6080cf8"
+                  },
+                  "message": "Transação removida permanentemente"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação removida permanentemente",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Transação não encontrada",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Transação não encontrada",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao remover transação",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Remover transação permanentemente",
+        "tags": ["Transações"]
+      }
+    },
+    "/user/bootstrap": {
+      "get": {
+        "description": "Retorna o bootstrap explícito da home do usuário autenticado.\n\nOwnership:\n- `/user/me` (`v3`) = contexto autenticado canônico\n- `/transactions` = coleção e filtros completos\n- `/wallet` = coleção canônica de carteira\n- `/user/bootstrap` = agregado leve para reduzir round-trips na home\n\nO bootstrap não substitui endpoints canônicos de coleção e expõe apenas previews recentes de transações e carteira.",
+        "parameters": [
+          {
+            "description": "Opcional. Recomendado enviar `v2` ou `v3` para o envelope padronizado.",
+            "example": "v3",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "transactions_preview": {
+                      "has_more": false,
+                      "items": [
+                        {
+                          "amount": "150.00",
+                          "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                          "status": "pending",
+                          "title": "Conta de luz",
+                          "type": "expense"
+                        }
+                      ],
+                      "limit": 5,
+                      "returned_items": 1
+                    },
+                    "user": {
+                      "financial_profile": {
+                        "initial_investment": 200,
+                        "investment_goal_date": "2026-12-31",
+                        "monthly_expenses": 500,
+                        "monthly_income_net": 1000,
+                        "monthly_investment": 100,
+                        "net_worth": 2000
+                      },
+                      "identity": {
+                        "email": "italo@email.com",
+                        "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                        "name": "Italo"
+                      },
+                      "investor_profile": {
+                        "declared": "conservador",
+                        "financial_objectives": "crescer",
+                        "quiz_score": 8,
+                        "suggested": "moderado",
+                        "taxonomy_version": "2026.1"
+                      },
+                      "product_context": {
+                        "entitlements_version": 3
+                      },
+                      "profile": {
+                        "birth_date": "1990-01-01",
+                        "gender": "outro",
+                        "occupation": "Founder",
+                        "state_uf": "SP"
+                      }
+                    },
+                    "wallet": {
+                      "has_more": true,
+                      "items": [
+                        {
+                          "asset_class": "cash",
+                          "id": "wallet-1",
+                          "name": "Caixa",
+                          "quantity": 1,
+                          "value": 100
+                        }
+                      ],
+                      "limit": 5,
+                      "returned_items": 1,
+                      "total": 8
+                    }
+                  },
+                  "message": "Bootstrap do usuário retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Bootstrap retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetros do bootstrap inválidos.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido ou expirado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter bootstrap da home do usuário",
+        "tags": ["Usuário"]
       }
     },
     "/user/me": {
-      "get": {
-        "parameters": [],
-        "responses": {}
+      "delete": {
+        "description": "Anonimiza permanentemente todos os dados pessoais do usuário autenticado (soft-delete LGPD). Requer confirmação de senha.\n\nApós a exclusão:\n- Todos os campos de PII são anonimizados\n- O JWT é revogado (sessão encerrada)\n- O usuário não consegue mais fazer login\n\nEsta ação é irreversível.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_DeleteAccountSchema"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Senha atual do usuário para confirmar a exclusão.",
+              "example": {
+                "password": "MinhaSenha@123"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_DeleteAccountSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {},
+                  "message": "Account deleted."
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Conta excluída com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido ou expirado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INVALID_CREDENTIALS",
+                  "message": "Invalid credentials.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Senha incorreta",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Validation error",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Campo 'password' ausente ou inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Excluir conta do usuário (LGPD)",
+        "tags": ["Usuário"]
       },
-      "options": {
-        "parameters": [],
-        "responses": {}
+      "get": {
+        "description": "Retorna o contexto do usuário autenticado.\n\nUso recomendado:\n- `X-API-Contract: v3` para o contrato canônico e leve\n- `/user/bootstrap` para agregado da home\n- `/transactions` para coleção paginada e filtros\n\nLegado:\n- `v1`/`v2` ainda aceitam paginação e filtros de coleção\n- respostas legadas enviam headers de deprecação e sunset",
+        "parameters": [
+          {
+            "description": "Opcional. `v2` mantém o shape legado padronizado; `v3` publica o contrato canônico sem coleções.",
+            "example": "v3",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "financial_profile": {
+                        "initial_investment": 200,
+                        "investment_goal_date": "2026-12-31",
+                        "monthly_expenses": 500,
+                        "monthly_income_net": 1000,
+                        "monthly_investment": 100,
+                        "net_worth": 2000
+                      },
+                      "identity": {
+                        "email": "italo@auraxis.com.br",
+                        "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                        "name": "Italo Chagas"
+                      },
+                      "investor_profile": {
+                        "declared": "conservador",
+                        "financial_objectives": "crescer",
+                        "quiz_score": 8,
+                        "suggested": "moderado",
+                        "taxonomy_version": "2026.1"
+                      },
+                      "product_context": {
+                        "entitlements_version": 3
+                      },
+                      "profile": {
+                        "birth_date": "1990-01-01",
+                        "gender": "outro",
+                        "occupation": "Founder",
+                        "state_uf": "SP"
+                      }
+                    }
+                  },
+                  "message": "Contexto autenticado retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Contexto autenticado retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter contexto do usuário autenticado",
+        "tags": ["Usuário"]
       }
     },
     "/user/profile": {
       "get": {
-        "parameters": [],
-        "responses": {}
-      },
-      "options": {
-        "parameters": [],
-        "responses": {}
+        "description": "Retorna o perfil reduzido do usuário autenticado (sem transações e sem carteira).",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "email": "italo@auraxis.com.br",
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "investor_profile": "conservador",
+                      "monthly_income_net": "5000.00",
+                      "name": "Italo Chagas"
+                    }
+                  },
+                  "message": "Perfil retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Perfil retornado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Usuário não encontrado",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Usuário não encontrado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Obter perfil reduzido do usuário",
+        "tags": ["Usuário"]
       },
       "put": {
-        "parameters": [],
-        "responses": {}
+        "description": "Atualiza o perfil do usuário autenticado.\n\nCampos aceitos:\n- gender: 'masculino', 'feminino', 'outro'\n- birth_date: 'YYYY-MM-DD'\n- monthly_income, net_worth, monthly_expenses, initial_investment,\n  monthly_investment: decimal\n- investment_goal_date: 'YYYY-MM-DD'\n- investor_profile: 'conservador', 'explorador', 'entusiasta'\n\nExemplo de request:\n{\n  'gender': 'masculino',\n  'birth_date': '1990-05-15',\n  'monthly_income': '5000.00',\n  'net_worth': '100000.00',\n  'monthly_expenses': '2000.00',\n  'initial_investment': '10000.00',\n  'monthly_investment': '500.00',\n  'investment_goal_date': '2025-12-31',\n  'investor_profile': 'conservador'\n}\n\nExemplo de resposta:\n{ 'message': 'Perfil atualizado com sucesso', 'data': { ...dados do usuário... } }",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_UserProfileSchema"
+            }
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Campos parciais do perfil financeiro e investidor.",
+              "example": {
+                "birth_date": "1990-05-15",
+                "gender": "masculino",
+                "investor_profile": "conservador",
+                "monthly_expenses": "2000.00",
+                "monthly_income_net": "5000.00",
+                "net_worth": "100000.00",
+                "occupation": "Founder",
+                "state_uf": "SP"
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_UserProfileSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "user": {
+                      "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                      "investor_profile": "conservador",
+                      "monthly_expenses": "2000.00",
+                      "monthly_income_net": "5000.00"
+                    }
+                  },
+                  "message": "Perfil atualizado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Perfil atualizado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Erro de validação",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro de validação",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "NOT_FOUND",
+                  "message": "Usuário não encontrado",
+                  "status_code": 404
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Usuário não encontrado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao atualizar perfil",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro ao atualizar perfil",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Atualizar perfil do usuário",
+        "tags": ["Usuário"]
+      }
+    },
+    "/user/profile/questionnaire": {
+      "get": {
+        "description": "Retorna as 5 perguntas do questionário de perfil de investidor.\n\nCada pergunta contém 3 opções com pontuações de 1 a 3.\nEnvie os pontos via POST para receber o perfil sugerido.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "questions": [
+                      {
+                        "options": [
+                          {
+                            "points": 1,
+                            "text": "Preservar capital"
+                          },
+                          {
+                            "points": 2,
+                            "text": "Crescer com equilíbrio"
+                          },
+                          {
+                            "points": 3,
+                            "text": "Maximizar retorno"
+                          }
+                        ],
+                        "question": "Qual é o seu principal objetivo ao investir?"
+                      }
+                    ]
+                  },
+                  "message": "Questionário retornado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Lista de perguntas retornada com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Listar questionário de perfil de investidor",
+        "tags": ["Usuário"]
+      },
+      "post": {
+        "description": "Submete as respostas do questionário e classifica o perfil de investidor.\n\nEnvie exatamente 5 respostas, cada uma com os pontos da opção escolhida (1–3).\n\nPerfis possíveis:\n- **conservador** — score ≤ 7\n- **explorador**  — score de 8 a 11\n- **entusiasta**  — score ≥ 12\n\nO resultado é persistido no perfil do usuário autenticado.",
+        "parameters": [
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "description": "Lista de 5 respostas, cada uma entre 1 e 3 pontos.",
+              "example": {
+                "answers": [1, 2, 2, 3, 1]
+              },
+              "schema": {
+                "$ref": "#/components/schemas/app_schemas_user_schemas_QuestionnaireAnswerSchema"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "score": 9,
+                    "suggested_profile": "explorador"
+                  },
+                  "message": "Perfil sugerido calculado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Perfil sugerido calculado e persistido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INVALID_ANSWER_COUNT",
+                  "message": "O questionário exige exatamente 5 respostas.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Número de respostas inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido, expirado ou revogado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "details": {
+                    "answers": ["Missing data for required field."]
+                  },
+                  "message": "Dados inválidos",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Payload inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Responder questionário de perfil de investidor",
+        "tags": ["Usuário"]
+      }
+    },
+    "/user/simulate-salary-increase": {
+      "post": {
+        "description": "Simula o aumento salarial e recomposição da inflação.",
+        "parameters": [
+          {
+            "in": "body",
+            "name": "body",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Simulação realizada com sucesso"
+          },
+          "400": {
+            "description": "Erro de validação"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Usuário"]
       }
     },
     "/wallet": {
@@ -422,9 +7798,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Lista os investimentos cadastrados na carteira com paginação.",
@@ -468,9 +7842,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "post": {
         "description": "Adiciona um novo item à carteira do usuário.\n\nVocê pode informar um valor fixo (como R$1000,00 em poupança) ou um ativo com ticker.\n\nRegras:\n- Se informar o campo 'ticker', o campo 'value' será ignorado.\n- Se não informar 'ticker', é obrigatório informar 'value'.\n- Se informar 'ticker', também é obrigatório informar 'quantity'.\n\nExemplo com valor fixo:\n{'name': 'Poupança', 'value': 1500.00, 'register_date': '2024-07-01', 'should_be_on_wallet': true}\n\nExemplo com ticker:\n{'name': 'Investimento PETR4', 'ticker': 'petr4', 'quantity': 10, 'register_date': '2024-07-01', 'should_be_on_wallet': true}\n\nResposta esperada:\n{'message': 'Ativo cadastrado com sucesso'}",
@@ -494,9 +7866,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/valuation": {
@@ -524,9 +7894,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna a valorização atual consolidada da carteira do usuário, com cálculo por investimento.",
@@ -552,9 +7920,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/valuation/history": {
@@ -562,15 +7928,10 @@
         "description": "Retorna histórico diário de evolução da carteira por período, com totais de compra/venda e valor líquido investido acumulado.",
         "parameters": [
           {
-            "description": "Data final (YYYY-MM-DD). Opcional.",
+            "deprecated": true,
+            "description": "Alias legado de `end_date`.",
             "in": "query",
             "name": "finalDate",
-            "required": false
-          },
-          {
-            "description": "Data inicial (YYYY-MM-DD). Opcional.",
-            "in": "query",
-            "name": "startDate",
             "required": false
           },
           {
@@ -579,11 +7940,60 @@
             "name": "X-API-Contract",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "start_date",
+            "required": false
+          },
+          {
+            "description": "Data final (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "end_date",
+            "required": false
+          },
+          {
+            "deprecated": true,
+            "description": "Alias legado de `start_date`.",
+            "in": "query",
+            "name": "startDate",
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "Histórico retornado com sucesso"
+            "description": "Histórico retornado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Warning": {
+                "description": "Mensagem adicional de deprecação enviada em runtime.",
+                "example": "299 - \"Query params startDate/finalDate are deprecated; use start_date/end_date\"",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Field": {
+                "description": "Campo recomendado para a migração do payload.",
+                "example": "start_date,end_date",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Parâmetros inválidos"
@@ -597,23 +8007,16 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna histórico diário de evolução da carteira por período, com totais de compra/venda e valor líquido investido acumulado.",
         "parameters": [
           {
-            "description": "Data final (YYYY-MM-DD). Opcional.",
+            "deprecated": true,
+            "description": "Alias legado de `end_date`.",
             "in": "query",
             "name": "finalDate",
-            "required": false
-          },
-          {
-            "description": "Data inicial (YYYY-MM-DD). Opcional.",
-            "in": "query",
-            "name": "startDate",
             "required": false
           },
           {
@@ -622,11 +8025,60 @@
             "name": "X-API-Contract",
             "required": false,
             "type": "string"
+          },
+          {
+            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "start_date",
+            "required": false
+          },
+          {
+            "description": "Data final (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "end_date",
+            "required": false
+          },
+          {
+            "deprecated": true,
+            "description": "Alias legado de `start_date`.",
+            "in": "query",
+            "name": "startDate",
+            "required": false
           }
         ],
         "responses": {
           "200": {
-            "description": "Histórico retornado com sucesso"
+            "description": "Histórico retornado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Warning": {
+                "description": "Mensagem adicional de deprecação enviada em runtime.",
+                "example": "299 - \"Query params startDate/finalDate are deprecated; use start_date/end_date\"",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Field": {
+                "description": "Campo recomendado para a migração do payload.",
+                "example": "start_date,end_date",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Parâmetros inválidos"
@@ -640,9 +8092,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}": {
@@ -683,12 +8133,118 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
+      },
+      "get": {
+        "description": "Retorna o detalhe canônico de um investimento específico da carteira do usuário autenticado.",
+        "parameters": [
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento retornado com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Wallet"]
       },
       "options": {
-        "description": "Atualiza um investimento existente da carteira do usuário.",
+        "description": "Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico.",
+        "parameters": [
+          {
+            "description": "ID do investimento",
+            "in": "path",
+            "name": "investment_id",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie 'v2' para o contrato padronizado.",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Investimento atualizado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/wallet/{investment_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "404": {
+            "description": "Investimento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Wallet"]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente um investimento existente da carteira do usuário. Este é o método canônico para alterações parciais.",
         "parameters": [
           {
             "description": "ID do investimento",
@@ -724,12 +8280,10 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "put": {
-        "description": "Atualiza um investimento existente da carteira do usuário.",
+        "description": "Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico.",
         "parameters": [
           {
             "description": "ID do investimento",
@@ -748,7 +8302,37 @@
         ],
         "responses": {
           "200": {
-            "description": "Investimento atualizado com sucesso"
+            "description": "Investimento atualizado com sucesso",
+            "headers": {
+              "Deprecation": {
+                "description": "Indica que a superfície atual está em deprecação.",
+                "example": "true",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Sunset": {
+                "description": "Data prevista para remoção da superfície legada.",
+                "example": "Tue, 30 Jun 2026 23:59:59 GMT",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Endpoint": {
+                "description": "Endpoint sucessor recomendado.",
+                "example": "/wallet/{investment_id}",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Auraxis-Successor-Method": {
+                "description": "Método HTTP recomendado para a superfície sucessora.",
+                "example": "PATCH",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Dados inválidos"
@@ -765,9 +8349,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/history": {
@@ -808,9 +8390,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna o histórico de alterações de um investimento, paginado e ordenado.",
@@ -849,9 +8429,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations": {
@@ -910,9 +8488,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Lista operações de investimento de um item da carteira com paginação.",
@@ -969,9 +8545,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "post": {
         "description": "Registra uma operação de investimento (buy/sell) para um item da carteira.",
@@ -1013,9 +8587,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/invested-amount": {
@@ -1068,9 +8640,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna o valor investido no dia informado, considerando operações de compra e venda do investimento.",
@@ -1121,9 +8691,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/position": {
@@ -1164,9 +8732,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna posição atual e custo médio do investimento com base nas operações registradas.",
@@ -1205,9 +8771,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/summary": {
@@ -1248,9 +8812,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Resumo agregado das operações de um investimento.",
@@ -1289,9 +8851,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/{operation_id}": {
@@ -1299,16 +8859,16 @@
         "description": "Remove operação de investimento.",
         "parameters": [
           {
-            "description": "ID da operação",
+            "description": "ID do investimento",
             "in": "path",
-            "name": "operation_id",
+            "name": "investment_id",
             "required": true,
             "type": "string"
           },
           {
-            "description": "ID do investimento",
+            "description": "ID da operação",
             "in": "path",
-            "name": "investment_id",
+            "name": "operation_id",
             "required": true,
             "type": "string"
           },
@@ -1339,24 +8899,22 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Atualiza operação de investimento existente.",
         "parameters": [
           {
-            "description": "ID da operação",
+            "description": "ID do investimento",
             "in": "path",
-            "name": "operation_id",
+            "name": "investment_id",
             "required": true,
             "type": "string"
           },
           {
-            "description": "ID do investimento",
+            "description": "ID da operação",
             "in": "path",
-            "name": "investment_id",
+            "name": "operation_id",
             "required": true,
             "type": "string"
           },
@@ -1390,24 +8948,22 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "put": {
         "description": "Atualiza operação de investimento existente.",
         "parameters": [
           {
-            "description": "ID da operação",
+            "description": "ID do investimento",
             "in": "path",
-            "name": "operation_id",
+            "name": "investment_id",
             "required": true,
             "type": "string"
           },
           {
-            "description": "ID do investimento",
+            "description": "ID da operação",
             "in": "path",
-            "name": "investment_id",
+            "name": "operation_id",
             "required": true,
             "type": "string"
           },
@@ -1441,9 +8997,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/valuation": {
@@ -1484,9 +9038,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna a valorização atual de um investimento específico.",
@@ -1525,9 +9077,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     }
   },
@@ -1555,6 +9105,10 @@
     {
       "description": "Endpoint público para liveness/readiness de infraestrutura",
       "name": "Health"
+    },
+    {
+      "description": "Export operacional protegido para métricas e collector externo",
+      "name": "Observability"
     },
     {
       "description": "Gerenciamento de contas bancárias (pendente)",

--- a/core/query/query-keys.ts
+++ b/core/query/query-keys.ts
@@ -16,6 +16,11 @@ export const queryKeys = {
     list: () => ["alerts", "list"] as const,
     preferences: () => ["alerts", "preferences"] as const,
   },
+  entitlements: {
+    root: ["entitlements"] as const,
+    check: (featureKey: string) => ["entitlements", "check", featureKey] as const,
+    access: (featureKey: string) => ["entitlements", "access", featureKey] as const,
+  },
   subscription: {
     root: ["subscription"] as const,
     me: () => ["subscription", "me"] as const,

--- a/features/alerts/services/alerts-service.ts
+++ b/features/alerts/services/alerts-service.ts
@@ -83,10 +83,14 @@ export const createAlertsService = (client: AxiosInstance) => {
       };
     },
     markRead: async (alertId: string): Promise<void> => {
-      await client.post(`/alerts/${alertId}/read`);
+      await client.post(
+        apiContractMap.alertsMarkRead.path.replace("{alertId}", alertId),
+      );
     },
     deleteAlert: async (alertId: string): Promise<void> => {
-      await client.delete(`/alerts/${alertId}`);
+      await client.delete(
+        apiContractMap.alertsDelete.path.replace("{alertId}", alertId),
+      );
     },
     updatePreference: async (
       category: string,
@@ -95,9 +99,9 @@ export const createAlertsService = (client: AxiosInstance) => {
       const response = await client.put(
         apiContractMap.updateAlertPreference.path.replace("{category}", category),
         {
-        enabled: command.enabled,
-        channels: command.channels,
-        global_opt_out: command.globalOptOut,
+          enabled: command.enabled,
+          channels: command.channels,
+          global_opt_out: command.globalOptOut,
         },
       );
 

--- a/features/dashboard/services/dashboard-service.ts
+++ b/features/dashboard/services/dashboard-service.ts
@@ -85,7 +85,7 @@ export const createDashboardService = (client: AxiosInstance) => {
       );
     },
     getTrends: async (months = 6): Promise<DashboardTrends> => {
-      const response = await client.get("/dashboard/trends", {
+      const response = await client.get(apiContractMap.dashboardTrends.path, {
         params: {
           months,
         },

--- a/features/entitlements/contracts.ts
+++ b/features/entitlements/contracts.ts
@@ -1,0 +1,15 @@
+export type FeatureKey =
+  | "basic_simulations"
+  | "advanced_simulations"
+  | "export_pdf"
+  | "shared_entries"
+  | "wallet_read";
+
+export interface EntitlementCheckQuery {
+  readonly featureKey: FeatureKey;
+}
+
+export interface EntitlementCheckResult {
+  readonly featureKey: string;
+  readonly active: boolean;
+}

--- a/features/entitlements/services/entitlements-service.ts
+++ b/features/entitlements/services/entitlements-service.ts
@@ -1,0 +1,43 @@
+import type { AxiosInstance } from "axios";
+
+import { unwrapEnvelopeData } from "@/core/http/contracts";
+import { httpClient } from "@/core/http/http-client";
+import type {
+  EntitlementCheckQuery,
+  EntitlementCheckResult,
+} from "@/features/entitlements/contracts";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
+
+interface EntitlementCheckPayload {
+  readonly feature_key: string;
+  readonly active: boolean;
+}
+
+const mapEntitlementCheckPayload = (
+  payload: EntitlementCheckPayload,
+): EntitlementCheckResult => {
+  return {
+    featureKey: payload.feature_key,
+    active: payload.active,
+  };
+};
+
+export const createEntitlementsService = (client: AxiosInstance) => {
+  return {
+    checkEntitlement: async (
+      query: EntitlementCheckQuery,
+    ): Promise<EntitlementCheckResult> => {
+      const response = await client.get(apiContractMap.entitlementsCheck.path, {
+        params: {
+          feature_key: query.featureKey,
+        },
+      });
+
+      return mapEntitlementCheckPayload(
+        unwrapEnvelopeData<EntitlementCheckPayload>(response.data),
+      );
+    },
+  };
+};
+
+export const entitlementsService = createEntitlementsService(httpClient);

--- a/hooks/mutations/use-delete-alert-mutation.ts
+++ b/hooks/mutations/use-delete-alert-mutation.ts
@@ -1,14 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { alertsApi } from "@/lib/alerts-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { alertsService } from "@/features/alerts/services/alerts-service";
 
 export const useDeleteAlertMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, string>({
-    mutationFn: (id: string) => alertsApi.deleteAlert(id),
+    mutationFn: (id: string) => alertsService.deleteAlert(id),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["alerts"] });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.alerts.root });
     },
   });
 };

--- a/hooks/mutations/use-mark-read-mutation.ts
+++ b/hooks/mutations/use-mark-read-mutation.ts
@@ -1,14 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { alertsApi } from "@/lib/alerts-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { alertsService } from "@/features/alerts/services/alerts-service";
 
 export const useMarkReadMutation = () => {
   const queryClient = useQueryClient();
 
   return useMutation<void, Error, string>({
-    mutationFn: (id: string) => alertsApi.markRead(id),
+    mutationFn: (id: string) => alertsService.markRead(id),
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["alerts"] });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.alerts.root });
     },
   });
 };

--- a/hooks/mutations/use-update-preference-mutation.ts
+++ b/hooks/mutations/use-update-preference-mutation.ts
@@ -1,11 +1,15 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 
-import { alertsApi, type UpdatePreferencePayload } from "@/lib/alerts-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { alertsService } from "@/features/alerts/services/alerts-service";
 import type { AlertPreference } from "@/types/contracts";
 
 interface UpdatePreferenceVariables {
   readonly category: string;
-  readonly payload: UpdatePreferencePayload;
+  readonly payload: {
+    readonly enabled: boolean;
+    readonly channels: string[];
+  };
 }
 
 export const useUpdatePreferenceMutation = () => {
@@ -13,9 +17,20 @@ export const useUpdatePreferenceMutation = () => {
 
   return useMutation<AlertPreference, Error, UpdatePreferenceVariables>({
     mutationFn: ({ category, payload }) =>
-      alertsApi.updatePreference(category, payload),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["alerts", "preferences"] });
+      alertsService.updatePreference(category, {
+        enabled: payload.enabled,
+        channels: payload.channels,
+        globalOptOut: false,
+      }).then((preference) => ({
+        id: preference.id,
+        category: preference.category,
+        enabled: preference.enabled,
+        channels: payload.channels,
+      })),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: queryKeys.alerts.preferences(),
+      });
     },
   });
 };

--- a/hooks/queries/use-alert-preferences-query.ts
+++ b/hooks/queries/use-alert-preferences-query.ts
@@ -1,13 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { alertsApi } from "@/lib/alerts-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { alertsService } from "@/features/alerts/services/alerts-service";
 import type { AlertPreference } from "@/types/contracts";
+
+const DEFAULT_ALERT_CHANNELS = ["email"] as const;
 
 export const useAlertPreferencesQuery = () => {
   return useQuery<AlertPreference[]>({
-    queryKey: ["alerts", "preferences"],
+    queryKey: queryKeys.alerts.preferences(),
     queryFn: async (): Promise<AlertPreference[]> => {
-      return await alertsApi.getPreferences();
+      const response = await alertsService.getPreferences();
+
+      return response.preferences.map((preference) => ({
+        id: preference.id,
+        category: preference.category,
+        enabled: preference.enabled,
+        channels: [...DEFAULT_ALERT_CHANNELS],
+      }));
     },
   });
 };

--- a/hooks/queries/use-alerts-query.spec.ts
+++ b/hooks/queries/use-alerts-query.spec.ts
@@ -3,15 +3,15 @@ import type { AlertsResponse } from "@/types/contracts";
 import { useAlertsQuery } from "@/hooks/queries/use-alerts-query";
 
 const mockUseQuery = jest.fn();
-const mockGetAlerts = jest.fn();
+const mockListAlerts = jest.fn();
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: readonly unknown[]) => mockUseQuery(...args),
 }));
 
-jest.mock("@/lib/alerts-api", () => ({
-  alertsApi: {
-    getAlerts: (...args: readonly unknown[]) => mockGetAlerts(...args),
+jest.mock("@/features/alerts/services/alerts-service", () => ({
+  alertsService: {
+    listAlerts: (...args: readonly unknown[]) => mockListAlerts(...args),
   },
 }));
 
@@ -25,7 +25,7 @@ describe("useAlertsQuery", () => {
 
   it("propagates error when backend fails", async () => {
     const expectedError = new Error("backend unavailable");
-    mockGetAlerts.mockRejectedValue(expectedError);
+    mockListAlerts.mockRejectedValue(expectedError);
 
     const query = useAlertsQuery() as unknown as {
       readonly queryFn: () => Promise<AlertsResponse>;

--- a/hooks/queries/use-alerts-query.ts
+++ b/hooks/queries/use-alerts-query.ts
@@ -1,13 +1,38 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { alertsApi } from "@/lib/alerts-api";
-import type { AlertsResponse } from "@/types/contracts";
+import { queryKeys } from "@/core/query/query-keys";
+import { alertsService } from "@/features/alerts/services/alerts-service";
+import type { Alert, AlertsResponse } from "@/types/contracts";
+
+const mapAlertRecord = (
+  alert: Awaited<ReturnType<typeof alertsService.listAlerts>>["alerts"][number],
+): Alert => {
+  const createdAt = alert.createdAt ?? alert.triggeredAt ?? new Date().toISOString();
+  const isRead = alert.status === "read";
+
+  return {
+    id: alert.id,
+    type: alert.category,
+    title: alert.category.replace(/_/gu, " "),
+    body: alert.entityType
+      ? `Evento relacionado a ${alert.entityType}.`
+      : "Nova atualizacao disponivel.",
+    severity: isRead ? "info" : "warning",
+    read_at: isRead ? alert.sentAt ?? alert.triggeredAt ?? createdAt : null,
+    created_at: createdAt,
+  };
+};
 
 export const useAlertsQuery = () => {
   return useQuery<AlertsResponse>({
-    queryKey: ["alerts"],
+    queryKey: queryKeys.alerts.list(),
     queryFn: async (): Promise<AlertsResponse> => {
-      return await alertsApi.getAlerts();
+      const response = await alertsService.listAlerts();
+
+      return {
+        items: response.alerts.map(mapAlertRecord),
+        total: response.alerts.length,
+      };
     },
   });
 };

--- a/hooks/queries/use-dashboard-query.ts
+++ b/hooks/queries/use-dashboard-query.ts
@@ -1,16 +1,42 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { dashboardApi, dashboardPlaceholder } from "@/lib/dashboard-api";
-import type {
-  DashboardOverview,
-  MonthlySnapshot,
-} from "@/types/contracts";
+import { queryKeys } from "@/core/query/query-keys";
+import { dashboardService } from "@/features/dashboard/services/dashboard-service";
+import type { DashboardOverview, MonthlySnapshot } from "@/types/contracts";
+
+export const dashboardPlaceholder: DashboardOverview = {
+  currentBalance: 22340,
+  monthly: [
+    { month: "2026-01", incomes: 12000, expenses: 8000, balance: 4000 },
+    { month: "2026-02", incomes: 14300, expenses: 9960, balance: 4340 },
+    { month: "2026-03", incomes: 11800, expenses: 7800, balance: 4000 },
+  ],
+};
 
 const emptySnapshot: MonthlySnapshot = {
   month: "1970-01",
   incomes: 0,
   expenses: 0,
   balance: 0,
+};
+
+const getCurrentMonth = (): string => {
+  return new Date().toISOString().slice(0, 7);
+};
+
+const mapLegacyOverview = (
+  overview: Awaited<ReturnType<typeof dashboardService.getOverview>>,
+  trends: Awaited<ReturnType<typeof dashboardService.getTrends>>,
+): DashboardOverview => {
+  return {
+    currentBalance: overview.totals.balance,
+    monthly: trends.series.map((point) => ({
+      month: point.month,
+      incomes: point.income,
+      expenses: point.expenses,
+      balance: point.balance,
+    })),
+  };
 };
 
 export const selectMonthlySnapshot = (
@@ -28,10 +54,15 @@ export const selectMonthlySnapshot = (
 
 export const useDashboardOverviewQuery = () => {
   return useQuery<DashboardOverview>({
-    queryKey: ["dashboard", "overview"],
+    queryKey: queryKeys.dashboard.overview(),
     queryFn: async (): Promise<DashboardOverview> => {
       try {
-        return await dashboardApi.getOverview();
+        const [overview, trends] = await Promise.all([
+          dashboardService.getOverview({ month: getCurrentMonth() }),
+          dashboardService.getTrends(),
+        ]);
+
+        return mapLegacyOverview(overview, trends);
       } catch {
         return dashboardPlaceholder;
       }

--- a/hooks/queries/use-entitlement-check-query.ts
+++ b/hooks/queries/use-entitlement-check-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { entitlementsApi } from "@/lib/entitlements-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { entitlementsService } from "@/features/entitlements/services/entitlements-service";
 import type { FeatureKey } from "@/types/contracts/entitlement";
 
 export const useEntitlementCheckQuery = (
@@ -8,10 +9,11 @@ export const useEntitlementCheckQuery = (
   enabled = true,
 ) => {
   return useQuery<boolean>({
-    queryKey: ["entitlements", featureKey],
+    queryKey: queryKeys.entitlements.access(featureKey),
     enabled,
     queryFn: async (): Promise<boolean> => {
-      return entitlementsApi.checkEntitlement(featureKey);
+      const entitlement = await entitlementsService.checkEntitlement({ featureKey });
+      return entitlement.active;
     },
   });
 };

--- a/hooks/queries/use-entitlement-query.ts
+++ b/hooks/queries/use-entitlement-query.ts
@@ -1,13 +1,13 @@
-import { useQuery } from "@tanstack/react-query";
-
-import { entitlementApi } from "@/lib/entitlement-api";
+import { createApiQuery } from "@/core/query/create-api-query";
+import { queryKeys } from "@/core/query/query-keys";
+import { entitlementsService } from "@/features/entitlements/services/entitlements-service";
 import type { EntitlementCheck, FeatureKey } from "@/types/contracts";
 
 export const useEntitlementQuery = (featureKey: FeatureKey) => {
-  return useQuery<EntitlementCheck>({
-    queryKey: ["entitlements", "check", featureKey],
-    queryFn: async (): Promise<EntitlementCheck> => {
-      return entitlementApi.checkEntitlement(featureKey);
-    },
+  return createApiQuery<EntitlementCheck>(queryKeys.entitlements.check(featureKey), async () => {
+    const entitlement = await entitlementsService.checkEntitlement({ featureKey });
+    return {
+      has_access: entitlement.active,
+    };
   });
 };

--- a/hooks/queries/use-subscription-query.spec.ts
+++ b/hooks/queries/use-subscription-query.spec.ts
@@ -3,15 +3,15 @@ import type { Subscription } from "@/types/contracts";
 import { useSubscriptionQuery } from "@/hooks/queries/use-subscription-query";
 
 const mockUseQuery = jest.fn();
-const mockGetMySubscription = jest.fn();
+const mockGetSubscription = jest.fn();
 
 jest.mock("@tanstack/react-query", () => ({
   useQuery: (...args: readonly unknown[]) => mockUseQuery(...args),
 }));
 
-jest.mock("@/lib/subscription-api", () => ({
-  subscriptionApi: {
-    getMySubscription: (...args: readonly unknown[]) => mockGetMySubscription(...args),
+jest.mock("@/features/subscription/services/subscription-service", () => ({
+  subscriptionService: {
+    getSubscription: (...args: readonly unknown[]) => mockGetSubscription(...args),
   },
 }));
 
@@ -25,7 +25,7 @@ describe("useSubscriptionQuery", () => {
 
   it("propaga erro quando o backend falha", async () => {
     const networkError = new Error("network error");
-    mockGetMySubscription.mockRejectedValue(networkError);
+    mockGetSubscription.mockRejectedValue(networkError);
 
     const query = useSubscriptionQuery() as unknown as {
       readonly queryFn: () => Promise<Subscription>;

--- a/hooks/queries/use-subscription-query.ts
+++ b/hooks/queries/use-subscription-query.ts
@@ -1,13 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { subscriptionApi } from "@/lib/subscription-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { subscriptionService } from "@/features/subscription/services/subscription-service";
 import type { Subscription } from "@/types/contracts";
 
 export const useSubscriptionQuery = () => {
   return useQuery<Subscription>({
-    queryKey: ["subscription", "me"],
+    queryKey: queryKeys.subscription.me(),
     queryFn: async (): Promise<Subscription> => {
-      return subscriptionApi.getMySubscription();
+      const subscription = await subscriptionService.getSubscription();
+
+      return {
+        plan_slug: subscription.offerCode ?? subscription.planCode,
+        status:
+          subscription.status === "expired" || subscription.status === "free"
+            ? "canceled"
+            : subscription.status,
+        trial_ends_at: subscription.trialEndsAt,
+        current_period_end: subscription.currentPeriodEnd,
+      };
     },
   });
 };

--- a/hooks/queries/use-wallet-query.ts
+++ b/hooks/queries/use-wallet-query.ts
@@ -1,17 +1,36 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { walletApi, walletPlaceholder } from "@/lib/wallet-api";
+import { queryKeys } from "@/core/query/query-keys";
+import { walletService } from "@/features/wallet/services/wallet-service";
 import type { WalletSummary } from "@/types/contracts";
+
+const toAllocationPercentage = (amount: number, total: number): number => {
+  if (total <= 0) {
+    return 0;
+  }
+
+  return Number(((amount / total) * 100).toFixed(2));
+};
 
 export const useWalletSummaryQuery = () => {
   return useQuery<WalletSummary>({
-    queryKey: ["wallet", "summary"],
+    queryKey: queryKeys.wallet.summary(),
     queryFn: async (): Promise<WalletSummary> => {
-      try {
-        return await walletApi.getSummary();
-      } catch {
-        return walletPlaceholder;
-      }
+      const collection = await walletService.listEntries();
+
+      return {
+        total: collection.total,
+        assets: collection.items.map((item) => {
+          const amount = item.value ?? 0;
+
+          return {
+            id: item.id,
+            name: item.name,
+            amount,
+            allocation: toAllocationPercentage(amount, collection.total),
+          };
+        }),
+      };
     },
   });
 };

--- a/lib/entitlements-api.ts
+++ b/lib/entitlements-api.ts
@@ -10,11 +10,11 @@ interface EntitlementsApiClient {
 const normalizeEntitlementCheck = (
   payload: EntitlementCheckResponse,
 ): boolean => {
-  if (typeof payload.has_access === "boolean") {
-    return payload.has_access;
+  if ("active" in payload) {
+    return payload.active === true;
   }
 
-  return payload.active === true;
+  return payload.has_access === true;
 };
 
 export const createEntitlementsApi = (client: EntitlementsApiClient) => {

--- a/lib/web-urls.ts
+++ b/lib/web-urls.ts
@@ -1,20 +1,6 @@
-const DEFAULT_WEB_BASE_URL = "https://app.auraxis.com.br";
-
-const resolveWebBaseUrl = (): string => {
-  const raw = process.env.EXPO_PUBLIC_WEB_BASE_URL ?? DEFAULT_WEB_BASE_URL;
-  return raw.replace(/\/+$/u, "");
-};
-
-const WEB_BASE_URL = resolveWebBaseUrl();
-
-/** Canonical URL for the Terms of Use page. */
-export const TERMS_URL = `${WEB_BASE_URL}/termos` as const;
-
-/** Canonical URL for the Privacy Policy page. */
-export const PRIVACY_URL = `${WEB_BASE_URL}/privacidade` as const;
-
-/** Canonical URL for the subscription plans page. */
-export const PLANS_URL = `${WEB_BASE_URL}/planos` as const;
-
-/** Canonical URL for managing an existing subscription. */
-export const MANAGE_SUBSCRIPTION_URL = `${WEB_BASE_URL}/conta/assinatura` as const;
+export {
+  MANAGE_SUBSCRIPTION_URL,
+  PLANS_URL,
+  PRIVACY_URL,
+  TERMS_URL,
+} from "@/shared/config/web-urls";

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -11,10 +11,13 @@ module.exports = {
   '**/*.{ts,tsx}': [
     'eslint --fix --max-warnings 0 --no-warn-ignored',
     'node scripts/check-frontend-governance.cjs',
+    'node scripts/check-api-contract-governance.cjs',
+    'node scripts/check-openapi-secret-hygiene.cjs',
   ],
 
   // JSON — formatação
   '**/*.json': [
     'prettier --write',
+    'node scripts/check-openapi-secret-hygiene.cjs',
   ],
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "test:coverage": "jest --coverage",
     "flags:check": "node scripts/check-feature-flags.cjs",
     "contracts:sync": "node scripts/contracts-sync.cjs",
+    "contracts:sync:api-local": "node scripts/contracts-sync-local-api.cjs",
     "contracts:check": "node scripts/contracts-check.cjs",
-    "policy:check": "node scripts/check-frontend-governance.cjs",
+    "policy:check": "node scripts/check-frontend-governance.cjs && node scripts/check-api-contract-governance.cjs && node scripts/check-openapi-secret-hygiene.cjs",
     "quality-check": "npm run lint && npm run typecheck && npm run policy:check && npm run contracts:check && npm run test:coverage",
     "test:watch": "jest --watchAll",
     "ci:local": "bash scripts/run_ci_like_actions_local.sh",
@@ -90,10 +91,13 @@
   "lint-staged": {
     "**/*.{ts,tsx}": [
       "eslint --fix --max-warnings 0 --no-warn-ignored",
-      "node scripts/check-frontend-governance.cjs"
+      "node scripts/check-frontend-governance.cjs",
+      "node scripts/check-api-contract-governance.cjs",
+      "node scripts/check-openapi-secret-hygiene.cjs"
     ],
     "**/*.json": [
-      "prettier --write"
+      "prettier --write",
+      "node scripts/check-openapi-secret-hygiene.cjs"
     ]
   }
 }

--- a/scripts/check-api-contract-governance.cjs
+++ b/scripts/check-api-contract-governance.cjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = process.cwd();
+const SCAN_DIRECTORIES = ["app", "components", "features", "hooks", "shared"];
+const API_CALL_LITERAL_PATTERN =
+  /\.(?:get|post|put|patch|delete)\s*(?:<[^>]+>)?\(\s*["']\/(?:auth|dashboard|subscriptions|ops|wallet|goals|alerts|shared-entries|shared_entries|fiscal|transactions|user|entitlements)\b/;
+const LEGACY_API_IMPORT_PATTERN =
+  /from\s+["']@\/lib\/(?:auth|dashboard|wallet|alerts|subscription|entitlement|entitlements)-api["']/;
+const EXCLUDED_FILE_PATTERNS = [
+  /^shared\/contracts\/api-contract-map\.ts$/,
+  /^shared\/contracts\/api-endpoint-catalog\.ts$/,
+  /^shared\/mocks\/api\/router\.ts$/,
+  /^.+\.(test|spec)\.(ts|tsx)$/,
+];
+
+const walk = (directory) => {
+  if (!fs.existsSync(directory)) {
+    return [];
+  }
+
+  const files = [];
+  const stack = [directory];
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+    const entries = fs.readdirSync(current, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (entry.name === "node_modules" || entry.name === ".git" || entry.name === ".expo") {
+        continue;
+      }
+
+      const absolutePath = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(absolutePath);
+        continue;
+      }
+
+      if (!absolutePath.endsWith(".ts") && !absolutePath.endsWith(".tsx")) {
+        continue;
+      }
+
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+};
+
+const toRelative = (absolutePath) =>
+  path.relative(ROOT, absolutePath).split(path.sep).join("/");
+
+const isExcluded = (relativePath) =>
+  EXCLUDED_FILE_PATTERNS.some((pattern) => pattern.test(relativePath));
+
+const main = () => {
+  const errors = [];
+
+  for (const directory of SCAN_DIRECTORIES) {
+    const absoluteDirectory = path.resolve(ROOT, directory);
+    for (const filePath of walk(absoluteDirectory)) {
+      const relativePath = toRelative(filePath);
+
+      if (isExcluded(relativePath)) {
+        continue;
+      }
+
+      const contents = fs.readFileSync(filePath, "utf8");
+      const lines = contents.split("\n");
+
+      lines.forEach((line, index) => {
+        if (LEGACY_API_IMPORT_PATTERN.test(line)) {
+          errors.push(
+            `legacy api import detected: ${relativePath}:${index + 1}`,
+          );
+        }
+
+        if (API_CALL_LITERAL_PATTERN.test(line)) {
+          errors.push(
+            `direct API route literal detected: ${relativePath}:${index + 1}`,
+          );
+        }
+      });
+    }
+  }
+
+  if (errors.length > 0) {
+    process.stderr.write("[api-contract-governance] FAILED\n");
+    for (const error of errors) {
+      process.stderr.write(` - ${error}\n`);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write("[api-contract-governance] OK\n");
+};
+
+main();

--- a/scripts/check-openapi-secret-hygiene.cjs
+++ b/scripts/check-openapi-secret-hygiene.cjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+
+const {
+  GENERATED_TYPES_PATH,
+  OPENAPI_SNAPSHOT_PATH,
+} = require("./contracts.config.cjs");
+const {
+  findUnsafeGeneratedTypeExamples,
+  findUnsafeOpenApiExamples,
+} = require("./openapi-secret-hygiene.cjs");
+const { readJsonFile } = require("./contracts.utils.cjs");
+
+const run = () => {
+  const openApiDocument = readJsonFile(OPENAPI_SNAPSHOT_PATH);
+  const openApiFindings = findUnsafeOpenApiExamples(openApiDocument);
+  const generatedTypesText = fs.readFileSync(GENERATED_TYPES_PATH, "utf8");
+  const generatedTypeFindings = findUnsafeGeneratedTypeExamples(generatedTypesText);
+
+  if (openApiFindings.length === 0 && generatedTypeFindings.length === 0) {
+    process.stdout.write("[openapi-secret-hygiene] OK\n");
+    return;
+  }
+
+  process.stderr.write("[openapi-secret-hygiene] FAILED\n");
+
+  for (const finding of openApiFindings.slice(0, 20)) {
+    process.stderr.write(
+      ` - openapi: ${finding.path} => ${JSON.stringify(finding.original)}\n`,
+    );
+  }
+
+  for (const finding of generatedTypeFindings.slice(0, 20)) {
+    process.stderr.write(
+      ` - generated: ${finding.label} at index ${finding.index}\n`,
+    );
+  }
+
+  process.stderr.write(
+    "Run `npm run contracts:sync` or `npm run contracts:sync:api-local` after sanitizing contract examples.\n",
+  );
+  process.exit(1);
+};
+
+try {
+  run();
+} catch (error) {
+  process.stderr.write(
+    `[openapi-secret-hygiene] FAILED: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exit(1);
+}

--- a/scripts/contracts-check.cjs
+++ b/scripts/contracts-check.cjs
@@ -17,6 +17,10 @@ const {
   sha256,
   validateRestEndpointsAgainstOpenApi,
 } = require("./contracts.utils.cjs");
+const {
+  findUnsafeGeneratedTypeExamples,
+  findUnsafeOpenApiExamples,
+} = require("./openapi-secret-hygiene.cjs");
 
 const ensureFileExists = (filePath) => {
   if (!fs.existsSync(filePath)) {
@@ -92,6 +96,29 @@ const run = async () => {
 
   const openApiDocument = readJsonFile(OPENAPI_SNAPSHOT_PATH);
   const baselinePayload = readJsonFile(CONTRACT_BASELINE_PATH);
+  const openApiSecretFindings = findUnsafeOpenApiExamples(openApiDocument);
+  const generatedTypesText = fs.readFileSync(GENERATED_TYPES_PATH, "utf8");
+  const generatedTypeSecretFindings = findUnsafeGeneratedTypeExamples(
+    generatedTypesText,
+  );
+
+  if (openApiSecretFindings.length > 0 || generatedTypeSecretFindings.length > 0) {
+    process.stderr.write("[contracts:check] FAILED\n");
+    for (const finding of openApiSecretFindings.slice(0, 20)) {
+      process.stderr.write(
+        ` - unsafe OpenAPI example at ${finding.path}: ${JSON.stringify(finding.original)}\n`,
+      );
+    }
+    for (const finding of generatedTypeSecretFindings.slice(0, 20)) {
+      process.stderr.write(
+        ` - unsafe generated example (${finding.label}) at index ${finding.index}\n`,
+      );
+    }
+    process.stderr.write(
+      " - sanitize examples and rerun `npm run contracts:sync`.\n",
+    );
+    process.exit(1);
+  }
 
   const skipRemoteCheck =
     String(process.env.AURAXIS_SKIP_REMOTE_CONTRACT_CHECK ?? "").toLowerCase()

--- a/scripts/contracts-sync-local-api.cjs
+++ b/scripts/contracts-sync-local-api.cjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+const { execFileSync } = require("node:child_process");
+
+const APP_REPO_ROOT = process.cwd();
+const DEFAULT_API_REPO_ROOT = path.resolve(APP_REPO_ROOT, "..", "auraxis-api");
+const API_REPO_ROOT =
+  process.env.AURAXIS_API_REPO_ROOT ?? DEFAULT_API_REPO_ROOT;
+const API_VENV_DIR =
+  process.env.AURAXIS_API_VENV_DIR ?? path.resolve(API_REPO_ROOT, ".venv");
+const API_REPO_BIN = path.resolve(API_REPO_ROOT, "scripts", "repo_bin.sh");
+const TEMP_OPENAPI_FILE = path.resolve(
+  os.tmpdir(),
+  `auraxis-app-openapi-local-${Date.now()}.json`,
+);
+const TEMP_SQLITE_DB = path.resolve(
+  os.tmpdir(),
+  "auraxis-app-contracts-sync.sqlite3",
+);
+
+const EXPORT_CODE = `
+import json
+import sys
+
+from app import create_app
+
+app = create_app()
+
+with app.test_client() as client:
+    response = client.get("/docs/swagger/")
+    if response.status_code != 200:
+        raise SystemExit(
+            f"[contracts:sync:api-local] failed to export openapi: {response.status_code}"
+        )
+    with open(sys.argv[1], "w", encoding="utf-8") as target:
+        json.dump(response.get_json(), target, ensure_ascii=False, indent=2)
+`.trim();
+
+const ensureApiRepoExists = () => {
+  if (!fs.existsSync(API_REPO_ROOT)) {
+    throw new Error(
+      `auraxis-api repo not found at ${API_REPO_ROOT}. Set AURAXIS_API_REPO_ROOT if needed.`,
+    );
+  }
+
+  if (!fs.existsSync(API_REPO_BIN)) {
+    throw new Error(`missing repo helper: ${API_REPO_BIN}`);
+  }
+};
+
+const exportOpenApiFromLocalApi = () => {
+  ensureApiRepoExists();
+
+  execFileSync(
+    API_REPO_BIN,
+    ["python", "-c", EXPORT_CODE, TEMP_OPENAPI_FILE],
+    {
+      cwd: API_REPO_ROOT,
+      stdio: "inherit",
+      env: {
+        ...process.env,
+        FLASK_DEBUG: "true",
+        DOCS_EXPOSURE_POLICY: "public",
+        DATABASE_URL: `sqlite:///${TEMP_SQLITE_DB}`,
+        VENV_DIR: API_VENV_DIR,
+      },
+    },
+  );
+};
+
+const runContractsSync = () => {
+  execFileSync(process.execPath, [path.resolve(APP_REPO_ROOT, "scripts", "contracts-sync.cjs")], {
+    cwd: APP_REPO_ROOT,
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      AURAXIS_OPENAPI_LOCAL_FILE: TEMP_OPENAPI_FILE,
+    },
+  });
+};
+
+const cleanup = () => {
+  fs.rmSync(TEMP_OPENAPI_FILE, { force: true });
+  fs.rmSync(TEMP_SQLITE_DB, { force: true });
+};
+
+try {
+  exportOpenApiFromLocalApi();
+  runContractsSync();
+} catch (error) {
+  process.stderr.write(
+    `[contracts:sync:api-local] FAILED: ${error instanceof Error ? error.message : String(error)}\n`,
+  );
+  process.exitCode = 1;
+} finally {
+  cleanup();
+}

--- a/scripts/contracts-sync.cjs
+++ b/scripts/contracts-sync.cjs
@@ -19,6 +19,7 @@ const {
   readOpenApiFromSource,
   writeJsonFile,
 } = require("./contracts.utils.cjs");
+const { sanitizeOpenApiDocument } = require("./openapi-secret-hygiene.cjs");
 
 const run = async () => {
   const localOpenApiSourcePath = process.env.AURAXIS_OPENAPI_LOCAL_FILE ?? "";
@@ -26,8 +27,9 @@ const run = async () => {
     OPENAPI_SNAPSHOT_URL,
     localOpenApiSourcePath,
   );
+  const sanitizedOpenApiDocument = sanitizeOpenApiDocument(openApiDocument);
 
-  writeJsonFile(OPENAPI_SNAPSHOT_PATH, openApiDocument);
+  writeJsonFile(OPENAPI_SNAPSHOT_PATH, sanitizedOpenApiDocument);
 
   const remotePacks = await listRemoteContractPacks(CONTRACTS_API_URL);
   const baselinePayload = computeContractBaseline(

--- a/scripts/openapi-secret-hygiene.cjs
+++ b/scripts/openapi-secret-hygiene.cjs
@@ -1,0 +1,156 @@
+const GENERATED_TOKEN_LITERAL_REGEX =
+  /"token":\s*"(eyJ[^"\n]+|[A-Za-z0-9_-]{24,})"/g;
+const GENERATED_REFRESH_TOKEN_LITERAL_REGEX =
+  /"refresh_token":\s*"(eyJ[^"\n]+|[A-Za-z0-9_-]{24,})"/g;
+const GENERATED_REQUEST_ID_LITERAL_REGEX =
+  /X-Request-ID[^"\n]*"([a-f0-9]{32,})"/gi;
+
+const cloneJson = (value) => JSON.parse(JSON.stringify(value));
+const SAFE_PLACEHOLDERS = new Set([
+  "req-example-id",
+  "refresh-token-example",
+  "captcha-token-example",
+  "jwt-example-token",
+  "example-token",
+]);
+
+const sanitizeExampleScalar = (value, pathSegments) => {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  if (SAFE_PLACEHOLDERS.has(value)) {
+    return value;
+  }
+
+  const loweredSegments = pathSegments.map((segment) =>
+    String(segment).toLowerCase(),
+  );
+
+  if (loweredSegments.includes("x-request-id")) {
+    return "req-example-id";
+  }
+
+  if (loweredSegments.includes("refresh_token")) {
+    return "refresh-token-example";
+  }
+
+  if (loweredSegments.includes("captcha_token")) {
+    return "captcha-token-example";
+  }
+
+  if (loweredSegments.includes("token")) {
+    return value.startsWith("eyJ") ? "jwt-example-token" : "example-token";
+  }
+
+  return value;
+};
+
+const sanitizeOpenApiNode = (node, pathSegments = [], insideExample = false) => {
+  if (Array.isArray(node)) {
+    return node.map((entry, index) =>
+      sanitizeOpenApiNode(entry, [...pathSegments, index], insideExample),
+    );
+  }
+
+  if (node && typeof node === "object") {
+    const sanitizedNode = {};
+
+    for (const [key, value] of Object.entries(node)) {
+      const nextInsideExample =
+        insideExample || key === "example" || key === "default";
+      sanitizedNode[key] = sanitizeOpenApiNode(
+        value,
+        [...pathSegments, key],
+        nextInsideExample,
+      );
+    }
+
+    return sanitizedNode;
+  }
+
+  if (insideExample) {
+    return sanitizeExampleScalar(node, pathSegments);
+  }
+
+  return node;
+};
+
+const sanitizeOpenApiDocument = (document) => {
+  return sanitizeOpenApiNode(cloneJson(document));
+};
+
+const findUnsafeOpenApiExamples = (document) => {
+  const sanitized = sanitizeOpenApiDocument(document);
+  const findings = [];
+
+  const walk = (originalNode, sanitizedNode, pathSegments = []) => {
+    if (Array.isArray(originalNode) && Array.isArray(sanitizedNode)) {
+      originalNode.forEach((entry, index) => {
+        walk(entry, sanitizedNode[index], [...pathSegments, index]);
+      });
+      return;
+    }
+
+    if (
+      originalNode &&
+      typeof originalNode === "object" &&
+      sanitizedNode &&
+      typeof sanitizedNode === "object"
+    ) {
+      for (const [key, value] of Object.entries(originalNode)) {
+        walk(value, sanitizedNode[key], [...pathSegments, key]);
+      }
+      return;
+    }
+
+    if (originalNode !== sanitizedNode) {
+      findings.push({
+        path: pathSegments.join("."),
+        original: originalNode,
+        sanitized: sanitizedNode,
+      });
+    }
+  };
+
+  walk(document, sanitized);
+  return findings;
+};
+
+const collectRegexMatches = (text, regex, label) => {
+  const matches = [];
+  for (const match of text.matchAll(regex)) {
+    matches.push({
+      label,
+      literal: match[0],
+      index: match.index ?? -1,
+    });
+  }
+  return matches;
+};
+
+const findUnsafeGeneratedTypeExamples = (generatedTypesText) => {
+  return [
+    ...collectRegexMatches(
+      generatedTypesText,
+      GENERATED_TOKEN_LITERAL_REGEX,
+      "token example",
+    ),
+    ...collectRegexMatches(
+      generatedTypesText,
+      GENERATED_REFRESH_TOKEN_LITERAL_REGEX,
+      "refresh token example",
+    ),
+    ...collectRegexMatches(
+      generatedTypesText,
+      GENERATED_REQUEST_ID_LITERAL_REGEX,
+      "request id example",
+    ),
+  ];
+};
+
+module.exports = {
+  findUnsafeGeneratedTypeExamples,
+  findUnsafeOpenApiExamples,
+  sanitizeOpenApiDocument,
+};

--- a/shared/config/web-urls.ts
+++ b/shared/config/web-urls.ts
@@ -1,0 +1,13 @@
+const DEFAULT_WEB_BASE_URL = "https://app.auraxis.com.br";
+
+const resolveWebBaseUrl = (): string => {
+  const raw = process.env.EXPO_PUBLIC_WEB_BASE_URL ?? DEFAULT_WEB_BASE_URL;
+  return raw.replace(/\/+$/u, "");
+};
+
+const WEB_BASE_URL = resolveWebBaseUrl();
+
+export const TERMS_URL = `${WEB_BASE_URL}/termos` as const;
+export const PRIVACY_URL = `${WEB_BASE_URL}/privacidade` as const;
+export const PLANS_URL = `${WEB_BASE_URL}/planos` as const;
+export const MANAGE_SUBSCRIPTION_URL = `${WEB_BASE_URL}/conta/assinatura` as const;

--- a/shared/contracts/api-contract-map.test.ts
+++ b/shared/contracts/api-contract-map.test.ts
@@ -1,7 +1,23 @@
+import fs from "node:fs";
+import path from "node:path";
+
 import {
   apiContractMap,
   type ApiContractKey,
 } from "@/shared/contracts/api-contract-map";
+import { apiEndpointCatalog } from "@/shared/contracts/api-endpoint-catalog";
+
+const KNOWN_OPENAPI_GAPS = new Set([
+  "GET /alerts",
+  "POST /alerts/{alertId}/read",
+  "DELETE /alerts/{alertId}",
+  "GET /alerts/preferences",
+  "PUT /alerts/preferences/{category}",
+  "GET /subscriptions/plans",
+  "GET /subscriptions/me",
+  "POST /subscriptions/checkout",
+  "POST /subscriptions/cancel",
+]);
 
 describe("apiContractMap", () => {
   it("mantem path/method unicos por contrato", () => {
@@ -27,5 +43,44 @@ describe("apiContractMap", () => {
     expect(
       publicContracts.every((contractKey) => !apiContractMap[contractKey].authRequired),
     ).toBe(true);
+  });
+
+  it("mantem todos os contratos registrados no catalogo de endpoints", () => {
+    const catalogEntries = new Set<string>(
+      Object.values(apiEndpointCatalog).flatMap((entries) => entries),
+    );
+
+    const missingEntries = Object.values(apiContractMap)
+      .map((contract) => `${contract.method} ${contract.path}`)
+      .filter((signature) => !catalogEntries.has(signature));
+
+    expect(missingEntries).toEqual([]);
+  });
+
+  it("mantem contratos alinhados ao snapshot OpenAPI, exceto gaps conhecidos do backend", () => {
+    const snapshot = JSON.parse(
+      fs.readFileSync(
+        path.resolve(__dirname, "../../contracts/openapi.snapshot.json"),
+        "utf8",
+      ),
+    ) as {
+      readonly paths?: Record<string, Record<string, unknown>>;
+    };
+    const openApiEntries = new Set<string>();
+
+    for (const [path, methods] of Object.entries(snapshot.paths ?? {})) {
+      for (const method of Object.keys(methods)) {
+        openApiEntries.add(`${method.toUpperCase()} ${path}`);
+      }
+    }
+
+    const missingFromOpenApi = Object.values(apiContractMap)
+      .map((contract) => `${contract.method} ${contract.path}`)
+      .filter(
+        (signature) =>
+          !openApiEntries.has(signature) && !KNOWN_OPENAPI_GAPS.has(signature),
+      );
+
+    expect(missingFromOpenApi).toEqual([]);
   });
 });

--- a/shared/contracts/api-contract-map.ts
+++ b/shared/contracts/api-contract-map.ts
@@ -11,7 +11,14 @@ import type {
   UserBootstrap,
   UserBootstrapQuery,
 } from "@/features/bootstrap/contracts";
-import type { DashboardOverview } from "@/features/dashboard/contracts";
+import type {
+  DashboardOverview,
+  DashboardTrends,
+} from "@/features/dashboard/contracts";
+import type {
+  EntitlementCheckQuery,
+  EntitlementCheckResult,
+} from "@/features/entitlements/contracts";
 import type { GoalListResponse } from "@/features/goals/contracts";
 import type {
   ObservabilityMetricsSnapshot,
@@ -145,6 +152,16 @@ export const apiContractMap = {
     path: "/dashboard/overview",
     authRequired: true,
   }),
+  dashboardTrends: defineApiContract<
+    "GET",
+    "/dashboard/trends",
+    never,
+    DashboardTrends
+  >({
+    method: "GET",
+    path: "/dashboard/trends",
+    authRequired: true,
+  }),
   goalsList: defineApiContract<"GET", "/goals", never, GoalListResponse>({
     method: "GET",
     path: "/goals",
@@ -158,6 +175,26 @@ export const apiContractMap = {
   alertsList: defineApiContract<"GET", "/alerts", never, AlertListResponse>({
     method: "GET",
     path: "/alerts",
+    authRequired: true,
+  }),
+  alertsMarkRead: defineApiContract<
+    "POST",
+    "/alerts/{alertId}/read",
+    never,
+    void
+  >({
+    method: "POST",
+    path: "/alerts/{alertId}/read",
+    authRequired: true,
+  }),
+  alertsDelete: defineApiContract<
+    "DELETE",
+    "/alerts/{alertId}",
+    never,
+    void
+  >({
+    method: "DELETE",
+    path: "/alerts/{alertId}",
     authRequired: true,
   }),
   alertPreferences: defineApiContract<
@@ -178,6 +215,17 @@ export const apiContractMap = {
   >({
     method: "PUT",
     path: "/alerts/preferences/{category}",
+    authRequired: true,
+  }),
+  entitlementsCheck: defineApiContract<
+    "GET",
+    "/entitlements/check",
+    never,
+    EntitlementCheckResult,
+    EntitlementCheckQuery
+  >({
+    method: "GET",
+    path: "/entitlements/check",
     authRequired: true,
   }),
   subscriptionPlans: defineApiContract<

--- a/shared/contracts/api-endpoint-catalog.ts
+++ b/shared/contracts/api-endpoint-catalog.ts
@@ -67,10 +67,13 @@ export const apiEndpointCatalog = {
   ],
   alerts: [
     "GET /alerts",
-    "POST /alerts/{alert_id}/read",
-    "DELETE /alerts/{alert_id}",
+    "POST /alerts/{alertId}/read",
+    "DELETE /alerts/{alertId}",
     "GET /alerts/preferences",
     "PUT /alerts/preferences/{category}",
+  ],
+  entitlements: [
+    "GET /entitlements/check",
   ],
   subscriptions: [
     "GET /subscriptions/plans",

--- a/shared/mocks/api/router.ts
+++ b/shared/mocks/api/router.ts
@@ -433,6 +433,25 @@ const handleBootstrapRoute: MockRouteHandler = (context) => {
   return ok(serializeBootstrapResponse(limit));
 };
 
+const handleEntitlementRoutes: MockRouteHandler = (context) => {
+  if (context.method !== "GET" || context.pathname !== "/entitlements/check") {
+    return null;
+  }
+
+  const featureKey = context.query.get("feature_key") ?? "";
+  const activeFeatures = new Set([
+    "advanced_simulations",
+    "export_pdf",
+    "shared_entries",
+    "wallet_read",
+  ]);
+
+  return ok({
+    feature_key: featureKey,
+    active: activeFeatures.has(featureKey),
+  });
+};
+
 const handleSubscriptionRoutes: MockRouteHandler = (context) => {
   if (context.method === "GET" && context.pathname === "/subscriptions/plans") {
     return ok(serializeSubscriptionPlans());
@@ -564,6 +583,7 @@ const routeHandlers: MockRouteHandler[] = [
   handleHealthRoute,
   handleAuthRoutes,
   handleBootstrapRoute,
+  handleEntitlementRoutes,
   handleSubscriptionRoutes,
   handleDashboardRoutes,
   handleWalletRoute,

--- a/shared/types/generated/openapi.ts
+++ b/shared/types/generated/openapi.ts
@@ -4,6 +4,240 @@
  */
 
 export interface paths {
+    "/auth/email/confirm": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Confirmar conta
+         * @description Confirma a conta do usuario a partir do token enviado por email.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    /**
+                     * @description Token de confirmacao recebido por email.
+                     * @example {
+                     *       "token": "example-token"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_auth_schema_ConfirmEmailSchema"];
+                };
+            };
+            responses: {
+                /** @description Email confirmado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {},
+                         *       "message": "Email confirmed successfully."
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido, expirado ou payload inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Invalid or expired email confirmation token.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno ao confirmar email */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Email confirmation failed",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/email/resend": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Reenviar confirmacao de conta
+         * @description Reenvia o email de confirmacao do usuario autenticado. Requer token JWT valido no header Authorization. A resposta e neutra para evitar enumeracao de contas.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Solicitação recebida com resposta neutra */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {},
+                         *       "message": "If an account exists for this email, confirmation instructions were sent."
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token JWT ausente ou inválido */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Missing or invalid authorization token",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno ao reenviar confirmacao */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Email confirmation resend failed",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/auth/login": {
         parameters: {
             query?: never;
@@ -13,27 +247,218 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Autenticar usuário
+         * @description Autentica o usuário e devolve um token JWT.
+         *
+         *     Headers:
+         *     - `X-API-Contract`: opcional; `v2` padroniza o envelope.
+         *
+         *     Payload:
+         *     - `email` é o identificador obrigatório e canônico de login
+         *     - `password` é obrigatório
+         *
+         *     Sessão:
+         *     - um login bem-sucedido atualiza o `current_jti` do usuário e revoga a sessão JWT anterior
+         *
+         *     Resposta:
+         *     - `data.token`: JWT para chamadas autenticadas
+         *     - `data.user`: dados básicos do usuário autenticado
+         */
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
-            responses: never;
+            requestBody: {
+                content: {
+                    /**
+                     * @description Credenciais para login. `email` é o único identificador aceito para autenticação.
+                     * @example {
+                     *       "email": "italo@auraxis.com.br",
+                     *       "password": "MinhaSenha@123"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_auth_schema_AuthSchema"];
+                };
+            };
+            responses: {
+                /** @description Login realizado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "token": "jwt-example-token",
+                         *         "user": {
+                         *           "email": "italo@auraxis.com.br",
+                         *           "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                         *           "name": "Italo Chagas"
+                         *         }
+                         *       },
+                         *       "message": "Login successful"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Credenciais ausentes ou payload inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Missing credentials",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Credenciais inválidas */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Invalid credentials",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Muitas tentativas de login */
+                429: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "TOO_MANY_ATTEMPTS",
+                         *       "details": {
+                         *         "retry_after_seconds": 300
+                         *       },
+                         *       "message": "Too many login attempts. Try again later.",
+                         *       "status_code": 429
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno ao efetuar login */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Login failed",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Serviço de autenticação temporariamente indisponível */
+                503: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "AUTH_BACKEND_UNAVAILABLE",
+                         *       "message": "Authentication temporarily unavailable. Try again later.",
+                         *       "status_code": 503
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -47,27 +472,55 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Revogar sessão atual
+         * @description Revoga o JWT atual do usuário autenticado.
+         *
+         *     Depois dessa chamada, o token utilizado deixa de ser aceito nas rotas protegidas.
+         */
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Logout realizado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {},
+                         *       "message": "Logout successful"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+            };
         };
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -81,27 +534,141 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Solicitar recuperação de senha
+         * @description Solicita recuperação de senha por link. A resposta é sempre neutra para evitar enumeração de contas.
+         */
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
-            responses: never;
+            requestBody: {
+                content: {
+                    /**
+                     * @description Email da conta que deseja recuperar acesso.
+                     * @example {
+                     *       "email": "italo@auraxis.com.br"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_auth_schema_ForgotPasswordSchema"];
+                };
+            };
+            responses: {
+                /** @description Solicitação recebida com resposta neutra */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {},
+                         *       "message": "If an account exists for this email, recovery instructions were sent."
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Dados inválidos",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno ao solicitar recuperação */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Password reset request failed",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Serviço de autenticação temporariamente indisponível */
+                503: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "AUTH_BACKEND_UNAVAILABLE",
+                         *       "message": "Authentication temporarily unavailable. Try again later.",
+                         *       "status_code": 503
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -115,27 +682,239 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Redefinir senha
+         * @description Redefine a senha de um usuário a partir de um token de recuperação.
+         */
         post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
-            responses: never;
+            requestBody: {
+                content: {
+                    /**
+                     * @description Token de recuperação e nova senha válida.
+                     * @example {
+                     *       "new_password": "NovaSenha@123",
+                     *       "token": "example-token"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_auth_schema_ResetPasswordSchema"];
+                };
+            };
+            responses: {
+                /** @description Senha redefinida com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {},
+                         *       "message": "Password updated successfully"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido, expirado ou payload inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Token inválido ou expirado",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno ao redefinir senha */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Password reset failed",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         delete?: never;
-        options: {
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Renovar access token
+         * @description Emite um novo par de tokens (access + refresh) usando um refresh token válido.
+         *
+         *     Rotation:
+         *     - Cada uso invalida o refresh token anterior (replay attack prevention).
+         *     - O novo refresh token tem TTL de 7 dias a partir da emissão.
+         *
+         *     Headers:
+         *     - `Authorization: Bearer <refresh_token>` (obrigatório)
+         *     - `X-API-Contract`: opcional; `v2` padroniza o envelope.
+         */
+        post: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Tokens renovados com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "refresh_token": "refresh-token-example",
+                         *         "token": "example-token"
+                         *       },
+                         *       "message": "Token refreshed"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Refresh token inválido, expirado ou já utilizado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "TOKEN_INVALID",
+                         *       "message": "Token invalid or already used",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Muitas requisições de renovação */
+                429: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "RATE_LIMIT_EXCEEDED",
+                         *       "message": "Too many requests",
+                         *       "status_code": 429
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
+        delete?: never;
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -149,6 +928,543 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /**
+         * Registrar usuário
+         * @description Cria uma nova conta no sistema.
+         *
+         *     Payload:
+         *     - `name`, `email` e `password` são obrigatórios
+         *     - `investor_profile` é opcional no onboarding inicial
+         *
+         *     Dependendo da política de segurança, conflitos de email podem ser neutralizados com uma resposta de aceite para evitar enumeração.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    /**
+                     * @description Dados necessários para criação da conta.
+                     * @example {
+                     *       "email": "italo@auraxis.com.br",
+                     *       "investor_profile": "conservador",
+                     *       "name": "Italo Chagas",
+                     *       "password": "MinhaSenha@123"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_user_schemas_UserRegistrationSchema"];
+                };
+            };
+            responses: {
+                /** @description Usuário criado com sucesso */
+                201: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "user": {
+                         *           "email": "italo@auraxis.com.br",
+                         *           "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                         *           "name": "Italo Chagas"
+                         *         }
+                         *       },
+                         *       "message": "User created successfully"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Erro de validação",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Email já registrado */
+                409: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "CONFLICT",
+                         *       "message": "Email já registrado",
+                         *       "status_code": 409
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno do servidor */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Failed to create user",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dashboard/overview": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Obter overview mensal do dashboard
+         * @description Contrato canônico do dashboard financeiro do MVP1. Use esta rota para visão agregada mensal; `/transactions/dashboard` permanece apenas como compatibilidade transitória.
+         */
+        get: {
+            parameters: {
+                query: {
+                    /**
+                     * @description Mês de referência no formato YYYY-MM
+                     * @example 2026-03
+                     */
+                    month: string;
+                };
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Overview do dashboard */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "counts": {
+                         *           "expense_transactions": 10,
+                         *           "income_transactions": 4,
+                         *           "status": {
+                         *             "paid": 9,
+                         *             "pending": 5
+                         *           },
+                         *           "total_transactions": 14
+                         *         },
+                         *         "month": "2026-03",
+                         *         "top_categories": {
+                         *           "expense": [
+                         *             {
+                         *               "category_name": "Moradia",
+                         *               "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *               "total_amount": 1800,
+                         *               "transactions_count": 3
+                         *             }
+                         *           ],
+                         *           "income": [
+                         *             {
+                         *               "category_name": "Receitas",
+                         *               "tag_id": null,
+                         *               "total_amount": 5000,
+                         *               "transactions_count": 4
+                         *             }
+                         *           ]
+                         *         },
+                         *         "totals": {
+                         *           "balance": 1800,
+                         *           "expense_total": 3200,
+                         *           "income_total": 5000
+                         *         }
+                         *       },
+                         *       "message": "Overview do dashboard calculado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Parâmetro inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao calcular overview do dashboard",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dashboard/trends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Tendências mensais do dashboard
+         * @description Retorna a série histórica de receitas, despesas e saldo para os últimos N meses (apenas transações pagas).
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description Número de meses a incluir (1–24, padrão 6)
+                     * @example 6
+                     */
+                    months?: string;
+                };
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Série de tendências mensais */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "months": 6,
+                         *         "series": [
+                         *           {
+                         *             "balance": 1800,
+                         *             "expenses": 3200,
+                         *             "income": 5000,
+                         *             "month": "2026-04"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Tendências calculadas com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Parâmetro inválido */
+                422: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "O parâmetro 'months' deve ser um inteiro entre 1 e 24.",
+                         *       "status_code": 422
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao calcular tendências do dashboard",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/entitlements": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Lista os entitlements do usuário autenticado. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Lista de entitlements */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/entitlements/admin": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Concede um entitlement a um usuário. Requer role 'admin'. */
         post: {
             parameters: {
                 query?: never;
@@ -157,19 +1473,132 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Entitlement concedido */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Parâmetros inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Acesso negado — requer role admin */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
         delete?: never;
-        options: {
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/entitlements/admin/{entitlement_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** @description Revoga um entitlement pelo seu UUID. Requer role 'admin'. */
+        delete: {
             parameters: {
                 query?: never;
+                header?: never;
+                path: {
+                    entitlement_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Entitlement revogado */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Acesso negado — requer role admin */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Entitlement não encontrado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/entitlements/check": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Verifica se o usuário autenticado possui um entitlement ativo para a feature especificada. Parâmetro obrigatório: ?feature_key=xxx */
+        get: {
+            parameters: {
+                query: {
+                    feature_key: string;
+                };
                 header?: never;
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Resultado da verificação */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Parâmetro feature_key ausente */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -226,6 +1655,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
+        /** @description Executa simulação de meta sem persistência (what-if), retornando projeção e recomendações acionáveis. */
         post: {
             parameters: {
                 query?: never;
@@ -234,19 +1664,32 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Simulação calculada com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -258,6 +1701,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** @description Retorna uma meta específica do usuário autenticado. */
         get: {
             parameters: {
                 query?: never;
@@ -268,8 +1712,38 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Meta encontrada */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Meta não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
+        /** @description Alias legado para atualização de metas. Use `PATCH /goals/{goal_id}` como contrato canônico para update parcial. */
         put: {
             parameters: {
                 query?: never;
@@ -280,9 +1754,66 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Meta atualizada via compatibilidade legada */
+                200: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /goals/{goal_id}
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example PATCH
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Meta não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
         post?: never;
+        /** @description Remove uma meta específica do usuário autenticado. */
         delete: {
             parameters: {
                 query?: never;
@@ -293,9 +1824,41 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Meta removida */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Meta não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        options: {
+        options?: never;
+        head?: never;
+        /** @description Atualiza parcialmente uma meta específica do usuário autenticado. */
+        patch: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -305,10 +1868,44 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Meta atualizada */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Meta não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/goals/{goal_id}/plan": {
@@ -318,6 +1915,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /** @description Calcula o plano da meta considerando renda, despesas e capacidade de aporte do usuário. */
         get: {
             parameters: {
                 query?: never;
@@ -328,23 +1926,41 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Planejamento calculado com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Meta não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    goal_id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -401,15 +2017,254 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
-    "/transactions": {
+    "/ops/metrics": {
         parameters: {
             query?: never;
             header?: never;
             path?: never;
             cookie?: never;
         };
-        get?: never;
-        put: {
+        /** @description Exporta métricas em formato texto compatível com scrape simples. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Payload Prometheus text exposition */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Chave inválida ou ausente */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Export desabilitado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        /** @description Exporta métricas em formato texto compatível com scrape simples. */
+        options: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Payload Prometheus text exposition */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Chave inválida ou ausente */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Export desabilitado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/ops/observability": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Exporta snapshot JSON de métricas internas para collector externo. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Snapshot JSON de observabilidade */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Chave inválida ou ausente */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Export desabilitado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        /** @description Exporta snapshot JSON de métricas internas para collector externo. */
+        options: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Snapshot JSON de observabilidade */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Chave inválida ou ausente */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Export desabilitado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/readiness": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Todas as dependências saudáveis */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token de autorização ausente ou inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Uma ou mais dependências indisponíveis */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        /** @description Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado. */
+        options: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Todas as dependências saudáveis */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token de autorização ausente ou inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Uma ou mais dependências indisponíveis */
+                503: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -419,6 +2274,7 @@ export interface paths {
             requestBody?: never;
             responses: never;
         };
+        put?: never;
         post: {
             parameters: {
                 query?: never;
@@ -429,16 +2285,7 @@ export interface paths {
             requestBody?: never;
             responses: never;
         };
-        delete: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        delete?: never;
         options: {
             parameters: {
                 query?: never;
@@ -449,6 +2296,693 @@ export interface paths {
             requestBody?: never;
             responses: never;
         };
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations/installment-vs-cash": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Recalcula e persiste uma simulação parcelado vs à vista no subdomínio canônico de `simulations`. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Simulação salva com sucesso */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations/installment-vs-cash/calculate": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Executa a simulação pública de parcelado vs à vista, retornando comparativo, cronograma e recomendação. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Simulação calculada com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations/installment-vs-cash/save": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Alias legado do salvamento parcelado vs à vista. Use `POST /simulations/installment-vs-cash` como contrato canônico. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Simulação salva com sucesso via alias legado */
+                201: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /simulations/installment-vs-cash
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example POST
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations/{simulation_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Retorna uma simulação específica do usuário autenticado. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    simulation_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Simulação encontrada */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Simulação não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** @description Remove uma simulação específica do usuário autenticado. */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    simulation_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Simulação removida */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Simulação não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations/{simulation_id}/goal": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Converte uma simulação salva em meta de compra. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    simulation_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Meta criada a partir da simulação */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Entitlement necessário */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Simulação não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/simulations/{simulation_id}/planned-expense": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Converte uma simulação salva em despesa planejada. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    simulation_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Despesa planejada criada a partir da simulação */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Entitlement necessário */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Simulação não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/transactions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Listar transações
+         * @description Lista canônica de transações ativas com filtros, ordenação e paginação.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Lista de transações */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "items": [
+                         *           {
+                         *             "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *             "amount": "150.00",
+                         *             "bank_name": null,
+                         *             "created_at": "2026-03-01T10:00:00+00:00",
+                         *             "credit_card_id": null,
+                         *             "currency": "BRL",
+                         *             "description": "Fatura mensal de energia",
+                         *             "due_date": "2026-03-10",
+                         *             "end_date": null,
+                         *             "external_id": null,
+                         *             "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *             "installment_count": null,
+                         *             "installment_group_id": null,
+                         *             "is_installment": false,
+                         *             "is_recurring": false,
+                         *             "observation": "Pagar antes do dia 10",
+                         *             "paid_at": null,
+                         *             "source": "manual",
+                         *             "start_date": null,
+                         *             "status": "pending",
+                         *             "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *             "title": "Conta de luz",
+                         *             "type": "expense",
+                         *             "updated_at": "2026-03-01T10:00:00+00:00"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Lista de transações retornada com sucesso",
+                         *       "meta": {
+                         *         "pagination": {
+                         *           "page": 1,
+                         *           "pages": 2,
+                         *           "per_page": 10,
+                         *           "total": 14
+                         *         }
+                         *       }
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao listar transações",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        /**
+         * Criar transação
+         * @description Cria uma nova transação financeira.
+         *
+         *     Aceita receitas e despesas, com suporte a recorrência e parcelamento.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    /**
+                     * @description Payload de criação da transação.
+                     * @example {
+                     *       "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                     *       "amount": "150.00",
+                     *       "description": "Fatura mensal de energia",
+                     *       "due_date": "2026-03-10",
+                     *       "observation": "Pagar antes do dia 10",
+                     *       "status": "pending",
+                     *       "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                     *       "title": "Conta de luz",
+                     *       "type": "expense"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["TransactionCreate"];
+                };
+            };
+            responses: {
+                /** @description Transação criada com sucesso */
+                201: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction": {
+                         *           "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *           "amount": "150.00",
+                         *           "bank_name": null,
+                         *           "created_at": "2026-03-01T10:00:00+00:00",
+                         *           "credit_card_id": null,
+                         *           "currency": "BRL",
+                         *           "description": "Fatura mensal de energia",
+                         *           "due_date": "2026-03-10",
+                         *           "end_date": null,
+                         *           "external_id": null,
+                         *           "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *           "installment_count": null,
+                         *           "installment_group_id": null,
+                         *           "is_installment": false,
+                         *           "is_recurring": false,
+                         *           "observation": "Pagar antes do dia 10",
+                         *           "paid_at": null,
+                         *           "source": "manual",
+                         *           "start_date": null,
+                         *           "status": "pending",
+                         *           "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *           "title": "Conta de luz",
+                         *           "type": "expense",
+                         *           "updated_at": "2026-03-01T10:00:00+00:00"
+                         *         }
+                         *       },
+                         *       "message": "Transação criada com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Erro de validação",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao criar transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -460,29 +2994,169 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Obter dashboard mensal legado de transações
+         * @description Compatibilidade transitória para o dashboard mensal. Prefira `GET /dashboard/overview`.
+         */
         get: {
             parameters: {
-                query?: never;
-                header?: never;
+                query?: {
+                    /**
+                     * @description Mês de referência no formato YYYY-MM
+                     * @example 2026-03
+                     */
+                    month?: string;
+                };
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Dashboard mensal legado */
+                200: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /dashboard/overview
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example GET
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "balance": 1800,
+                         *         "counts": {
+                         *           "expense_transactions": 10,
+                         *           "income_transactions": 4,
+                         *           "total_transactions": 14
+                         *         },
+                         *         "expense_total": 3200,
+                         *         "income_total": 5000,
+                         *         "month": "2026-03"
+                         *       },
+                         *       "message": "Dashboard mensal retornado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Parâmetro inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao calcular dashboard mensal",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -494,29 +3168,136 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Listar transações deletadas
+         * @description Lista a lixeira de transações deletadas do usuário.
+         */
         get: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Lista de transações deletadas */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "items": [
+                         *           {
+                         *             "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *             "amount": "150.00",
+                         *             "bank_name": null,
+                         *             "created_at": "2026-03-01T10:00:00+00:00",
+                         *             "credit_card_id": null,
+                         *             "currency": "BRL",
+                         *             "description": "Fatura mensal de energia",
+                         *             "due_date": "2026-03-10",
+                         *             "end_date": null,
+                         *             "external_id": null,
+                         *             "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *             "installment_count": null,
+                         *             "installment_group_id": null,
+                         *             "is_installment": false,
+                         *             "is_recurring": false,
+                         *             "observation": "Pagar antes do dia 10",
+                         *             "paid_at": null,
+                         *             "source": "manual",
+                         *             "start_date": null,
+                         *             "status": "pending",
+                         *             "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *             "title": "Conta de luz",
+                         *             "type": "expense",
+                         *             "updated_at": "2026-03-01T10:00:00+00:00"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Lista de transações deletadas"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao listar transações deletadas",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -528,29 +3309,175 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Listar vencimentos por período
+         * @description Lista vencimentos (receitas + despesas) por período com paginação, contadores e ordenação por vencimento.
+         */
         get: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Lista de vencimentos */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "counts": {
+                         *           "expense_transactions": 10,
+                         *           "income_transactions": 4,
+                         *           "total_transactions": 14
+                         *         },
+                         *         "items": [
+                         *           {
+                         *             "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *             "amount": "150.00",
+                         *             "bank_name": null,
+                         *             "created_at": "2026-03-01T10:00:00+00:00",
+                         *             "credit_card_id": null,
+                         *             "currency": "BRL",
+                         *             "description": "Fatura mensal de energia",
+                         *             "due_date": "2026-03-10",
+                         *             "end_date": null,
+                         *             "external_id": null,
+                         *             "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *             "installment_count": null,
+                         *             "installment_group_id": null,
+                         *             "is_installment": false,
+                         *             "is_recurring": false,
+                         *             "observation": "Pagar antes do dia 10",
+                         *             "paid_at": null,
+                         *             "source": "manual",
+                         *             "start_date": null,
+                         *             "status": "pending",
+                         *             "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *             "title": "Conta de luz",
+                         *             "type": "expense",
+                         *             "updated_at": "2026-03-01T10:00:00+00:00"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Lista de vencimentos retornada com sucesso",
+                         *       "meta": {
+                         *         "pagination": {
+                         *           "page": 1,
+                         *           "pages": 2,
+                         *           "per_page": 10,
+                         *           "total": 14
+                         *         }
+                         *       }
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Parâmetros inválidos */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetros de período inválidos.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao listar vencimentos",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -562,29 +3489,195 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Listar despesas por período (compatibilidade)
+         * @description Compatibilidade transitória para despesas por período. Prefira `GET /transactions?type=expense&start_date=...&end_date=...`.
+         */
         get: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Lista de despesas */
+                200: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /transactions
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example GET
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "counts": {
+                         *           "expense_transactions": 10,
+                         *           "income_transactions": 4,
+                         *           "total_transactions": 14
+                         *         },
+                         *         "expenses": [
+                         *           {
+                         *             "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *             "amount": "150.00",
+                         *             "bank_name": null,
+                         *             "created_at": "2026-03-01T10:00:00+00:00",
+                         *             "credit_card_id": null,
+                         *             "currency": "BRL",
+                         *             "description": "Fatura mensal de energia",
+                         *             "due_date": "2026-03-10",
+                         *             "end_date": null,
+                         *             "external_id": null,
+                         *             "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *             "installment_count": null,
+                         *             "installment_group_id": null,
+                         *             "is_installment": false,
+                         *             "is_recurring": false,
+                         *             "observation": "Pagar antes do dia 10",
+                         *             "paid_at": null,
+                         *             "source": "manual",
+                         *             "start_date": null,
+                         *             "status": "pending",
+                         *             "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *             "title": "Conta de luz",
+                         *             "type": "expense",
+                         *             "updated_at": "2026-03-01T10:00:00+00:00"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Lista de despesas por período",
+                         *       "meta": {
+                         *         "pagination": {
+                         *           "page": 1,
+                         *           "pages": 2,
+                         *           "per_page": 10,
+                         *           "total": 14
+                         *         }
+                         *       }
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Parâmetros inválidos */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetros de período inválidos.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao listar despesas por período",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -596,29 +3689,164 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Listar transações (compatibilidade /transactions/list)
+         * @description Compatibilidade transitória para listagem de transações ativas. Prefira `GET /transactions`.
+         */
         get: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Lista de transações (compatibilidade transitória) */
+                200: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /transactions
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example GET
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "items": [
+                         *           {
+                         *             "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *             "amount": "150.00",
+                         *             "bank_name": null,
+                         *             "created_at": "2026-03-01T10:00:00+00:00",
+                         *             "credit_card_id": null,
+                         *             "currency": "BRL",
+                         *             "description": "Fatura mensal de energia",
+                         *             "due_date": "2026-03-10",
+                         *             "end_date": null,
+                         *             "external_id": null,
+                         *             "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *             "installment_count": null,
+                         *             "installment_group_id": null,
+                         *             "is_installment": false,
+                         *             "is_recurring": false,
+                         *             "observation": "Pagar antes do dia 10",
+                         *             "paid_at": null,
+                         *             "source": "manual",
+                         *             "start_date": null,
+                         *             "status": "pending",
+                         *             "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *             "title": "Conta de luz",
+                         *             "type": "expense",
+                         *             "updated_at": "2026-03-01T10:00:00+00:00"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Lista de transações retornada com sucesso",
+                         *       "meta": {
+                         *         "pagination": {
+                         *           "page": 1,
+                         *           "pages": 2,
+                         *           "per_page": 10,
+                         *           "total": 14
+                         *         }
+                         *       }
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao listar transações",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -634,30 +3862,163 @@ export interface paths {
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path: {
-                    transaction_id: string;
-                };
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
+        /**
+         * Restaurar transação deletada
+         * @description Restaura uma transação deletada logicamente.
+         */
         patch: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path: {
+                    /**
+                     * @description ID da transação
+                     * @example cfef66a6-a148-49db-a72f-cc63b6080cf8
+                     */
                     transaction_id: string;
                 };
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Transação restaurada */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction": {
+                         *           "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *           "amount": "150.00",
+                         *           "bank_name": null,
+                         *           "created_at": "2026-03-01T10:00:00+00:00",
+                         *           "credit_card_id": null,
+                         *           "currency": "BRL",
+                         *           "description": "Fatura mensal de energia",
+                         *           "due_date": "2026-03-10",
+                         *           "end_date": null,
+                         *           "external_id": null,
+                         *           "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *           "installment_count": null,
+                         *           "installment_group_id": null,
+                         *           "is_installment": false,
+                         *           "is_recurring": false,
+                         *           "observation": "Pagar antes do dia 10",
+                         *           "paid_at": null,
+                         *           "source": "manual",
+                         *           "start_date": null,
+                         *           "status": "pending",
+                         *           "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *           "title": "Conta de luz",
+                         *           "type": "expense",
+                         *           "updated_at": "2026-03-01T10:00:00+00:00"
+                         *         }
+                         *       },
+                         *       "message": "Transação restaurada com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Transação não encontrada */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Transação não encontrada",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao restaurar transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         trace?: never;
     };
@@ -668,29 +4029,178 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Obter resumo mensal de transações
+         * @description Resumo mensal de receitas, despesas e itens paginados por mês.
+         */
         get: {
             parameters: {
-                query?: never;
-                header?: never;
+                query?: {
+                    /**
+                     * @description Mês de referência no formato YYYY-MM
+                     * @example 2026-03
+                     */
+                    month?: string;
+                };
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Resumo mensal */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "expense_total": 3200,
+                         *         "income_total": 5000,
+                         *         "month": "2026-03",
+                         *         "transactions": [
+                         *           {
+                         *             "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *             "amount": "150.00",
+                         *             "bank_name": null,
+                         *             "created_at": "2026-03-01T10:00:00+00:00",
+                         *             "credit_card_id": null,
+                         *             "currency": "BRL",
+                         *             "description": "Fatura mensal de energia",
+                         *             "due_date": "2026-03-10",
+                         *             "end_date": null,
+                         *             "external_id": null,
+                         *             "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *             "installment_count": null,
+                         *             "installment_group_id": null,
+                         *             "is_installment": false,
+                         *             "is_recurring": false,
+                         *             "observation": "Pagar antes do dia 10",
+                         *             "paid_at": null,
+                         *             "source": "manual",
+                         *             "start_date": null,
+                         *             "status": "pending",
+                         *             "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *             "title": "Conta de luz",
+                         *             "type": "expense",
+                         *             "updated_at": "2026-03-01T10:00:00+00:00"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Resumo mensal retornado com sucesso",
+                         *       "meta": {
+                         *         "pagination": {
+                         *           "page": 1,
+                         *           "per_page": 10,
+                         *           "total": 14
+                         *         }
+                         *       }
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Parâmetro inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetro 'month' inválido. Use o formato YYYY-MM.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao calcular resumo mensal",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
         delete?: never;
-        options: {
-            parameters: {
-                query?: never;
-                header?: never;
-                path?: never;
-                cookie?: never;
-            };
-            requestBody?: never;
-            responses: never;
-        };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -702,46 +4212,806 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
+        /**
+         * Obter detalhe de transação
+         * @description Retorna o detalhe canônico de uma transação do usuário.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path: {
+                    /**
+                     * @description ID da transação
+                     * @example cfef66a6-a148-49db-a72f-cc63b6080cf8
+                     */
+                    transaction_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Detalhe da transação */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction": {
+                         *           "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *           "amount": "150.00",
+                         *           "bank_name": null,
+                         *           "created_at": "2026-03-01T10:00:00+00:00",
+                         *           "credit_card_id": null,
+                         *           "currency": "BRL",
+                         *           "description": "Fatura mensal de energia",
+                         *           "due_date": "2026-03-10",
+                         *           "end_date": null,
+                         *           "external_id": null,
+                         *           "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *           "installment_count": null,
+                         *           "installment_group_id": null,
+                         *           "is_installment": false,
+                         *           "is_recurring": false,
+                         *           "observation": "Pagar antes do dia 10",
+                         *           "paid_at": null,
+                         *           "source": "manual",
+                         *           "start_date": null,
+                         *           "status": "pending",
+                         *           "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *           "title": "Conta de luz",
+                         *           "type": "expense",
+                         *           "updated_at": "2026-03-01T10:00:00+00:00"
+                         *         }
+                         *       },
+                         *       "message": "Detalhe da transação retornado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "FORBIDDEN",
+                         *       "message": "Sem permissão",
+                         *       "status_code": 403
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Transação não encontrada */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Transação não encontrada",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao carregar transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        /**
+         * Atualizar transação (compatibilidade PUT)
+         * @description Compatibilidade transitória para update parcial. Prefira `PATCH /transactions/{transaction_id}`.
+         */
         put: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path: {
+                    /**
+                     * @description ID da transação
+                     * @example cfef66a6-a148-49db-a72f-cc63b6080cf8
+                     */
                     transaction_id: string;
                 };
                 cookie?: never;
             };
-            requestBody?: never;
-            responses: never;
+            requestBody: {
+                content: {
+                    /**
+                     * @description Campos parciais a serem atualizados.
+                     * @example {
+                     *       "paid_at": "2026-03-10T12:00:00+00:00",
+                     *       "status": "paid"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["TransactionCreate_7d3b606eab"];
+                };
+            };
+            responses: {
+                /** @description Transação atualizada (compatibilidade transitória) */
+                200: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /transactions/{transaction_id}
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example PATCH
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction": {
+                         *           "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *           "amount": "150.00",
+                         *           "bank_name": null,
+                         *           "created_at": "2026-03-01T10:00:00+00:00",
+                         *           "credit_card_id": null,
+                         *           "currency": "BRL",
+                         *           "description": "Fatura mensal de energia",
+                         *           "due_date": "2026-03-10",
+                         *           "end_date": null,
+                         *           "external_id": null,
+                         *           "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *           "installment_count": null,
+                         *           "installment_group_id": null,
+                         *           "is_installment": false,
+                         *           "is_recurring": false,
+                         *           "observation": "Pagar antes do dia 10",
+                         *           "paid_at": null,
+                         *           "source": "manual",
+                         *           "start_date": null,
+                         *           "status": "paid",
+                         *           "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *           "title": "Conta de luz",
+                         *           "type": "expense",
+                         *           "updated_at": "2026-03-01T10:00:00+00:00"
+                         *         }
+                         *       },
+                         *       "message": "Transação atualizada com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Erro de validação",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "FORBIDDEN",
+                         *       "message": "Sem permissão",
+                         *       "status_code": 403
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Transação não encontrada */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Transação não encontrada",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao atualizar transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         post?: never;
+        /**
+         * Remover transação logicamente
+         * @description Realiza soft delete de uma transação do usuário autenticado.
+         */
         delete: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path: {
+                    /**
+                     * @description ID da transação
+                     * @example cfef66a6-a148-49db-a72f-cc63b6080cf8
+                     */
                     transaction_id: string;
                 };
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Transação deletada */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction_id": "cfef66a6-a148-49db-a72f-cc63b6080cf8"
+                         *       },
+                         *       "message": "Transação deletada com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "FORBIDDEN",
+                         *       "message": "Sem permissão",
+                         *       "status_code": 403
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Transação não encontrada */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Transação não encontrada",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao deletar transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
-        options: {
+        options?: never;
+        head?: never;
+        /**
+         * Atualizar transação parcialmente
+         * @description Atualiza parcialmente uma transação existente. Este é o contrato canônico de update do MVP1.
+         */
+        patch: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path: {
+                    /**
+                     * @description ID da transação
+                     * @example cfef66a6-a148-49db-a72f-cc63b6080cf8
+                     */
                     transaction_id: string;
                 };
                 cookie?: never;
             };
-            requestBody?: never;
-            responses: never;
+            requestBody: {
+                content: {
+                    /**
+                     * @description Campos parciais a serem atualizados.
+                     * @example {
+                     *       "paid_at": "2026-03-10T12:00:00+00:00",
+                     *       "status": "paid"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["TransactionCreate_7d3b606eab"];
+                };
+            };
+            responses: {
+                /** @description Transação atualizada */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction": {
+                         *           "account_id": "2d16ea71-b7ae-4da7-adc4-e93e54cd52cb",
+                         *           "amount": "150.00",
+                         *           "bank_name": null,
+                         *           "created_at": "2026-03-01T10:00:00+00:00",
+                         *           "credit_card_id": null,
+                         *           "currency": "BRL",
+                         *           "description": "Fatura mensal de energia",
+                         *           "due_date": "2026-03-10",
+                         *           "end_date": null,
+                         *           "external_id": null,
+                         *           "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *           "installment_count": null,
+                         *           "installment_group_id": null,
+                         *           "is_installment": false,
+                         *           "is_recurring": false,
+                         *           "observation": "Pagar antes do dia 10",
+                         *           "paid_at": null,
+                         *           "source": "manual",
+                         *           "start_date": null,
+                         *           "status": "paid",
+                         *           "tag_id": "73c3b094-60bf-45d5-8e32-0f673b2ab4a2",
+                         *           "title": "Conta de luz",
+                         *           "type": "expense",
+                         *           "updated_at": "2026-03-01T10:00:00+00:00"
+                         *         }
+                         *       },
+                         *       "message": "Transação atualizada com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Erro de validação",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "FORBIDDEN",
+                         *       "message": "Sem permissão",
+                         *       "status_code": 403
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Transação não encontrada */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Transação não encontrada",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao atualizar transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/transactions/{transaction_id}/force": {
@@ -754,30 +5024,319 @@ export interface paths {
         get?: never;
         put?: never;
         post?: never;
+        /**
+         * Remover transação permanentemente
+         * @description Remove permanentemente uma transação já deletada logicamente.
+         */
         delete: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path: {
+                    /**
+                     * @description ID da transação
+                     * @example cfef66a6-a148-49db-a72f-cc63b6080cf8
+                     */
                     transaction_id: string;
                 };
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Transação removida permanentemente */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transaction_id": "cfef66a6-a148-49db-a72f-cc63b6080cf8"
+                         *       },
+                         *       "message": "Transação removida permanentemente"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Transação não encontrada */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Transação não encontrada",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao remover transação",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
-        options: {
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/user/bootstrap": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Obter bootstrap da home do usuário
+         * @description Retorna o bootstrap explícito da home do usuário autenticado.
+         *
+         *     Ownership:
+         *     - `/user/me` (`v3`) = contexto autenticado canônico
+         *     - `/transactions` = coleção e filtros completos
+         *     - `/wallet` = coleção canônica de carteira
+         *     - `/user/bootstrap` = agregado leve para reduzir round-trips na home
+         *
+         *     O bootstrap não substitui endpoints canônicos de coleção e expõe apenas previews recentes de transações e carteira.
+         */
+        get: {
             parameters: {
                 query?: never;
-                header?: never;
-                path: {
-                    transaction_id: string;
+                header?: {
+                    /**
+                     * @description Opcional. Recomendado enviar `v2` ou `v3` para o envelope padronizado.
+                     * @example v3
+                     */
+                    "X-API-Contract"?: string;
                 };
+                path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Bootstrap retornado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "transactions_preview": {
+                         *           "has_more": false,
+                         *           "items": [
+                         *             {
+                         *               "amount": "150.00",
+                         *               "id": "cfef66a6-a148-49db-a72f-cc63b6080cf8",
+                         *               "status": "pending",
+                         *               "title": "Conta de luz",
+                         *               "type": "expense"
+                         *             }
+                         *           ],
+                         *           "limit": 5,
+                         *           "returned_items": 1
+                         *         },
+                         *         "user": {
+                         *           "financial_profile": {
+                         *             "initial_investment": 200,
+                         *             "investment_goal_date": "2026-12-31",
+                         *             "monthly_expenses": 500,
+                         *             "monthly_income_net": 1000,
+                         *             "monthly_investment": 100,
+                         *             "net_worth": 2000
+                         *           },
+                         *           "identity": {
+                         *             "email": "italo@email.com",
+                         *             "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                         *             "name": "Italo"
+                         *           },
+                         *           "investor_profile": {
+                         *             "declared": "conservador",
+                         *             "financial_objectives": "crescer",
+                         *             "quiz_score": 8,
+                         *             "suggested": "moderado",
+                         *             "taxonomy_version": "2026.1"
+                         *           },
+                         *           "product_context": {
+                         *             "entitlements_version": 3
+                         *           },
+                         *           "profile": {
+                         *             "birth_date": "1990-01-01",
+                         *             "gender": "outro",
+                         *             "occupation": "Founder",
+                         *             "state_uf": "SP"
+                         *           }
+                         *         },
+                         *         "wallet": {
+                         *           "has_more": true,
+                         *           "items": [
+                         *             {
+                         *               "asset_class": "cash",
+                         *               "id": "wallet-1",
+                         *               "name": "Caixa",
+                         *               "quantity": 1,
+                         *               "value": 100
+                         *             }
+                         *           ],
+                         *           "limit": 5,
+                         *           "returned_items": 1,
+                         *           "total": 8
+                         *         }
+                         *       },
+                         *       "message": "Bootstrap do usuário retornado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetros do bootstrap inválidos.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token inválido ou expirado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -789,29 +5348,255 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Obter contexto do usuário autenticado
+         * @description Retorna o contexto do usuário autenticado.
+         *
+         *     Uso recomendado:
+         *     - `X-API-Contract: v3` para o contrato canônico e leve
+         *     - `/user/bootstrap` para agregado da home
+         *     - `/transactions` para coleção paginada e filtros
+         *
+         *     Legado:
+         *     - `v1`/`v2` ainda aceitam paginação e filtros de coleção
+         *     - respostas legadas enviam headers de deprecação e sunset
+         */
         get: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. `v2` mantém o shape legado padronizado; `v3` publica o contrato canônico sem coleções.
+                     * @example v3
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Contexto autenticado retornado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "user": {
+                         *           "financial_profile": {
+                         *             "initial_investment": 200,
+                         *             "investment_goal_date": "2026-12-31",
+                         *             "monthly_expenses": 500,
+                         *             "monthly_income_net": 1000,
+                         *             "monthly_investment": 100,
+                         *             "net_worth": 2000
+                         *           },
+                         *           "identity": {
+                         *             "email": "italo@auraxis.com.br",
+                         *             "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                         *             "name": "Italo Chagas"
+                         *           },
+                         *           "investor_profile": {
+                         *             "declared": "conservador",
+                         *             "financial_objectives": "crescer",
+                         *             "quiz_score": 8,
+                         *             "suggested": "moderado",
+                         *             "taxonomy_version": "2026.1"
+                         *           },
+                         *           "product_context": {
+                         *             "entitlements_version": 3
+                         *           },
+                         *           "profile": {
+                         *             "birth_date": "1990-01-01",
+                         *             "gender": "outro",
+                         *             "occupation": "Founder",
+                         *             "state_uf": "SP"
+                         *           }
+                         *         }
+                         *       },
+                         *       "message": "Contexto autenticado retornado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido, expirado ou revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
         put?: never;
         post?: never;
-        delete?: never;
-        options: {
+        /**
+         * Excluir conta do usuário (LGPD)
+         * @description Anonimiza permanentemente todos os dados pessoais do usuário autenticado (soft-delete LGPD). Requer confirmação de senha.
+         *
+         *     Após a exclusão:
+         *     - Todos os campos de PII são anonimizados
+         *     - O JWT é revogado (sessão encerrada)
+         *     - O usuário não consegue mais fazer login
+         *
+         *     Esta ação é irreversível.
+         */
+        delete: {
             parameters: {
                 query?: never;
                 header?: never;
                 path?: never;
                 cookie?: never;
             };
-            requestBody?: never;
-            responses: never;
+            requestBody: {
+                content: {
+                    /**
+                     * @description Senha atual do usuário para confirmar a exclusão.
+                     * @example {
+                     *       "password": "MinhaSenha@123"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_user_schemas_DeleteAccountSchema"];
+                };
+            };
+            responses: {
+                /** @description Conta excluída com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {},
+                         *       "message": "Account deleted."
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido ou expirado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Senha incorreta */
+                403: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INVALID_CREDENTIALS",
+                         *       "message": "Invalid credentials.",
+                         *       "status_code": 403
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Campo 'password' ausente ou inválido */
+                422: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Validation error",
+                         *       "status_code": 422
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -823,29 +5608,590 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
+        /**
+         * Obter perfil reduzido do usuário
+         * @description Retorna o perfil reduzido do usuário autenticado (sem transações e sem carteira).
+         */
         get: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Perfil retornado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "user": {
+                         *           "email": "italo@auraxis.com.br",
+                         *           "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                         *           "investor_profile": "conservador",
+                         *           "monthly_income_net": "5000.00",
+                         *           "name": "Italo Chagas"
+                         *         }
+                         *       },
+                         *       "message": "Perfil retornado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Usuário não encontrado */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Usuário não encontrado",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
+        /**
+         * Atualizar perfil do usuário
+         * @description Atualiza o perfil do usuário autenticado.
+         *
+         *     Campos aceitos:
+         *     - gender: 'masculino', 'feminino', 'outro'
+         *     - birth_date: 'YYYY-MM-DD'
+         *     - monthly_income, net_worth, monthly_expenses, initial_investment,
+         *       monthly_investment: decimal
+         *     - investment_goal_date: 'YYYY-MM-DD'
+         *     - investor_profile: 'conservador', 'explorador', 'entusiasta'
+         *
+         *     Exemplo de request:
+         *     {
+         *       'gender': 'masculino',
+         *       'birth_date': '1990-05-15',
+         *       'monthly_income': '5000.00',
+         *       'net_worth': '100000.00',
+         *       'monthly_expenses': '2000.00',
+         *       'initial_investment': '10000.00',
+         *       'monthly_investment': '500.00',
+         *       'investment_goal_date': '2025-12-31',
+         *       'investor_profile': 'conservador'
+         *     }
+         *
+         *     Exemplo de resposta:
+         *     { 'message': 'Perfil atualizado com sucesso', 'data': { ...dados do usuário... } }
+         */
         put: {
             parameters: {
                 query?: never;
-                header?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    /**
+                     * @description Campos parciais do perfil financeiro e investidor.
+                     * @example {
+                     *       "birth_date": "1990-05-15",
+                     *       "gender": "masculino",
+                     *       "investor_profile": "conservador",
+                     *       "monthly_expenses": "2000.00",
+                     *       "monthly_income_net": "5000.00",
+                     *       "net_worth": "100000.00",
+                     *       "occupation": "Founder",
+                     *       "state_uf": "SP"
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_user_schemas_UserProfileSchema"];
+                };
+            };
+            responses: {
+                /** @description Perfil atualizado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "user": {
+                         *           "id": "4b2ef64b-b35d-4ea2-a6f2-4ef3cfb295f1",
+                         *           "investor_profile": "conservador",
+                         *           "monthly_expenses": "2000.00",
+                         *           "monthly_income_net": "5000.00"
+                         *         }
+                         *       },
+                         *       "message": "Perfil atualizado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Erro de validação",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Usuário não encontrado */
+                404: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "NOT_FOUND",
+                         *       "message": "Usuário não encontrado",
+                         *       "status_code": 404
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro ao atualizar perfil */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao atualizar perfil",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/user/profile/questionnaire": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Listar questionário de perfil de investidor
+         * @description Retorna as 5 perguntas do questionário de perfil de investidor.
+         *
+         *     Cada pergunta contém 3 opções com pontuações de 1 a 3.
+         *     Envie os pontos via POST para receber o perfil sugerido.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
                 path?: never;
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Lista de perguntas retornada com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "questions": [
+                         *           {
+                         *             "options": [
+                         *               {
+                         *                 "points": 1,
+                         *                 "text": "Preservar capital"
+                         *               },
+                         *               {
+                         *                 "points": 2,
+                         *                 "text": "Crescer com equilíbrio"
+                         *               },
+                         *               {
+                         *                 "points": 3,
+                         *                 "text": "Maximizar retorno"
+                         *               }
+                         *             ],
+                         *             "question": "Qual é o seu principal objetivo ao investir?"
+                         *           }
+                         *         ]
+                         *       },
+                         *       "message": "Questionário retornado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido, expirado ou revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
         };
-        post?: never;
+        put?: never;
+        /**
+         * Responder questionário de perfil de investidor
+         * @description Submete as respostas do questionário e classifica o perfil de investidor.
+         *
+         *     Envie exatamente 5 respostas, cada uma com os pontos da opção escolhida (1–3).
+         *
+         *     Perfis possíveis:
+         *     - **conservador** — score ≤ 7
+         *     - **explorador**  — score de 8 a 11
+         *     - **entusiasta**  — score ≥ 12
+         *
+         *     O resultado é persistido no perfil do usuário autenticado.
+         */
+        post: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody: {
+                content: {
+                    /**
+                     * @description Lista de 5 respostas, cada uma entre 1 e 3 pontos.
+                     * @example {
+                     *       "answers": [
+                     *         1,
+                     *         2,
+                     *         2,
+                     *         3,
+                     *         1
+                     *       ]
+                     *     }
+                     */
+                    "application/json": components["schemas"]["app_schemas_user_schemas_QuestionnaireAnswerSchema"];
+                };
+            };
+            responses: {
+                /** @description Perfil sugerido calculado e persistido */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "score": 9,
+                         *         "suggested_profile": "explorador"
+                         *       },
+                         *       "message": "Perfil sugerido calculado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Número de respostas inválido */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INVALID_ANSWER_COUNT",
+                         *       "message": "O questionário exige exatamente 5 respostas.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token inválido, expirado ou revogado */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Payload inválido */
+                422: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "details": {
+                         *         "answers": [
+                         *           "Missing data for required field."
+                         *         ]
+                         *       },
+                         *       "message": "Dados inválidos",
+                         *       "status_code": 422
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
         delete?: never;
-        options: {
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/user/simulate-salary-increase": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** @description Simula o aumento salarial e recomposição da inflação. */
+        post: {
             parameters: {
                 query?: never;
                 header?: never;
@@ -853,8 +6199,32 @@ export interface paths {
                 cookie?: never;
             };
             requestBody?: never;
-            responses: never;
+            responses: {
+                /** @description Simulação realizada com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Erro de validação */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido ou expirado */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
         };
+        delete?: never;
+        options?: never;
         head?: never;
         patch?: never;
         trace?: never;
@@ -1077,9 +6447,19 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Data final (YYYY-MM-DD). Opcional. */
+                    /**
+                     * @deprecated
+                     * @description Alias legado de `end_date`.
+                     */
                     finalDate?: string;
                     /** @description Data inicial (YYYY-MM-DD). Opcional. */
+                    start_date?: string;
+                    /** @description Data final (YYYY-MM-DD). Opcional. */
+                    end_date?: string;
+                    /**
+                     * @deprecated
+                     * @description Alias legado de `start_date`.
+                     */
                     startDate?: string;
                 };
                 header?: {
@@ -1094,6 +6474,26 @@ export interface paths {
                 /** @description Histórico retornado com sucesso */
                 200: {
                     headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Mensagem adicional de deprecação enviada em runtime.
+                         * @example 299 - "Query params startDate/finalDate are deprecated; use start_date/end_date"
+                         */
+                        Warning?: string;
+                        /**
+                         * @description Campo recomendado para a migração do payload.
+                         * @example start_date,end_date
+                         */
+                        "X-Auraxis-Successor-Field"?: string;
                         [name: string]: unknown;
                     };
                     content?: never;
@@ -1121,9 +6521,19 @@ export interface paths {
         options: {
             parameters: {
                 query?: {
-                    /** @description Data final (YYYY-MM-DD). Opcional. */
+                    /**
+                     * @deprecated
+                     * @description Alias legado de `end_date`.
+                     */
                     finalDate?: string;
                     /** @description Data inicial (YYYY-MM-DD). Opcional. */
+                    start_date?: string;
+                    /** @description Data final (YYYY-MM-DD). Opcional. */
+                    end_date?: string;
+                    /**
+                     * @deprecated
+                     * @description Alias legado de `start_date`.
+                     */
                     startDate?: string;
                 };
                 header?: {
@@ -1138,6 +6548,26 @@ export interface paths {
                 /** @description Histórico retornado com sucesso */
                 200: {
                     headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Mensagem adicional de deprecação enviada em runtime.
+                         * @example 299 - "Query params startDate/finalDate are deprecated; use start_date/end_date"
+                         */
+                        Warning?: string;
+                        /**
+                         * @description Campo recomendado para a migração do payload.
+                         * @example start_date,end_date
+                         */
+                        "X-Auraxis-Successor-Field"?: string;
                         [name: string]: unknown;
                     };
                     content?: never;
@@ -1169,8 +6599,53 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        get?: never;
-        /** @description Atualiza um investimento existente da carteira do usuário. */
+        /** @description Retorna o detalhe canônico de um investimento específico da carteira do usuário autenticado. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description Opcional. Envie 'v2' para o contrato padronizado. */
+                    "X-API-Contract"?: string;
+                };
+                path: {
+                    /** @description ID do investimento */
+                    investment_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Investimento retornado com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Investimento não encontrado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        /** @description Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico. */
         put: {
             parameters: {
                 query?: never;
@@ -1189,6 +6664,26 @@ export interface paths {
                 /** @description Investimento atualizado com sucesso */
                 200: {
                     headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /wallet/{investment_id}
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example PATCH
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
                         [name: string]: unknown;
                     };
                     content?: never;
@@ -1263,8 +6758,75 @@ export interface paths {
                 };
             };
         };
-        /** @description Atualiza um investimento existente da carteira do usuário. */
+        /** @description Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico. */
         options: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /** @description Opcional. Envie 'v2' para o contrato padronizado. */
+                    "X-API-Contract"?: string;
+                };
+                path: {
+                    /** @description ID do investimento */
+                    investment_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Investimento atualizado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Indica que a superfície atual está em deprecação.
+                         * @example true
+                         */
+                        Deprecation?: string;
+                        /**
+                         * @description Data prevista para remoção da superfície legada.
+                         * @example Tue, 30 Jun 2026 23:59:59 GMT
+                         */
+                        Sunset?: string;
+                        /**
+                         * @description Endpoint sucessor recomendado.
+                         * @example /wallet/{investment_id}
+                         */
+                        "X-Auraxis-Successor-Endpoint"?: string;
+                        /**
+                         * @description Método HTTP recomendado para a superfície sucessora.
+                         * @example PATCH
+                         */
+                        "X-Auraxis-Successor-Method"?: string;
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Investimento não encontrado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        head?: never;
+        /** @description Atualiza parcialmente um investimento existente da carteira do usuário. Este é o método canônico para alterações parciais. */
+        patch: {
             parameters: {
                 query?: never;
                 header?: {
@@ -1309,8 +6871,6 @@ export interface paths {
                 };
             };
         };
-        head?: never;
-        patch?: never;
         trace?: never;
     };
     "/wallet/{investment_id}/history": {
@@ -1936,10 +7496,10 @@ export interface paths {
                     "X-API-Contract"?: string;
                 };
                 path: {
-                    /** @description ID da operação */
-                    operation_id: string;
                     /** @description ID do investimento */
                     investment_id: string;
+                    /** @description ID da operação */
+                    operation_id: string;
                 };
                 cookie?: never;
             };
@@ -1992,10 +7552,10 @@ export interface paths {
                     "X-API-Contract"?: string;
                 };
                 path: {
-                    /** @description ID da operação */
-                    operation_id: string;
                     /** @description ID do investimento */
                     investment_id: string;
+                    /** @description ID da operação */
+                    operation_id: string;
                 };
                 cookie?: never;
             };
@@ -2040,10 +7600,10 @@ export interface paths {
                     "X-API-Contract"?: string;
                 };
                 path: {
-                    /** @description ID da operação */
-                    operation_id: string;
                     /** @description ID do investimento */
                     investment_id: string;
+                    /** @description ID da operação */
+                    operation_id: string;
                 };
                 cookie?: never;
             };
@@ -2199,7 +7759,560 @@ export interface paths {
 }
 export type webhooks = Record<string, never>;
 export interface components {
-    schemas: never;
+    schemas: {
+        InstallmentVsCashCalculation: {
+            cash_price: number;
+            /** @default false */
+            fees_enabled: boolean;
+            /** @default 0.00 */
+            fees_upfront: number;
+            /** @default 30 */
+            first_payment_delay_days: number;
+            inflation_rate_annual: number;
+            /** @default null */
+            installment_amount: number | null;
+            installment_count: number;
+            /** @default null */
+            installment_total: number | null;
+            /** @default null */
+            opportunity_rate_annual: number | null;
+            /**
+             * @default manual
+             * @enum {string}
+             */
+            opportunity_rate_type: "manual" | "product_default" | "inflation_only";
+            /** @default null */
+            scenario_label: string | null;
+        };
+        InstallmentVsCashGoalBridge: {
+            /** @default planned_purchase */
+            category: string | null;
+            /** @default 0.00 */
+            current_amount: number;
+            /** @default null */
+            description: string | null;
+            /** @default 3 */
+            priority: number;
+            /** @enum {string} */
+            selected_option: "cash" | "installment";
+            /**
+             * Format: date
+             * @default null
+             */
+            target_date: string | null;
+            title: string;
+        };
+        InstallmentVsCashPlannedExpenseBridge: {
+            /**
+             * Format: uuid
+             * @default null
+             */
+            account_id: string | null;
+            /**
+             * Format: uuid
+             * @default null
+             */
+            credit_card_id: string | null;
+            /** @default BRL */
+            currency: string;
+            /** @default null */
+            description: string | null;
+            /**
+             * Format: date
+             * @default null
+             */
+            due_date: string | null;
+            /**
+             * Format: date
+             * @default null
+             */
+            first_due_date: string | null;
+            /** @default null */
+            observation: string | null;
+            /** @enum {string} */
+            selected_option: "cash" | "installment";
+            /**
+             * @default pending
+             * @enum {string}
+             */
+            status: "pending" | "paid" | "cancelled" | "postponed" | "overdue";
+            /**
+             * Format: uuid
+             * @default null
+             */
+            tag_id: string | null;
+            title: string;
+            /**
+             * Format: date
+             * @default null
+             */
+            upfront_due_date: string | null;
+        };
+        InstallmentVsCashSave: {
+            cash_price: number;
+            /** @default false */
+            fees_enabled: boolean;
+            /** @default 0.00 */
+            fees_upfront: number;
+            /** @default 30 */
+            first_payment_delay_days: number;
+            inflation_rate_annual: number;
+            /** @default null */
+            installment_amount: number | null;
+            installment_count: number;
+            /** @default null */
+            installment_total: number | null;
+            /** @default null */
+            opportunity_rate_annual: number | null;
+            /**
+             * @default manual
+             * @enum {string}
+             */
+            opportunity_rate_type: "manual" | "product_default" | "inflation_only";
+            /** @default null */
+            scenario_label: string | null;
+        };
+        TransactionCreate: {
+            /**
+             * Format: uuid
+             * @description ID da conta bancária associada
+             */
+            account_id?: string | null;
+            /**
+             * @description Valor da transação
+             * @example 150.50
+             */
+            amount: number;
+            /**
+             * Format: date-time
+             * @description Data de criação da transação
+             */
+            readonly created_at?: string;
+            /**
+             * Format: uuid
+             * @description ID do cartão de crédito associado
+             */
+            credit_card_id?: string | null;
+            /**
+             * @description Código da moeda (ISO 4217)
+             * @example BRL
+             */
+            currency?: string;
+            /**
+             * @description Descrição detalhada da transação
+             * @default null
+             * @example Conta de energia elétrica do mês de janeiro
+             */
+            description: string | null;
+            /**
+             * Format: date
+             * @description Data de vencimento da transação
+             * @example 2024-02-15
+             */
+            due_date: string;
+            /**
+             * Format: date
+             * @description Data de fim (para transações recorrentes)
+             * @default null
+             * @example 2024-12-31
+             */
+            end_date: string | null;
+            /**
+             * Format: uuid
+             * @description ID único da transação (gerado automaticamente)
+             */
+            readonly id?: string;
+            /**
+             * @description Número de parcelas (apenas se is_installment=True)
+             * @example 12
+             */
+            installment_count?: number;
+            /**
+             * Format: uuid
+             * @description ID do grupo de parcelas (gerado automaticamente)
+             */
+            readonly installment_group_id?: string;
+            /**
+             * @description Indica se a transação é parcelada
+             * @example false
+             */
+            is_installment?: boolean;
+            /**
+             * @description Indica se a transação é recorrente
+             * @example false
+             */
+            is_recurring?: boolean;
+            /**
+             * @description Observações adicionais sobre a transação
+             * @default null
+             * @example Pagar até o dia 10 para evitar multa
+             */
+            observation: string | null;
+            /**
+             * Format: date-time
+             * @description Data e hora do pagamento
+             * @example 2024-02-10T14:30:00Z
+             */
+            paid_at?: string | null;
+            /**
+             * Format: date
+             * @description Data de início (para transações recorrentes)
+             * @default null
+             * @example 2024-01-01
+             */
+            start_date: string | null;
+            /**
+             * @description Status atual da transação
+             * @example pending
+             * @enum {string}
+             */
+            status?: "paid" | "pending" | "cancelled" | "postponed" | "overdue";
+            /**
+             * Format: uuid
+             * @description ID da tag associada à transação
+             */
+            tag_id?: string | null;
+            /**
+             * @description Título da transação
+             * @example Pagamento da conta de luz
+             */
+            title: string;
+            /**
+             * @description Tipo da transação: receita ou despesa
+             * @example expense
+             * @enum {string}
+             */
+            type: "income" | "expense";
+            /**
+             * Format: date-time
+             * @description Data da última atualização
+             */
+            readonly updated_at?: string;
+            /**
+             * Format: uuid
+             * @description ID do usuário proprietário da transação
+             */
+            readonly user_id?: string;
+        };
+        TransactionCreate_7d3b606eab: {
+            /**
+             * Format: uuid
+             * @description ID da conta bancária associada
+             */
+            account_id?: string | null;
+            /**
+             * @description Valor da transação
+             * @example 150.50
+             */
+            amount?: number;
+            /**
+             * Format: date-time
+             * @description Data de criação da transação
+             */
+            readonly created_at?: string;
+            /**
+             * Format: uuid
+             * @description ID do cartão de crédito associado
+             */
+            credit_card_id?: string | null;
+            /**
+             * @description Código da moeda (ISO 4217)
+             * @example BRL
+             */
+            currency?: string;
+            /**
+             * @description Descrição detalhada da transação
+             * @default null
+             * @example Conta de energia elétrica do mês de janeiro
+             */
+            description: string | null;
+            /**
+             * Format: date
+             * @description Data de vencimento da transação
+             * @example 2024-02-15
+             */
+            due_date?: string;
+            /**
+             * Format: date
+             * @description Data de fim (para transações recorrentes)
+             * @default null
+             * @example 2024-12-31
+             */
+            end_date: string | null;
+            /**
+             * Format: uuid
+             * @description ID único da transação (gerado automaticamente)
+             */
+            readonly id?: string;
+            /**
+             * @description Número de parcelas (apenas se is_installment=True)
+             * @example 12
+             */
+            installment_count?: number;
+            /**
+             * Format: uuid
+             * @description ID do grupo de parcelas (gerado automaticamente)
+             */
+            readonly installment_group_id?: string;
+            /**
+             * @description Indica se a transação é parcelada
+             * @example false
+             */
+            is_installment?: boolean;
+            /**
+             * @description Indica se a transação é recorrente
+             * @example false
+             */
+            is_recurring?: boolean;
+            /**
+             * @description Observações adicionais sobre a transação
+             * @default null
+             * @example Pagar até o dia 10 para evitar multa
+             */
+            observation: string | null;
+            /**
+             * Format: date-time
+             * @description Data e hora do pagamento
+             * @example 2024-02-10T14:30:00Z
+             */
+            paid_at?: string | null;
+            /**
+             * Format: date
+             * @description Data de início (para transações recorrentes)
+             * @default null
+             * @example 2024-01-01
+             */
+            start_date: string | null;
+            /**
+             * @description Status atual da transação
+             * @example pending
+             * @enum {string}
+             */
+            status?: "paid" | "pending" | "cancelled" | "postponed" | "overdue";
+            /**
+             * Format: uuid
+             * @description ID da tag associada à transação
+             */
+            tag_id?: string | null;
+            /**
+             * @description Título da transação
+             * @example Pagamento da conta de luz
+             */
+            title?: string;
+            /**
+             * @description Tipo da transação: receita ou despesa
+             * @example expense
+             * @enum {string}
+             */
+            type?: "income" | "expense";
+            /**
+             * Format: date-time
+             * @description Data da última atualização
+             */
+            readonly updated_at?: string;
+            /**
+             * Format: uuid
+             * @description ID do usuário proprietário da transação
+             */
+            readonly user_id?: string;
+        };
+        app_schemas_auth_schema_AuthSchema: {
+            /**
+             * @description Token Cloudflare Turnstile obtido pelo cliente. Obrigatório quando CAPTCHA está habilitado no servidor.
+             * @default null
+             * @example captcha-token-example
+             */
+            captcha_token: string | null;
+            /**
+             * Format: email
+             * @description Endereço de email do usuário (identificador canônico)
+             * @example joao.silva@email.com
+             */
+            email: string;
+            /**
+             * @description Senha do usuário
+             * @example minhasenha123
+             */
+            password: string;
+        };
+        app_schemas_auth_schema_ConfirmEmailSchema: {
+            /**
+             * @description Token de confirmacao recebido por email
+             * @example example-token
+             */
+            token: string;
+        };
+        app_schemas_auth_schema_ForgotPasswordSchema: {
+            /**
+             * Format: email
+             * @description Email da conta que deseja recuperar acesso
+             * @example joao.silva@email.com
+             */
+            email: string;
+        };
+        app_schemas_auth_schema_ResetPasswordSchema: {
+            /**
+             * @description Nova senha (mínimo 10 caracteres, com maiúscula, número e símbolo)
+             * @example NovaSenha@123
+             */
+            new_password: string;
+            /**
+             * @description Token de recuperação recebido por email
+             * @example example-token
+             */
+            token: string;
+        };
+        app_schemas_user_schemas_DeleteAccountSchema: {
+            /**
+             * @description Senha atual do usuário para confirmar a exclusão da conta
+             * @example MinhaSenha@123
+             */
+            password: string;
+        };
+        app_schemas_user_schemas_QuestionnaireAnswerSchema: {
+            /** @description Lista de 5 respostas — pontos da opção escolhida em cada pergunta (1–3). */
+            answers: number[];
+        };
+        app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema: {
+            /**
+             * Format: date
+             * @description Data base do salário atual
+             * @example 2022-01-01
+             */
+            base_date: string;
+            /**
+             * @description Salário base atual
+             * @example 5000.00
+             */
+            base_salary: number;
+            /**
+             * @description Descontos aplicáveis
+             * @example 500.00
+             */
+            discounts: number;
+            /**
+             * @description Aumento real desejado (%)
+             * @example 5.00
+             */
+            target_real_increase: number;
+        };
+        app_schemas_user_schemas_UserProfileSchema: {
+            /**
+             * Format: date
+             * @description Data de nascimento
+             * @example 1990-05-15
+             */
+            birth_date?: string;
+            /**
+             * @description Objetivos financeiros do usuário
+             * @example Aposentar cedo
+             */
+            financial_objectives?: string;
+            /**
+             * @description Gênero do usuário
+             * @example masculino
+             * @enum {string}
+             */
+            gender?: "masculino" | "feminino" | "outro";
+            /**
+             * @description Investimento inicial disponível
+             * @example 10000.00
+             */
+            initial_investment?: number;
+            /**
+             * Format: date
+             * @description Data meta para atingir objetivo de investimento
+             * @example 2030-12-31
+             */
+            investment_goal_date?: string;
+            /**
+             * @description Perfil do investidor
+             * @example conservador
+             * @enum {string}
+             */
+            investor_profile?: "conservador" | "explorador" | "entusiasta";
+            /**
+             * @description Perfil de investidor sugerido
+             * @example explorador
+             */
+            investor_profile_suggested?: string | null;
+            /**
+             * @description Gastos mensais totais
+             * @example 3000.00
+             */
+            monthly_expenses?: number;
+            /**
+             * @description Renda mensal em reais
+             * @example 5000.00
+             */
+            monthly_income?: number;
+            /**
+             * @description Renda líquida mensal em reais
+             * @example 5000.00
+             */
+            monthly_income_net?: number;
+            /**
+             * @description Valor mensal para investimentos
+             * @example 1000.00
+             */
+            monthly_investment?: number;
+            /**
+             * @description Patrimônio líquido atual
+             * @example 50000.00
+             */
+            net_worth?: number;
+            /**
+             * @description Profissão do usuário
+             * @example Engenheiro de Software
+             */
+            occupation?: string;
+            /**
+             * @description Pontuação do quiz de perfil
+             * @example 85
+             */
+            profile_quiz_score?: number | null;
+            /**
+             * @description Estado (UF) do usuário
+             * @example SP
+             */
+            state_uf?: string;
+            /**
+             * @description Versão da taxonomia
+             * @example v1.0
+             */
+            taxonomy_version?: string | null;
+        };
+        app_schemas_user_schemas_UserRegistrationSchema: {
+            /**
+             * @description Token Cloudflare Turnstile obtido pelo cliente. Obrigatório quando CAPTCHA está habilitado no servidor.
+             * @default null
+             * @example captcha-token-example
+             */
+            captcha_token: string | null;
+            /**
+             * Format: email
+             * @description Endereço de email único do usuário
+             * @example joao.silva@email.com
+             */
+            email: string;
+            /**
+             * @description Perfil do investidor auto declarado
+             * @example conservador
+             * @enum {string|null}
+             */
+            investor_profile?: "conservador" | "explorador" | "entusiasta" | null;
+            /**
+             * @description Nome completo do usuário
+             * @example João Silva
+             */
+            name: string;
+            /**
+             * @description Senha do usuário (mínimo 10 caracteres, contendo ao menos uma letra maiúscula, um número e um símbolo)
+             * @example MinhaSenha@123
+             */
+            password: string;
+        };
+    };
     responses: never;
     parameters: never;
     requestBodies: never;

--- a/types/contracts/entitlement.ts
+++ b/types/contracts/entitlement.ts
@@ -1,16 +1,15 @@
-export type FeatureKey =
-  | "basic_simulations"
-  | "advanced_simulations"
-  | "export_pdf"
-  | "shared_entries"
-  | "wallet_read";
+import type {
+  EntitlementCheckQuery,
+  EntitlementCheckResult,
+  FeatureKey,
+} from "@/features/entitlements/contracts";
+
+export type { EntitlementCheckQuery, FeatureKey };
 
 export interface EntitlementCheck {
   readonly has_access: boolean;
 }
 
-export interface EntitlementCheckResponse {
-  readonly active?: boolean;
-  readonly has_access?: boolean;
-  readonly feature_key?: string;
-}
+export type EntitlementCheckResponse =
+  | EntitlementCheckResult
+  | EntitlementCheck;


### PR DESCRIPTION
## Summary
- sync the app OpenAPI snapshot against the local `auraxis-api` runtime and regenerate generated types
- expand the canonical API contract map/catalog and migrate active consumers away from raw endpoint strings / legacy `@/lib/*-api`
- add local guardrails so contract drift fails in `policy:check` before it reaches CI

## Validation
- `npm run contracts:sync:api-local`
- `npm run policy:check`
- `npm run contracts:check`
- `npm run typecheck`
- `npm run quality-check`
- `git diff --check`