### PR TITLE
feat(app): audit client security and config surface

### DIFF
--- a/.context/architecture.md
+++ b/.context/architecture.md
@@ -88,6 +88,26 @@ Telas (app/)
 - Versionar chamadas de API — não assumir contrato estável sem versão.
 - Toda integração nova deve preferir `apiContractMap` + services de feature antes de criar string solta de endpoint.
 
+## Matriz de segurança do cliente
+
+| Superfície | Classificação | Regra canônica |
+|:-----------|:--------------|:---------------|
+| `EXPO_PUBLIC_API_*`, `EXPO_PUBLIC_FLAG_*`, `EXPO_PUBLIC_UNLEASH_*`, `EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY` | Pública | Pode estar no bundle; nunca pode representar segredo de servidor ou credencial privilegiada |
+| `expo.extra.sentryDsn`, `expo.extra.appEnv`, `expo.extra.eas.projectId` | Pública | Permitida em `app.json`; serve apenas a bootstrap/observabilidade/release |
+| `accessToken`, `refreshToken`, `user.email` | Sensível | Persistir somente no payload canônico do `SecureStore`; proibido duplicar em storage legado, logs ou telemetria |
+| Chaves legadas `auraxis.access-token` / `auraxis.user-email` | Temporária | Apenas leitura de migração; devem ser limpas após regravação canônica |
+| Deep links, retorno de checkout, breadcrumbs e logs | Temporária sanitizada | Sempre registrar apenas URL/contexto redigido (`token`, `password`, `email`, `auth_code` e similares) |
+| Tokens de servidor, API tokens, secrets e passwords | Proibida no cliente | Não podem aparecer nem em `process.env`, nem em `expo.extra`, nem em fallbacks de runtime do app |
+
+## Guardrails de segurança do cliente
+
+- `scripts/check-client-security-governance.cjs` é o scanner canônico do app para:
+  - bloquear referências a env vars banidas em código cliente;
+  - bloquear `expo.extra` com nomes sensíveis;
+  - bloquear reintrodução de persistência legada de sessão.
+- O guardrail roda dentro de `npm run policy:check` e, por consequência, falha cedo em `npm run quality-check`.
+- `SecureStore` do app escreve somente `auraxis.session`; as chaves legadas existem apenas para migração e limpeza.
+
 ## Plataformas suportadas
 
 - **iOS**: target mínimo a definir (sugestão: iOS 15+)

--- a/.context/handoffs/APP5-mobile-foundation.md
+++ b/.context/handoffs/APP5-mobile-foundation.md
@@ -1,5 +1,39 @@
 # APP5 - Scaffold base do app mobile
 
+## Update - APP FND-08A (security and configuration audit)
+
+### O que foi feito
+- endureci a persistência de sessão em [`core/session/session-storage.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/core/session/session-storage.ts):
+  - o app agora grava apenas `auraxis.session` no `SecureStore`;
+  - as chaves legadas `auraxis.access-token` e `auraxis.user-email` ficaram restritas à leitura de migração e limpeza explícita;
+- atualizei [`core/session/session-store.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/core/session/session-store.ts) para regravar sessão legada no payload canônico e limpar imediatamente os artefatos antigos;
+- removi caminhos indevidos de segredo do cliente:
+  - retirei o fallback `AURAXIS_UNLEASH_API_TOKEN` de [`shared/feature-flags/service.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/shared/feature-flags/service.ts);
+  - removi o alias público `EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN` de [`shared/config/runtime.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/shared/config/runtime.ts);
+- expandi a sanitização de URLs em [`core/navigation/deep-linking.ts`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/core/navigation/deep-linking.ts) para redigir também `email`, `password`, `auth_code`, `secret`, `jwt` e similares;
+- criei o guardrail executável [`scripts/check-client-security-governance.cjs`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/scripts/check-client-security-governance.cjs) e o conectei ao `policy:check`, cobrindo:
+  - referências banidas de env vars no cliente;
+  - chaves sensíveis em `expo.extra`;
+  - regressão de escrita das chaves legadas de sessão;
+- documentei a matriz de segurança do cliente em [`architecture.md`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/.context/architecture.md) e alinhei o runbook de flags em [`docs/runbooks/PLT2-PLT5-foundation.md`](/Users/italochagas/Desktop/projetos/auraxis-platform/repos/auraxis-app/_worktrees/app-fnd-08a-security-audit/docs/runbooks/PLT2-PLT5-foundation.md).
+
+### O que foi validado
+- `npm run test -- core/session/session-storage.test.ts core/session/session-store.test.ts shared/feature-flags/service.test.ts core/navigation/deep-linking.test.ts scripts/check-client-security-governance.test.ts __tests__/services/sentry.test.ts core/telemetry/sanitization.test.ts --runInBand`
+- `npm run policy:check`
+- `node scripts/check-client-security-governance.cjs`
+- `node scripts/ci-audit-gate.js`
+- `npm run quality-check`
+- `git diff --check`
+
+### Riscos pendentes
+- o app ainda depende de `Constants.expoConfig.extra` para `sentryDsn` e `appEnv`; isso está classificado como superfície pública, mas futuras chaves novas nesse namespace precisam continuar passando pelo scanner novo;
+- a migração legada de sessão segue temporariamente suportada; quando não houver mais base instalada dependente dessa leitura, vale remover de vez o fallback e as chaves antigas;
+- o Node 24 LTS continua sendo o runtime canônico do repo, mas esta máquina local ainda precisa de `nvm install 24` para paridade completa de ambiente.
+
+### Proximo passo
+- seguir para `APP FND-08B`, consolidando forced sign-out, reauth e auth-failure flows usando a taxonomia canônica de erro/async state;
+- depois avançar para `APP FND-09A/B`, fechando observabilidade, logging e governança de redaction sobre a base endurecida.
+
 ## Update - APP FND-07B (axios security gate + local parity)
 
 ### O que foi feito

