### PR TITLE
feat(app): harden runtime security and observability

### DIFF
--- a/core/http/http-client.test.ts
+++ b/core/http/http-client.test.ts
@@ -2,6 +2,7 @@ import { AxiosError, type InternalAxiosRequestConfig } from "axios";
 
 import { createHttpClient, httpClient } from "@/core/http/http-client";
 import { useSessionStore } from "@/core/session/session-store";
+import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { appLogger } from "@/core/telemetry/app-logger";
 
 jest.mock("@/core/session/session-storage", () => ({
@@ -36,6 +37,14 @@ const resetSessionStore = (): void => {
   }));
 };
 
+const resetAppShellStore = (): void => {
+  useAppShellStore.setState((state) => ({
+    ...state,
+    connectivityStatus: "unknown",
+    runtimeDegradedReason: null,
+  }));
+};
+
 const readAuthorizationHeader = (
   config: InternalAxiosRequestConfig,
 ): string | undefined => {
@@ -53,6 +62,7 @@ describe("httpClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetSessionStore();
+    resetAppShellStore();
   });
 
   it("normaliza o baseURL sem barras duplicadas", () => {
@@ -257,6 +267,36 @@ describe("httpClient", () => {
     jest.dontMock("@/shared/config/runtime");
   });
 
+  it("restaura conectividade online apos request bem sucedido", async () => {
+    useAppShellStore.setState((state) => ({
+      ...state,
+      connectivityStatus: "offline",
+      runtimeDegradedReason: "offline",
+    }));
+
+    const client = createHttpClient("https://api.auraxis.dev/");
+    client.defaults.adapter = async (config) => ({
+      data: {
+        ok: true,
+      },
+      status: 200,
+      statusText: "OK",
+      headers: {},
+      config,
+    });
+
+    await expect(client.get("/dashboard")).resolves.toMatchObject({
+      data: {
+        ok: true,
+      },
+    });
+
+    expect(useAppShellStore.getState()).toMatchObject({
+      connectivityStatus: "online",
+      runtimeDegradedReason: null,
+    });
+  });
+
   it("registra sucesso em requests de observabilidade", async () => {
     const client = createHttpClient("https://api.auraxis.dev/");
     client.defaults.adapter = async (config) => ({
@@ -426,6 +466,12 @@ describe("httpClient", () => {
   });
 
   it("usa logger de erro para falhas de rede sem response", async () => {
+    useAppShellStore.setState((state) => ({
+      ...state,
+      connectivityStatus: "online",
+      runtimeDegradedReason: null,
+    }));
+
     const client = createHttpClient("https://api.auraxis.dev/");
     client.defaults.adapter = async (config) => {
       throw new AxiosError("Network Error", "ERR_NETWORK", config);
@@ -448,6 +494,10 @@ describe("httpClient", () => {
       },
       error: expect.any(AxiosError),
       captureInSentry: true,
+    });
+    expect(useAppShellStore.getState()).toMatchObject({
+      connectivityStatus: "offline",
+      runtimeDegradedReason: "offline",
     });
   });
 });

--- a/core/http/http-client.ts
+++ b/core/http/http-client.ts
@@ -13,6 +13,7 @@ import {
   resolveSessionInvalidationReason,
 } from "@/core/session/session-policy";
 import { useSessionStore } from "@/core/session/session-store";
+import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { networkLogger } from "@/core/telemetry/domain-loggers";
 import { createMockApiAdapter } from "@/shared/mocks/api/router";
 import { appRuntimeConfig, normalizeBaseUrl } from "@/shared/config/runtime";
@@ -86,6 +87,28 @@ const invalidateExpiredSessionIfNeeded = async (): Promise<void> => {
   }
 
   await sessionState.invalidateSession("expired");
+};
+
+const markConnectivityOnline = (): void => {
+  const shellState = useAppShellStore.getState();
+  if (shellState.connectivityStatus !== "offline") {
+    return;
+  }
+
+  shellState.setConnectivityStatus("online");
+  if (shellState.runtimeDegradedReason === "offline") {
+    shellState.setRuntimeDegradedReason(null);
+  }
+};
+
+const markConnectivityOffline = (): void => {
+  const shellState = useAppShellStore.getState();
+  if (shellState.connectivityStatus === "offline") {
+    return;
+  }
+
+  shellState.setConnectivityStatus("offline");
+  shellState.setRuntimeDegradedReason("offline");
 };
 
 const isMutatingMethod = (method: string): boolean => {
@@ -176,6 +199,7 @@ const attachAuthHeaders = async (
 const handleFulfilledResponse = (
   response: AxiosResponse,
 ): AxiosResponse => {
+  markConnectivityOnline();
   const metadata = (response.config as InstrumentedRequestConfig).auraxisTelemetry;
 
   if (metadata) {
@@ -199,6 +223,9 @@ const handleRejectedResponse = async (error: unknown): Promise<never> => {
   const apiError = toApiError(error);
 
   if (isAxiosError(error)) {
+    if (apiError.status === 0) {
+      markConnectivityOffline();
+    }
     const reason = resolveSessionInvalidationReason(error.response?.status ?? 0);
     const authorizationHeader = readHeader(error.config?.headers, "Authorization");
     const metadata = (error.config as InstrumentedRequestConfig | undefined)

--- a/core/telemetry/logging-policy.test.ts
+++ b/core/telemetry/logging-policy.test.ts
@@ -20,6 +20,12 @@ describe("logging policy", () => {
       minimumContextKeys: ["scope", "componentStack"],
       consolePolicy: "warn-and-error",
     });
+    expect(APP_EVENT_LOGGING_POLICY["observability.snapshot_requested"]).toEqual({
+      level: "info",
+      description: "Snapshot de observabilidade solicitado no cliente.",
+      minimumContextKeys: ["path"],
+      consolePolicy: "dev-only",
+    });
   });
 
   it("nao deixa eventos sem contexto minimo declarado", () => {

--- a/core/telemetry/logging-policy.ts
+++ b/core/telemetry/logging-policy.ts
@@ -165,6 +165,14 @@ export const APP_EVENT_LOGGING_POLICY = Object.freeze({
     "Retorno de checkout recebido via deep link.",
     ["href", "status", "provider", "url"],
   ),
+  "observability.snapshot_requested": devOnlyInfoPolicy(
+    "Snapshot de observabilidade solicitado no cliente.",
+    ["path"],
+  ),
+  "observability.metrics_requested": devOnlyInfoPolicy(
+    "Export de métricas Prometheus solicitado no cliente.",
+    ["path"],
+  ),
 } satisfies Record<AppTelemetryEvent, AppEventLoggingPolicy>);
 
 export const getAppEventLoggingPolicy = (

--- a/core/telemetry/types.ts
+++ b/core/telemetry/types.ts
@@ -27,7 +27,9 @@ export type AppTelemetryEvent =
   | "network.request_failed"
   | "auth.session_established"
   | "auth.session_invalidated"
-  | "checkout.return_received";
+  | "checkout.return_received"
+  | "observability.snapshot_requested"
+  | "observability.metrics_requested";
 
 export type AppLogLevel = "debug" | "info" | "warn" | "error";
 

--- a/features/auth/hooks/use-auth-mutations.test.ts
+++ b/features/auth/hooks/use-auth-mutations.test.ts
@@ -1,0 +1,58 @@
+import { useLogoutMutation } from "@/features/auth/hooks/use-auth-mutations";
+import { authService } from "@/features/auth/services/auth-service";
+import { useSessionStore } from "@/core/session/session-store";
+
+const mockCreateApiMutation = jest.fn();
+
+jest.mock("@/core/query/create-api-mutation", () => ({
+  createApiMutation: (...args: readonly unknown[]) => mockCreateApiMutation(...args),
+}));
+
+jest.mock("@/core/session/session-store", () => ({
+  useSessionStore: jest.fn(),
+}));
+
+jest.mock("@/features/auth/services/auth-service", () => ({
+  authService: {
+    logout: jest.fn(),
+  },
+}));
+
+const mockedUseSessionStore = jest.mocked(useSessionStore);
+const mockedAuthService = authService as jest.Mocked<typeof authService>;
+
+describe("useAuthMutations", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateApiMutation.mockImplementation(
+      (mutationFn: unknown, options: Record<string, unknown> | undefined) => ({
+        mutationFn,
+        ...(options ?? {}),
+      }),
+    );
+  });
+
+  it("invalida a sessao local ao concluir logout", async () => {
+    const signOut = jest.fn().mockResolvedValue(undefined);
+    mockedUseSessionStore.mockReturnValue(signOut as never);
+
+    const mutation = useLogoutMutation() as unknown as {
+      onSettled: (...args: readonly unknown[]) => Promise<void>;
+    };
+
+    const [mutationFn, options] = mockCreateApiMutation.mock.calls[0] ?? [];
+    expect(typeof mutationFn).toBe("function");
+    expect(options).toEqual(
+      expect.objectContaining({
+        onSettled: expect.any(Function),
+      }),
+    );
+
+    await (mutationFn as () => Promise<void>)();
+    expect(mockedAuthService.logout).toHaveBeenCalledTimes(1);
+
+    await mutation.onSettled(undefined, new Error("fail"), undefined, undefined);
+
+    expect(signOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/auth/hooks/use-auth-mutations.ts
+++ b/features/auth/hooks/use-auth-mutations.ts
@@ -30,6 +30,16 @@ export const useLoginMutation = () => {
   });
 };
 
+export const useLogoutMutation = () => {
+  const signOut = useSessionStore((state) => state.signOut);
+
+  return createApiMutation<void, void>(() => authService.logout(), {
+    onSettled: async () => {
+      await signOut();
+    },
+  });
+};
+
 export const useRegisterMutation = () => {
   return createApiMutation<AuthActionResult, RegisterCommand>(
     authService.register,

--- a/features/observability/services/observability-service.test.ts
+++ b/features/observability/services/observability-service.test.ts
@@ -1,0 +1,71 @@
+import type { AxiosInstance } from "axios";
+
+import { createObservabilityService } from "@/features/observability/services/observability-service";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
+import { observabilityLogger } from "@/core/telemetry/domain-loggers";
+
+jest.mock("@/core/telemetry/domain-loggers", () => ({
+  observabilityLogger: {
+    log: jest.fn(),
+  },
+}));
+
+const createClient = (): jest.Mocked<Pick<AxiosInstance, "get">> => {
+  return {
+    get: jest.fn(),
+  };
+};
+
+const mockedObservabilityLogger = jest.mocked(observabilityLogger);
+
+describe("observabilityService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("busca snapshot e registra telemetria", async () => {
+    const client = createClient();
+    const snapshot = {
+      generatedAt: "2026-04-10T10:00:00.000Z",
+      metrics: {},
+      budgets: {},
+      health: {},
+    };
+    client.get.mockResolvedValue({ data: snapshot });
+
+    const service = createObservabilityService(client as unknown as AxiosInstance);
+    await expect(service.getSnapshot()).resolves.toEqual(snapshot);
+
+    expect(client.get).toHaveBeenCalledWith(apiContractMap.opsObservability.path);
+    expect(mockedObservabilityLogger.log).toHaveBeenCalledWith(
+      "observability.snapshot_requested",
+      {
+        context: {
+          path: apiContractMap.opsObservability.path,
+        },
+      },
+    );
+  });
+
+  it("busca métricas e registra telemetria", async () => {
+    const client = createClient();
+    client.get.mockResolvedValue({ data: "metrics_payload" });
+
+    const service = createObservabilityService(client as unknown as AxiosInstance);
+    await expect(service.getMetrics()).resolves.toEqual({
+      payload: "metrics_payload",
+    });
+
+    expect(client.get).toHaveBeenCalledWith(apiContractMap.opsMetrics.path, {
+      responseType: "text",
+    });
+    expect(mockedObservabilityLogger.log).toHaveBeenCalledWith(
+      "observability.metrics_requested",
+      {
+        context: {
+          path: apiContractMap.opsMetrics.path,
+        },
+      },
+    );
+  });
+});

--- a/features/observability/services/observability-service.ts
+++ b/features/observability/services/observability-service.ts
@@ -1,6 +1,7 @@
 import type { AxiosInstance } from "axios";
 
 import { httpClient } from "@/core/http/http-client";
+import { observabilityLogger } from "@/core/telemetry/domain-loggers";
 import type {
   ObservabilitySnapshot,
   PrometheusMetricsExport,
@@ -10,12 +11,22 @@ import { apiContractMap } from "@/shared/contracts/api-contract-map";
 export const createObservabilityService = (client: AxiosInstance) => {
   return {
     getSnapshot: async (): Promise<ObservabilitySnapshot> => {
+      observabilityLogger.log("observability.snapshot_requested", {
+        context: {
+          path: apiContractMap.opsObservability.path,
+        },
+      });
       const response = await client.get<ObservabilitySnapshot>(
         apiContractMap.opsObservability.path,
       );
       return response.data;
     },
     getMetrics: async (): Promise<PrometheusMetricsExport> => {
+      observabilityLogger.log("observability.metrics_requested", {
+        context: {
+          path: apiContractMap.opsMetrics.path,
+        },
+      });
       const response = await client.get<string>(apiContractMap.opsMetrics.path, {
         responseType: "text",
       });


### PR DESCRIPTION
## Summary\n- add logout mutation with session cleanup on settle\n- log observability ops calls with new telemetry events\n- mark offline/online connectivity from HTTP outcomes and cover with tests\n\n## Testing\n- npm run quality-check