--- a/.context/quality_gates.md
+++ b/.context/quality_gates.md
@@ -19,7 +19,10 @@ npm run lint
 # 2. Type-check
 npm run typecheck
 
-# 3. Testes + coverage
+# 3. Guardrails de governança e segurança do cliente
+npm run policy:check
+
+# 4. Testes + coverage
 npm run test:coverage
 
 # Atalho — tudo de uma vez (obrigatório antes de commitar):
@@ -37,6 +40,7 @@ node scripts/ci-audit-gate.js
 
 - O relatório bruto do audit agora é gravado em arquivo temporário do sistema.
 - Para persistir um arquivo para debug manual, use `AURAXIS_AUDIT_OUTPUT_PATH=/caminho/audit.json`.
+- `npm run policy:check` inclui `check-client-security-governance.cjs`, que bloqueia env vars banidas no cliente, `expo.extra` sensível e regressões na persistência legada de sessão.
 
 > Se qualquer gate falhar: **não commitar**. Corrigir o problema primeiro.
 

--- a/core/navigation/deep-linking.test.ts
+++ b/core/navigation/deep-linking.test.ts
@@ -89,4 +89,14 @@ describe("deep linking", () => {
       "auraxisapp://assinatura?status=paid&token=%3Credacted%3E&checkout_token=%3Credacted%3E",
     );
   });
+
+  it("redige outros parametros sensiveis alem de tokens", () => {
+    expect(
+      sanitizeAppUrl(
+        "auraxisapp://login?email=italo@auraxis.dev&password=12345678&auth_code=abc123",
+      ),
+    ).toBe(
+      "auraxisapp://login?email=%3Credacted%3E&password=%3Credacted%3E&auth_code=%3Credacted%3E",
+    );
+  });
 });

--- a/core/navigation/deep-linking.ts
+++ b/core/navigation/deep-linking.ts
@@ -73,19 +73,19 @@ const readQueryValue = (
   return typeof value === "string" && value.length > 0 ? value : null;
 };
 
-const SENSITIVE_QUERY_KEYS = new Set([
-  "token",
-  "checkout_token",
-  "access_token",
-  "refresh_token",
-]);
+const SENSITIVE_QUERY_KEY_PATTERN =
+  /(^|[_-])(token|secret|password|email|authorization|auth|jwt|api[-_]?key|code)([_-]|$)/iu;
+
+const shouldRedactQueryKey = (key: string): boolean => {
+  return SENSITIVE_QUERY_KEY_PATTERN.test(key);
+};
 
 export const sanitizeAppUrl = (rawUrl: string): string => {
   try {
     const url = new URL(rawUrl);
 
-    for (const key of SENSITIVE_QUERY_KEYS) {
-      if (url.searchParams.has(key)) {
+    for (const key of [...url.searchParams.keys()]) {
+      if (shouldRedactQueryKey(key)) {
         url.searchParams.set(key, "<redacted>");
       }
     }

--- a/core/session/session-storage.test.ts
+++ b/core/session/session-storage.test.ts
@@ -1,6 +1,7 @@
 import * as SecureStore from "expo-secure-store";
 
 import {
+  clearLegacyStoredSession,
   clearStoredSession,
   loadStoredSession,
   persistStoredSession,
@@ -141,7 +142,7 @@ describe("session-storage", () => {
     });
   });
 
-  it("persiste a sessao normalizada no storage canônico e legado", async () => {
+  it("persiste a sessao normalizada apenas no storage canônico", async () => {
     await persistStoredSession(
       createStoredSession({
         authenticatedAt: null,
@@ -149,21 +150,24 @@ describe("session-storage", () => {
       }),
     );
 
-    expect(mockSetItemAsync).toHaveBeenCalledTimes(3);
-    expect(mockSetItemAsync).toHaveBeenNthCalledWith(
-      1,
+    expect(mockSetItemAsync).toHaveBeenCalledTimes(1);
+    expect(mockSetItemAsync).toHaveBeenCalledWith(
       "auraxis.session",
       expect.stringContaining("\"authenticatedAt\""),
     );
-    expect(mockSetItemAsync).toHaveBeenNthCalledWith(
-      2,
+  });
+
+  it("limpa apenas os artefatos legados quando requisitado", async () => {
+    await clearLegacyStoredSession();
+
+    expect(mockDeleteItemAsync).toHaveBeenCalledTimes(2);
+    expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(
+      1,
       "auraxis.access-token",
-      expect.any(String),
     );
-    expect(mockSetItemAsync).toHaveBeenNthCalledWith(
-      3,
+    expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(
+      2,
       "auraxis.user-email",
-      "italo@auraxis.dev",
     );
   });
 
@@ -172,13 +176,7 @@ describe("session-storage", () => {
 
     expect(mockDeleteItemAsync).toHaveBeenCalledTimes(3);
     expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(1, "auraxis.session");
-    expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(
-      2,
-      "auraxis.access-token",
-    );
-    expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(
-      3,
-      "auraxis.user-email",
-    );
+    expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(2, "auraxis.access-token");
+    expect(mockDeleteItemAsync).toHaveBeenNthCalledWith(3, "auraxis.user-email");
   });
 });

--- a/core/session/session-storage.ts
+++ b/core/session/session-storage.ts
@@ -108,17 +108,19 @@ export const persistStoredSession = async (
   session: StoredSession,
 ): Promise<void> => {
   const nextSession = withSessionMetadata(session);
+  await SecureStore.setItemAsync(SESSION_KEY, JSON.stringify(nextSession));
+};
+
+export const clearLegacyStoredSession = async (): Promise<void> => {
   await Promise.all([
-    SecureStore.setItemAsync(SESSION_KEY, JSON.stringify(nextSession)),
-    SecureStore.setItemAsync(LEGACY_ACCESS_TOKEN_KEY, nextSession.accessToken),
-    SecureStore.setItemAsync(LEGACY_USER_EMAIL_KEY, nextSession.user.email),
+    SecureStore.deleteItemAsync(LEGACY_ACCESS_TOKEN_KEY),
+    SecureStore.deleteItemAsync(LEGACY_USER_EMAIL_KEY),
   ]);
 };
 
 export const clearStoredSession = async (): Promise<void> => {
   await Promise.all([
     SecureStore.deleteItemAsync(SESSION_KEY),
-    SecureStore.deleteItemAsync(LEGACY_ACCESS_TOKEN_KEY),
-    SecureStore.deleteItemAsync(LEGACY_USER_EMAIL_KEY),
+    clearLegacyStoredSession(),
   ]);
 };

--- a/core/session/session-store.test.ts
+++ b/core/session/session-store.test.ts
@@ -1,4 +1,5 @@
 import {
+  clearLegacyStoredSession,
   clearStoredSession,
   loadStoredSession,
   persistStoredSession,
@@ -7,11 +8,13 @@ import { useSessionStore } from "@/core/session/session-store";
 import type { StoredSession } from "@/core/session/types";
 
 jest.mock("@/core/session/session-storage", () => ({
+  clearLegacyStoredSession: jest.fn().mockResolvedValue(undefined),
   loadStoredSession: jest.fn(),
   persistStoredSession: jest.fn(),
   clearStoredSession: jest.fn().mockResolvedValue(undefined),
 }));
 
+const mockClearLegacyStoredSession = jest.mocked(clearLegacyStoredSession);
 const mockLoadStoredSession = jest.mocked(loadStoredSession);
 const mockPersistStoredSession = jest.mocked(persistStoredSession);
 const mockClearStoredSession = jest.mocked(clearStoredSession);
@@ -167,6 +170,7 @@ describe("session store", () => {
         accessToken: "header.payload.signature",
       }),
     );
+    expect(mockClearLegacyStoredSession).toHaveBeenCalledTimes(1);
     expect(useSessionStore.getState()).toMatchObject({
       hydrated: true,
       isAuthenticated: true,

--- a/core/session/session-store.ts
+++ b/core/session/session-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 
 import {
+  clearLegacyStoredSession,
   clearStoredSession,
   loadStoredSession,
   persistStoredSession,
@@ -131,6 +132,7 @@ export const useSessionStore = create<SessionState>((set, get) => ({
 
         if (loadedSession.source === "legacy" && loadedSession.session) {
           await persistStoredSession(loadedSession.session);
+          await clearLegacyStoredSession();
         }
 
         if (

--- a/docs/runbooks/PLT2-PLT5-foundation.md
+++ b/docs/runbooks/PLT2-PLT5-foundation.md
@@ -81,9 +81,13 @@ Fallback canônico suportado (cross-repo):
 
 - `AURAXIS_FLAG_PROVIDER`
 - `AURAXIS_UNLEASH_URL`
-- `AURAXIS_UNLEASH_API_TOKEN` / `AURAXIS_UNLEASH_CLIENT_KEY`
+- `AURAXIS_UNLEASH_CLIENT_KEY`
 - `AURAXIS_UNLEASH_ENVIRONMENT` / `AURAXIS_RUNTIME_ENV`
 - `AURAXIS_UNLEASH_CACHE_TTL_MS`
+
+Regra de segurança:
+
+- `AURAXIS_UNLEASH_API_TOKEN` é proibido no app. O cliente mobile só pode usar chave pública de proxy (`*_UNLEASH_CLIENT_KEY`) ou fallback local.
 
 Bootstrap central recomendado:
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "contracts:sync:api-local": "node scripts/contracts-sync-local-api.cjs",
     "contracts:catalog:check": "node scripts/app-contract-catalog-check.cjs",
     "contracts:check": "node scripts/contracts-check.cjs",
-    "policy:check": "node scripts/check-frontend-governance.cjs && node scripts/check-api-contract-governance.cjs && node scripts/check-app-route-boundaries.cjs && node scripts/check-openapi-secret-hygiene.cjs && node scripts/check-sonar-config-governance.cjs && node scripts/check-runtime-release-governance.cjs",
+    "policy:check": "node scripts/check-frontend-governance.cjs && node scripts/check-api-contract-governance.cjs && node scripts/check-app-route-boundaries.cjs && node scripts/check-openapi-secret-hygiene.cjs && node scripts/check-sonar-config-governance.cjs && node scripts/check-runtime-release-governance.cjs && node scripts/check-client-security-governance.cjs",
     "quality-check": "npm run lint && npm run typecheck && npm run policy:check && npm run contracts:check && npm run test:coverage",
     "test:watch": "jest --watchAll",
     "ci:local": "bash scripts/run_ci_like_actions_local.sh",
@@ -95,14 +95,16 @@
       "node scripts/check-frontend-governance.cjs",
       "node scripts/check-api-contract-governance.cjs",
       "node scripts/check-app-route-boundaries.cjs",
-      "node scripts/check-openapi-secret-hygiene.cjs"
+      "node scripts/check-openapi-secret-hygiene.cjs",
+      "node scripts/check-client-security-governance.cjs"
     ],
     "**/*.json": [
       "prettier --write",
       "node scripts/check-openapi-secret-hygiene.cjs"
     ],
     "{package.json,package-lock.json,.nvmrc,app.json,eas.json,README.md,CODING_STANDARDS.md,steering.md,.context/quality_gates.md,.context/architecture.md,.github/workflows/ci.yml,.github/workflows/deploy-minimum.yml,.github/workflows/store-release.yml,scripts/run_ci_like_actions_local.sh}": [
-      "node scripts/check-runtime-release-governance.cjs"
+      "node scripts/check-runtime-release-governance.cjs",
+      "node scripts/check-client-security-governance.cjs"
     ]
   }
 }

--- a/scripts/check-client-security-governance.cjs
+++ b/scripts/check-client-security-governance.cjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const ROOT = process.cwd();
+const PRODUCT_DIRECTORIES = [
+  "app",
+  "components",
+  "config",
+  "constants",
+  "core",
+  "features",
+  "hooks",
+  "schemas",
+  "shared",
+  "stores",
+  "types",
+];
+const CODE_EXTENSIONS = new Set([".ts", ".tsx"]);
+const CODE_FILE_EXCLUDE_PATTERNS = [
+  /\.test\.tsx?$/u,
+  /\.spec\.tsx?$/u,
+  /__tests__\//u,
+];
+const BANNED_ENV_LITERAL_KEYS = [
+  "AURAXIS_UNLEASH_API_TOKEN",
+  "EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN",
+];
+const SENSITIVE_PROCESS_ENV_PATTERN =
+  /\bprocess\.env\.([A-Z0-9_]*(?:SECRET|PASSWORD|PRIVATE_KEY|ACCESS_TOKEN|REFRESH_TOKEN|API_TOKEN)[A-Z0-9_]*)\b/u;
+const SENSITIVE_APP_CONFIG_EXTRA_KEY_PATTERN =
+  /(token|secret|password|private[_-]?key|access[_-]?token|refresh[_-]?token|api[_-]?token)/iu;
+const SESSION_STORAGE_PATH = "core/session/session-storage.ts";
+const LEGACY_SESSION_WRITE_PATTERNS = [
+  /SecureStore\.setItemAsync\(\s*LEGACY_ACCESS_TOKEN_KEY\b/u,
+  /SecureStore\.setItemAsync\(\s*LEGACY_USER_EMAIL_KEY\b/u,
+  /SecureStore\.setItemAsync\(\s*["']auraxis\.access-token["']/u,
+  /SecureStore\.setItemAsync\(\s*["']auraxis\.user-email["']/u,
+];
+
+const walkDirectoryRecursively = (rootDirectory) => {
+  const visitedFiles = [];
+
+  if (!fs.existsSync(rootDirectory)) {
+    return visitedFiles;
+  }
+
+  const stack = [rootDirectory];
+
+  while (stack.length > 0) {
+    const currentDirectory = stack.pop();
+    const entries = fs.readdirSync(currentDirectory, { withFileTypes: true });
+
+    for (const entry of entries) {
+      if (
+        entry.name === "node_modules"
+        || entry.name === "coverage"
+        || entry.name === ".expo"
+        || entry.name === ".git"
+      ) {
+        continue;
+      }
+
+      const absoluteEntryPath = path.join(currentDirectory, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(absoluteEntryPath);
+        continue;
+      }
+
+      visitedFiles.push(absoluteEntryPath);
+    }
+  }
+
+  return visitedFiles;
+};
+
+const toUnixRelativePath = (absolutePath, rootDirectory = ROOT) => {
+  return path.relative(rootDirectory, absolutePath).split(path.sep).join("/");
+};
+
+const collectProductCodeFiles = (rootDirectory = ROOT) => {
+  return PRODUCT_DIRECTORIES.flatMap((directory) => {
+    const absoluteDirectory = path.resolve(rootDirectory, directory);
+    const files = walkDirectoryRecursively(absoluteDirectory);
+
+    return files.filter((absoluteFilePath) => {
+      const relativePath = toUnixRelativePath(absoluteFilePath, rootDirectory);
+      return (
+        CODE_EXTENSIONS.has(path.extname(absoluteFilePath))
+        && !CODE_FILE_EXCLUDE_PATTERNS.some((pattern) => pattern.test(relativePath))
+      );
+    });
+  });
+};
+
+const findLineViolations = ({ relativePath, fileContent }, predicate, messageBuilder) => {
+  const lines = fileContent.split("\n");
+  const errors = [];
+
+  lines.forEach((lineContent, lineIndex) => {
+    const detail = predicate(lineContent);
+    if (!detail) {
+      return;
+    }
+
+    errors.push(messageBuilder({
+      relativePath,
+      lineNumber: lineIndex + 1,
+      detail,
+    }));
+  });
+
+  return errors;
+};
+
+const findBannedEnvLiteralViolations = (files) => {
+  return files.flatMap(({ relativePath, fileContent }) => {
+    return findLineViolations(
+      { relativePath, fileContent },
+      (lineContent) => {
+        const key = BANNED_ENV_LITERAL_KEYS.find((candidate) => {
+          return lineContent.includes(candidate);
+        });
+        return key ?? null;
+      },
+      ({ relativePath: nextRelativePath, lineNumber, detail }) => {
+        return `banned client env key reference (${detail}): ${nextRelativePath}:${lineNumber}`;
+      },
+    );
+  });
+};
+
+const findSensitiveProcessEnvViolations = (files) => {
+  return files.flatMap(({ relativePath, fileContent }) => {
+    return findLineViolations(
+      { relativePath, fileContent },
+      (lineContent) => {
+        const match = lineContent.match(SENSITIVE_PROCESS_ENV_PATTERN);
+        return match?.[1] ?? null;
+      },
+      ({ relativePath: nextRelativePath, lineNumber, detail }) => {
+        return `sensitive process.env reference in client code (${detail}): ${nextRelativePath}:${lineNumber}`;
+      },
+    );
+  });
+};
+
+const visitObjectKeys = (value, prefix = "") => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return [];
+  }
+
+  return Object.entries(value).flatMap(([key, nestedValue]) => {
+    const nextPath = prefix.length > 0 ? `${prefix}.${key}` : key;
+    return [nextPath, ...visitObjectKeys(nestedValue, nextPath)];
+  });
+};
+
+const findSensitiveAppConfigExtraViolations = (appConfig) => {
+  const extra = appConfig?.expo?.extra ?? {};
+
+  return visitObjectKeys(extra)
+    .filter((keyPath) => SENSITIVE_APP_CONFIG_EXTRA_KEY_PATTERN.test(keyPath))
+    .map((keyPath) => {
+      return `sensitive expo.extra key detected in app.json (${keyPath})`;
+    });
+};
+
+const findLegacySessionPersistenceViolations = (sessionStorageContents) => {
+  return LEGACY_SESSION_WRITE_PATTERNS.flatMap((pattern) => {
+    return pattern.test(sessionStorageContents)
+      ? ["legacy session keys must not be written back to SecureStore"]
+      : [];
+  });
+};
+
+const loadInputs = (rootDirectory = ROOT) => {
+  const codeFiles = collectProductCodeFiles(rootDirectory).map((absolutePath) => {
+    return {
+      relativePath: toUnixRelativePath(absolutePath, rootDirectory),
+      fileContent: fs.readFileSync(absolutePath, "utf8"),
+    };
+  });
+  const appConfig = JSON.parse(
+    fs.readFileSync(path.resolve(rootDirectory, "app.json"), "utf8"),
+  );
+  const sessionStorageContents = fs.readFileSync(
+    path.resolve(rootDirectory, SESSION_STORAGE_PATH),
+    "utf8",
+  );
+
+  return {
+    appConfig,
+    codeFiles,
+    sessionStorageContents,
+  };
+};
+
+const run = () => {
+  const { appConfig, codeFiles, sessionStorageContents } = loadInputs();
+  const errors = [
+    ...findBannedEnvLiteralViolations(codeFiles),
+    ...findSensitiveProcessEnvViolations(codeFiles),
+    ...findSensitiveAppConfigExtraViolations(appConfig),
+    ...findLegacySessionPersistenceViolations(sessionStorageContents),
+  ];
+
+  if (errors.length > 0) {
+    process.stderr.write("[client-security-governance] FAILED\n");
+    for (const error of errors) {
+      process.stderr.write(` - ${error}\n`);
+    }
+    process.exit(1);
+  }
+
+  process.stdout.write("[client-security-governance] OK\n");
+};
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = {
+  BANNED_ENV_LITERAL_KEYS,
+  findBannedEnvLiteralViolations,
+  findLegacySessionPersistenceViolations,
+  findSensitiveAppConfigExtraViolations,
+  findSensitiveProcessEnvViolations,
+  loadInputs,
+  run,
+};

--- a/scripts/check-client-security-governance.test.ts
+++ b/scripts/check-client-security-governance.test.ts
@@ -1,0 +1,99 @@
+import {
+  findBannedEnvLiteralViolations,
+  findLegacySessionPersistenceViolations,
+  findSensitiveAppConfigExtraViolations,
+  findSensitiveProcessEnvViolations,
+} from "./check-client-security-governance.cjs";
+
+describe("check-client-security-governance", () => {
+  test("accepts a clean client security baseline", () => {
+    const codeFiles = [
+      {
+        relativePath: "shared/feature-flags/service.ts",
+        fileContent: [
+          'const key = process.env.EXPO_PUBLIC_UNLEASH_CLIENT_KEY;',
+          'const mode = process.env.EXPO_PUBLIC_FLAG_PROVIDER;',
+        ].join("\n"),
+      },
+      {
+        relativePath: "shared/config/runtime.ts",
+        fileContent: 'const apiUrl = process.env.EXPO_PUBLIC_API_URL;',
+      },
+    ];
+
+    expect(findBannedEnvLiteralViolations(codeFiles)).toEqual([]);
+    expect(findSensitiveProcessEnvViolations(codeFiles)).toEqual([]);
+    expect(
+      findSensitiveAppConfigExtraViolations({
+        expo: {
+          extra: {
+            sentryDsn: "",
+            appEnv: "development",
+            eas: {
+              projectId: "project-id",
+            },
+          },
+        },
+      }),
+    ).toEqual([]);
+    expect(
+      findLegacySessionPersistenceViolations(
+        'await SecureStore.setItemAsync(SESSION_KEY, "payload");',
+      ),
+    ).toEqual([]);
+  });
+
+  test("flags banned env key literals in client code", () => {
+    const errors = findBannedEnvLiteralViolations([
+      {
+        relativePath: "shared/config/runtime.ts",
+        fileContent:
+          'const legacy = process.env.EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN;',
+      },
+    ]);
+
+    expect(errors).toEqual([
+      "banned client env key reference (EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN): shared/config/runtime.ts:1",
+    ]);
+  });
+
+  test("flags sensitive process.env references in client code", () => {
+    const errors = findSensitiveProcessEnvViolations([
+      {
+        relativePath: "shared/config/runtime.ts",
+        fileContent: 'const password = process.env.API_PASSWORD;',
+      },
+    ]);
+
+    expect(errors).toEqual([
+      "sensitive process.env reference in client code (API_PASSWORD): shared/config/runtime.ts:1",
+    ]);
+  });
+
+  test("flags sensitive expo.extra keys", () => {
+    const errors = findSensitiveAppConfigExtraViolations({
+      expo: {
+        extra: {
+          observabilityExportToken: "secret",
+          eas: {
+            projectId: "project-id",
+          },
+        },
+      },
+    });
+
+    expect(errors).toEqual([
+      "sensitive expo.extra key detected in app.json (observabilityExportToken)",
+    ]);
+  });
+
+  test("flags legacy session writes back to secure storage", () => {
+    const errors = findLegacySessionPersistenceViolations(
+      'await SecureStore.setItemAsync(LEGACY_ACCESS_TOKEN_KEY, token);',
+    );
+
+    expect(errors).toEqual([
+      "legacy session keys must not be written back to SecureStore",
+    ]);
+  });
+});

--- a/shared/config/runtime.ts
+++ b/shared/config/runtime.ts
@@ -41,7 +41,6 @@ type RuntimeEnvKey =
   | "EXPO_PUBLIC_CHECKOUT_RETURN_PATH"
   | "EXPO_PUBLIC_OBSERVABILITY_EXPORT_ENABLED"
   | "EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY"
-  | "EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN"
   | "EXPO_PUBLIC_API_MOCK_LATENCY_MS";
 
 const readExpoEnv = (envKey: RuntimeEnvKey): string | undefined => {
@@ -68,8 +67,6 @@ const readExpoEnv = (envKey: RuntimeEnvKey): string | undefined => {
       return process.env.EXPO_PUBLIC_OBSERVABILITY_EXPORT_ENABLED;
     case "EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY":
       return process.env.EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY;
-    case "EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN":
-      return process.env.EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN;
     case "EXPO_PUBLIC_API_MOCK_LATENCY_MS":
       return process.env.EXPO_PUBLIC_API_MOCK_LATENCY_MS;
     default:
@@ -207,10 +204,6 @@ export const appRuntimeConfig: AppRuntimeConfig = Object.freeze({
     {
       envKey: "EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY",
       extraKey: "observabilityExportKey",
-    },
-    {
-      envKey: "EXPO_PUBLIC_OBSERVABILITY_EXPORT_TOKEN",
-      extraKey: "observabilityExportToken",
     },
   ]),
   mockLatencyMs: readNumber(

--- a/shared/feature-flags/service.test.ts
+++ b/shared/feature-flags/service.test.ts
@@ -21,6 +21,7 @@ const resetFeatureFlagTestEnv = (): void => {
   delete process.env.EXPO_PUBLIC_UNLEASH_CACHE_TTL_MS;
   delete process.env.AURAXIS_FLAG_PROVIDER;
   delete process.env.AURAXIS_UNLEASH_URL;
+  delete process.env.AURAXIS_UNLEASH_CLIENT_KEY;
   delete process.env.AURAXIS_UNLEASH_API_TOKEN;
   delete process.env.AURAXIS_UNLEASH_CACHE_TTL_MS;
   jest.restoreAllMocks();
@@ -215,5 +216,28 @@ describe("feature flag service - unleash provider", () => {
 
     const snapshot = await fetchUnleashSnapshot();
     expect(snapshot["app.tools.salary-raise-calculator"]).toBe(true);
+  });
+
+  it("nao usa AURAXIS_UNLEASH_API_TOKEN como fallback de header no cliente", async () => {
+    process.env.AURAXIS_FLAG_PROVIDER = "unleash";
+    process.env.AURAXIS_UNLEASH_URL = "https://flags.local";
+    process.env.AURAXIS_UNLEASH_API_TOKEN = "server-token-should-not-leak";
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        features: [],
+      }),
+    } as unknown as Response);
+
+    await fetchUnleashSnapshot();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "https://flags.local/api/client/features",
+      expect.objectContaining({
+        headers: expect.not.objectContaining({
+          Authorization: "server-token-should-not-leak",
+        }),
+      }),
+    );
   });
 });

--- a/shared/feature-flags/service.ts
+++ b/shared/feature-flags/service.ts
@@ -28,7 +28,6 @@ const getKnownEnvValues = (): Record<string, string | undefined> => {
     AURAXIS_UNLEASH_INSTANCE_ID: process.env.AURAXIS_UNLEASH_INSTANCE_ID,
     EXPO_PUBLIC_UNLEASH_CLIENT_KEY: process.env.EXPO_PUBLIC_UNLEASH_CLIENT_KEY,
     AURAXIS_UNLEASH_CLIENT_KEY: process.env.AURAXIS_UNLEASH_CLIENT_KEY,
-    AURAXIS_UNLEASH_API_TOKEN: process.env.AURAXIS_UNLEASH_API_TOKEN,
     EXPO_PUBLIC_UNLEASH_PROXY_URL: process.env.EXPO_PUBLIC_UNLEASH_PROXY_URL,
     AURAXIS_UNLEASH_URL: process.env.AURAXIS_UNLEASH_URL,
   };
@@ -128,7 +127,6 @@ const buildUnleashHeaders = (): Record<string, string> => {
     [
       "EXPO_PUBLIC_UNLEASH_CLIENT_KEY",
       "AURAXIS_UNLEASH_CLIENT_KEY",
-      "AURAXIS_UNLEASH_API_TOKEN",
     ],
     "",
   );


### PR DESCRIPTION
## Summary
- harden the mobile client security surface by removing forbidden client-side secret fallbacks and public env aliases
- consolidate secure session persistence around the canonical key and clear legacy sensitive keys during bootstrap
- add a client-security governance scanner plus tests to fail early locally and in CI

## Validation
- npm run test -- core/session/session-storage.test.ts core/session/session-store.test.ts shared/feature-flags/service.test.ts core/navigation/deep-linking.test.ts scripts/check-client-security-governance.test.ts __tests__/services/sentry.test.ts core/telemetry/sanitization.test.ts --runInBand
- node scripts/check-client-security-governance.cjs
- npm run policy:check
- node scripts/ci-audit-gate.js
- npm run quality-check
- git diff --check

Closes #230