### PR TITLE
APP FND-06A/B: testability + runtime revalidation

### DIFF
--- a/core/http/http-client.test.ts
+++ b/core/http/http-client.test.ts
@@ -4,6 +4,11 @@ import { createHttpClient, httpClient } from "@/core/http/http-client";
 import { useSessionStore } from "@/core/session/session-store";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { appLogger } from "@/core/telemetry/app-logger";
+import {
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 jest.mock("@/core/session/session-storage", () => ({
   loadStoredSession: jest.fn(),
@@ -19,31 +24,6 @@ jest.mock("@/core/telemetry/app-logger", () => ({
     error: jest.fn(),
   },
 }));
-
-const resetSessionStore = (): void => {
-  useSessionStore.setState((state) => ({
-    ...state,
-    accessToken: null,
-    refreshToken: null,
-    user: null,
-    userEmail: null,
-    authenticatedAt: null,
-    expiresAt: null,
-    authFailureReason: null,
-    lastValidatedAt: null,
-    lastInvalidatedAt: null,
-    hydrated: true,
-    isAuthenticated: false,
-  }));
-};
-
-const resetAppShellStore = (): void => {
-  useAppShellStore.setState((state) => ({
-    ...state,
-    connectivityStatus: "unknown",
-    runtimeDegradedReason: null,
-  }));
-};
 
 const readAuthorizationHeader = (
   config: InternalAxiosRequestConfig,
@@ -61,8 +41,12 @@ const readAuthorizationHeader = (
 describe("httpClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    resetSessionStore();
-    resetAppShellStore();
+    resetRuntimeStores({
+      session: makeSessionState({
+        hydrated: true,
+        isAuthenticated: false,
+      }),
+    });
   });
 
   it("normaliza o baseURL sem barras duplicadas", () => {
@@ -80,22 +64,18 @@ describe("httpClient", () => {
   });
 
   it("invalida a sessao local quando o token ja expirou antes do request", async () => {
-    useSessionStore.setState((state) => ({
-      ...state,
-      accessToken: "token",
-      refreshToken: "refresh",
-      user: {
-        id: "user-1",
-        name: "Italo",
-        email: "italo@auraxis.dev",
-        emailConfirmed: true,
-      },
-      userEmail: "italo@auraxis.dev",
-      authenticatedAt: "2026-04-08T10:00:00.000Z",
-      expiresAt: "2026-04-08T09:00:00.000Z",
-      hydrated: true,
-      isAuthenticated: true,
-    }));
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: "2026-04-08T09:00:00.000Z",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
 
     const client = createHttpClient("https://api.auraxis.dev/");
     client.defaults.adapter = async (config) => ({
@@ -118,22 +98,18 @@ describe("httpClient", () => {
   });
 
   it("derruba a sessao quando a API responde 401 em request autenticado", async () => {
-    useSessionStore.setState((state) => ({
-      ...state,
-      accessToken: "token",
-      refreshToken: "refresh",
-      user: {
-        id: "user-1",
-        name: "Italo",
-        email: "italo@auraxis.dev",
-        emailConfirmed: true,
-      },
-      userEmail: "italo@auraxis.dev",
-      authenticatedAt: "2026-04-08T10:00:00.000Z",
-      expiresAt: null,
-      hydrated: true,
-      isAuthenticated: true,
-    }));
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: null,
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
 
     const client = createHttpClient("https://api.auraxis.dev/");
     client.defaults.adapter = async (config) => {
@@ -178,22 +154,18 @@ describe("httpClient", () => {
   });
 
   it("anexa o bearer token no interceptor de request para sessao válida", async () => {
-    useSessionStore.setState((state) => ({
-      ...state,
-      accessToken: "token",
-      refreshToken: "refresh",
-      user: {
-        id: "user-1",
-        name: "Italo",
-        email: "italo@auraxis.dev",
-        emailConfirmed: true,
-      },
-      userEmail: "italo@auraxis.dev",
-      authenticatedAt: "2026-04-08T10:00:00.000Z",
-      expiresAt: "2099-04-08T09:00:00.000Z",
-      hydrated: true,
-      isAuthenticated: true,
-    }));
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: "2099-04-08T09:00:00.000Z",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
 
     const client = createHttpClient("https://api.auraxis.dev/");
     const requestHandler = (
@@ -322,22 +294,18 @@ describe("httpClient", () => {
   });
 
   it("derruba a sessao com motivo forbidden quando a API responde 403", async () => {
-    useSessionStore.setState((state) => ({
-      ...state,
-      accessToken: "token",
-      refreshToken: "refresh",
-      user: {
-        id: "user-1",
-        name: "Italo",
-        email: "italo@auraxis.dev",
-        emailConfirmed: true,
-      },
-      userEmail: "italo@auraxis.dev",
-      authenticatedAt: "2026-04-08T10:00:00.000Z",
-      expiresAt: null,
-      hydrated: true,
-      isAuthenticated: true,
-    }));
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: null,
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
 
     const client = createHttpClient("https://api.auraxis.dev/");
     const rejectedHandler = (
@@ -403,22 +371,18 @@ describe("httpClient", () => {
   });
 
   it("nao invalida a sessao quando o 401 chega sem header de autorizacao", async () => {
-    useSessionStore.setState((state) => ({
-      ...state,
-      accessToken: "token",
-      refreshToken: "refresh",
-      user: {
-        id: "user-1",
-        name: "Italo",
-        email: "italo@auraxis.dev",
-        emailConfirmed: true,
-      },
-      userEmail: "italo@auraxis.dev",
-      authenticatedAt: "2026-04-08T10:00:00.000Z",
-      expiresAt: null,
-      hydrated: true,
-      isAuthenticated: true,
-    }));
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: null,
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
 
     const client = createHttpClient("https://api.auraxis.dev/");
     const rejectedHandler = (

--- a/core/session/session-policy.test.ts
+++ b/core/session/session-policy.test.ts
@@ -3,7 +3,7 @@ import {
   resolveSessionInvalidationReason,
   withSessionMetadata,
 } from "@/core/session/session-policy";
-import type { StoredSession } from "@/core/session/types";
+import { makeStoredSession } from "@/shared/testing/runtime-fixtures";
 
 const createJwt = (exp: number): string => {
   const encode = (value: unknown): string => {
@@ -13,28 +13,14 @@ const createJwt = (exp: number): string => {
   return `${encode({ alg: "HS256", typ: "JWT" })}.${encode({ exp })}.signature`;
 };
 
-const createSession = (overrides: Partial<StoredSession> = {}): StoredSession => {
-  return {
-    accessToken: createJwt(Math.floor(Date.now() / 1_000) + 3_600),
-    refreshToken: "refresh-token",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    authenticatedAt: null,
-    expiresAt: null,
-    ...overrides,
-  };
-};
-
 describe("session policy", () => {
   it("enriquece a sessao com metadados derivados do JWT", () => {
     const expiresAt = new Date("2026-04-08T12:00:00.000Z");
     const session = withSessionMetadata(
-      createSession({
+      makeStoredSession({
         accessToken: createJwt(Math.floor(expiresAt.getTime() / 1_000)),
+        authenticatedAt: null,
+        expiresAt: null,
       }),
       new Date("2026-04-08T10:00:00.000Z"),
     );

--- a/core/session/session-storage.test.ts
+++ b/core/session/session-storage.test.ts
@@ -6,7 +6,7 @@ import {
   loadStoredSession,
   persistStoredSession,
 } from "@/core/session/session-storage";
-import type { StoredSession } from "@/core/session/types";
+import { makeStoredSession } from "@/shared/testing/runtime-fixtures";
 
 jest.mock("expo-secure-store", () => ({
   getItemAsync: jest.fn(),
@@ -28,31 +28,14 @@ const createJwt = (payload: Record<string, unknown>): string => {
   return `${encode({ alg: "HS256", typ: "JWT" })}.${encode(payload)}.signature`;
 };
 
-const createStoredSession = (
-  overrides: Partial<StoredSession> = {},
-): StoredSession => {
-  return {
-    accessToken: createJwt({ exp: 4_102_444_800 }),
-    refreshToken: "refresh-token",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    authenticatedAt: "2026-04-08T10:00:00.000Z",
-    expiresAt: "2100-01-01T00:00:00.000Z",
-    ...overrides,
-  };
-};
-
 describe("session-storage", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   it("carrega a sessao canônica e normaliza os metadados", async () => {
-    const storedSession = createStoredSession({
+    const storedSession = makeStoredSession({
+      accessToken: createJwt({ exp: 4_102_444_800 }),
       refreshToken: undefined as unknown as null,
       user: {
         id: undefined as unknown as string | null,
@@ -144,7 +127,8 @@ describe("session-storage", () => {
 
   it("persiste a sessao normalizada apenas no storage canônico", async () => {
     await persistStoredSession(
-      createStoredSession({
+      makeStoredSession({
+        accessToken: createJwt({ exp: 4_102_444_800 }),
         authenticatedAt: null,
         expiresAt: null,
       }),

--- a/core/session/session-store.test.ts
+++ b/core/session/session-store.test.ts
@@ -5,7 +5,10 @@ import {
   persistStoredSession,
 } from "@/core/session/session-storage";
 import { useSessionStore } from "@/core/session/session-store";
-import type { StoredSession } from "@/core/session/types";
+import {
+  makeStoredSession,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 jest.mock("@/core/telemetry/app-logger", () => ({
   appLogger: {
@@ -31,50 +34,15 @@ const mockLoadStoredSession = jest.mocked(loadStoredSession);
 const mockPersistStoredSession = jest.mocked(persistStoredSession);
 const mockClearStoredSession = jest.mocked(clearStoredSession);
 
-const resetSessionStore = (): void => {
-  useSessionStore.setState((state) => ({
-    ...state,
-    accessToken: null,
-    refreshToken: null,
-    user: null,
-    userEmail: null,
-    authenticatedAt: null,
-    expiresAt: null,
-    authFailureReason: null,
-    lastValidatedAt: null,
-    lastInvalidatedAt: null,
-    hydrated: false,
-    isAuthenticated: false,
-  }));
-};
-
-const createStoredSession = (
-  overrides: Partial<StoredSession> = {},
-): StoredSession => {
-  return {
-    accessToken: "header.payload.signature",
-    refreshToken: "refresh-token",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    authenticatedAt: "2026-04-08T10:00:00.000Z",
-    expiresAt: "2099-04-08T12:00:00.000Z",
-    ...overrides,
-  };
-};
-
 describe("session store", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    resetSessionStore();
+    resetRuntimeStores();
   });
 
   it("invalida a sessao expirada durante o bootstrap", async () => {
     mockLoadStoredSession.mockResolvedValue({
-      session: createStoredSession({
+      session: makeStoredSession({
         expiresAt: "2026-04-08T09:00:00.000Z",
       }),
       source: "canonical",
@@ -138,7 +106,7 @@ describe("session store", () => {
     }));
 
     await useSessionStore.getState().signIn(
-      createStoredSession({
+      makeStoredSession({
         authenticatedAt: null,
         expiresAt: null,
       }),
@@ -201,7 +169,7 @@ describe("session store", () => {
 
   it("regrava a sessao legada no storage canônico durante o bootstrap", async () => {
     mockLoadStoredSession.mockResolvedValue({
-      session: createStoredSession(),
+      session: makeStoredSession(),
       source: "legacy",
       invalidStoredPayload: false,
     });
@@ -234,7 +202,7 @@ describe("session store", () => {
   });
 
   it("seta a sessao explicitamente e mantém o estado autenticado", async () => {
-    const session = createStoredSession();
+    const session = makeStoredSession();
 
     await useSessionStore.getState().setSession(session);
 
@@ -267,7 +235,7 @@ describe("session store", () => {
   });
 
   it("persiste updateUser preservando metadados da sessao", async () => {
-    await useSessionStore.getState().setSession(createStoredSession());
+    await useSessionStore.getState().setSession(makeStoredSession());
     mockPersistStoredSession.mockClear();
 
     useSessionStore.getState().updateUser({
@@ -292,7 +260,7 @@ describe("session store", () => {
   });
 
   it("marca a sessao como validada sem derrubar autenticacao", async () => {
-    await useSessionStore.getState().setSession(createStoredSession());
+    await useSessionStore.getState().setSession(makeStoredSession());
     useSessionStore.setState((state) => ({
       ...state,
       authFailureReason: "unauthorized",
@@ -322,7 +290,7 @@ describe("session store", () => {
   });
 
   it("signOut usa invalidacao manual por padrão", async () => {
-    await useSessionStore.getState().setSession(createStoredSession());
+    await useSessionStore.getState().setSession(makeStoredSession());
     mockClearStoredSession.mockClear();
 
     await useSessionStore.getState().signOut();

--- a/core/session/session-store.ts
+++ b/core/session/session-store.ts
@@ -47,7 +47,22 @@ interface SessionState {
   signOut: (reason?: SessionInvalidationReason) => Promise<void>;
 }
 
-const unauthenticatedState = {
+export type SessionStateSnapshot = Pick<
+  SessionState,
+  | "accessToken"
+  | "refreshToken"
+  | "user"
+  | "userEmail"
+  | "authenticatedAt"
+  | "expiresAt"
+  | "authFailureReason"
+  | "lastValidatedAt"
+  | "lastInvalidatedAt"
+  | "hydrated"
+  | "isAuthenticated"
+>;
+
+export const sessionStateDefaults: SessionStateSnapshot = {
   accessToken: null,
   refreshToken: null,
   user: null,
@@ -59,7 +74,7 @@ const unauthenticatedState = {
   lastInvalidatedAt: null,
   hydrated: false,
   isAuthenticated: false,
-} as const;
+};
 
 const toStoredSession = (
   session: SessionSeed | StoredSession | string,
@@ -93,7 +108,7 @@ const toStoredSession = (
 const toState = (session: StoredSession | null): Partial<SessionState> => {
   if (!session) {
     return {
-      ...unauthenticatedState,
+      ...sessionStateDefaults,
       hydrated: true,
     };
   }
@@ -131,7 +146,7 @@ const logSessionRehydrated = (context: Record<string, unknown>): void => {
 let bootstrapSessionPromise: Promise<void> | null = null;
 
 export const useSessionStore = create<SessionState>((set, get) => ({
-  ...unauthenticatedState,
+  ...sessionStateDefaults,
   bootstrapSession: async (): Promise<void> => {
     if (get().hydrated) {
       return;
@@ -263,3 +278,16 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     await get().invalidateSession(reason);
   },
 }));
+
+/**
+ * Resets the session store and clears any pending bootstrap promise (test utility).
+ */
+export const resetSessionStore = (
+  overrides: Partial<SessionStateSnapshot> = {},
+): void => {
+  bootstrapSessionPromise = null;
+  useSessionStore.setState({
+    ...sessionStateDefaults,
+    ...overrides,
+  });
+};

--- a/core/shell/app-shell-store.ts
+++ b/core/shell/app-shell-store.ts
@@ -41,7 +41,22 @@ export interface AppShellState {
   recordReachabilityCheck: (timestamp: string) => void;
 }
 
-export const useAppShellStore = create<AppShellState>((set) => ({
+export type AppShellStateSnapshot = Pick<
+  AppShellState,
+  | "fontsReady"
+  | "reducedMotionEnabled"
+  | "startupReady"
+  | "appState"
+  | "connectivityStatus"
+  | "runtimeDegradedReason"
+  | "entitlementsVersion"
+  | "pendingCheckoutReturn"
+  | "lastHandledUrl"
+  | "lastForegroundSyncAt"
+  | "lastReachabilityCheckAt"
+>;
+
+export const appShellStateDefaults: AppShellStateSnapshot = {
   fontsReady: false,
   reducedMotionEnabled: false,
   startupReady: false,
@@ -53,6 +68,10 @@ export const useAppShellStore = create<AppShellState>((set) => ({
   lastHandledUrl: null,
   lastForegroundSyncAt: null,
   lastReachabilityCheckAt: null,
+};
+
+export const useAppShellStore = create<AppShellState>((set) => ({
+  ...appShellStateDefaults,
   setFontsReady: (value: boolean): void => {
     set({ fontsReady: value });
   },
@@ -87,3 +106,15 @@ export const useAppShellStore = create<AppShellState>((set) => ({
     set({ lastReachabilityCheckAt: timestamp });
   },
 }));
+
+/**
+ * Resets the app shell store to its default state (test utility).
+ */
+export const resetAppShellStore = (
+  overrides: Partial<AppShellStateSnapshot> = {},
+): void => {
+  useAppShellStore.setState({
+    ...appShellStateDefaults,
+    ...overrides,
+  });
+};

--- a/core/shell/runtime-revalidation.base.test.ts
+++ b/core/shell/runtime-revalidation.base.test.ts
@@ -2,7 +2,11 @@ import type { QueryClient } from "@tanstack/react-query";
 
 import { queryKeys } from "@/core/query/query-keys";
 import { createRuntimeRevalidationService } from "@/core/shell/runtime-revalidation";
-import { useSessionStore } from "@/core/session/session-store";
+import {
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 const createQueryClientMock = (): QueryClient => {
   return {
@@ -11,37 +15,6 @@ const createQueryClientMock = (): QueryClient => {
     invalidateQueries: jest.fn(),
     removeQueries: jest.fn(),
   } as unknown as QueryClient;
-};
-
-const resetUnauthenticatedSession = (): void => {
-  useSessionStore.setState({
-    accessToken: null,
-    refreshToken: null,
-    user: null,
-    userEmail: null,
-    authFailureReason: null,
-    lastInvalidatedAt: null,
-    hydrated: true,
-    isAuthenticated: false,
-  });
-};
-
-const setAuthenticatedSession = (): void => {
-  useSessionStore.setState({
-    accessToken: "token",
-    refreshToken: "refresh",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    userEmail: "italo@auraxis.dev",
-    authFailureReason: null,
-    lastInvalidatedAt: null,
-    hydrated: true,
-    isAuthenticated: true,
-  });
 };
 
 const createService = (queryClient: QueryClient) => {
@@ -62,7 +35,12 @@ const createService = (queryClient: QueryClient) => {
 
 describe("runtime revalidation service - base flow", () => {
   beforeEach(() => {
-    resetUnauthenticatedSession();
+    resetRuntimeStores({
+      session: makeSessionState({
+        hydrated: true,
+        isAuthenticated: false,
+      }),
+    });
   });
 
   it("nao sincroniza dados protegidos quando a sessao nao esta autenticada", async () => {
@@ -80,7 +58,16 @@ describe("runtime revalidation service - base flow", () => {
   });
 
   it("sincroniza bootstrap e assinatura quando o app volta ao foreground", async () => {
-    setAuthenticatedSession();
+    resetRuntimeStores({
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    });
 
     const queryClient = createQueryClientMock();
     (queryClient.fetchQuery as jest.Mock)
@@ -107,5 +94,40 @@ describe("runtime revalidation service - base flow", () => {
     expect(queryClient.invalidateQueries).toHaveBeenCalledWith({
       queryKey: queryKeys.entitlements.root,
     });
+  });
+
+  it("deduplica revalidacoes concorrentes para evitar excesso de fetch", async () => {
+    resetRuntimeStores({
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    });
+
+    const queryClient = createQueryClientMock();
+    (queryClient.fetchQuery as jest.Mock)
+      .mockResolvedValueOnce({
+        user: {
+          productContext: {
+            entitlementsVersion: 11,
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        status: "active",
+      });
+
+    const service = createService(queryClient);
+    const [first, second] = await Promise.all([
+      service.revalidate("foreground"),
+      service.revalidate("checkout-return"),
+    ]);
+
+    expect(first).toEqual(second);
+    expect(queryClient.fetchQuery).toHaveBeenCalledTimes(2);
   });
 });

--- a/core/shell/runtime-revalidation.errors.test.ts
+++ b/core/shell/runtime-revalidation.errors.test.ts
@@ -3,7 +3,11 @@ import type { QueryClient } from "@tanstack/react-query";
 import { ApiError } from "@/core/http/api-error";
 import { queryKeys } from "@/core/query/query-keys";
 import { createRuntimeRevalidationService } from "@/core/shell/runtime-revalidation";
-import { useSessionStore } from "@/core/session/session-store";
+import {
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 const createQueryClientMock = (): QueryClient => {
   return {
@@ -14,27 +18,18 @@ const createQueryClientMock = (): QueryClient => {
   } as unknown as QueryClient;
 };
 
-const setAuthenticatedSession = (): void => {
-  useSessionStore.setState({
-    accessToken: "token",
-    refreshToken: "refresh",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    userEmail: "italo@auraxis.dev",
-    authFailureReason: null,
-    lastInvalidatedAt: null,
-    hydrated: true,
-    isAuthenticated: true,
-  });
-};
-
 describe("runtime revalidation service - error handling", () => {
   it("derruba a sessao quando a revalidacao encontra erro de autorizacao", async () => {
-    setAuthenticatedSession();
+    resetRuntimeStores({
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    });
 
     const queryClient = createQueryClientMock();
     const signOut = jest.fn().mockResolvedValue(undefined);
@@ -86,7 +81,16 @@ describe("runtime revalidation service - error handling", () => {
   });
 
   it("propaga erros que nao sao de autorizacao", async () => {
-    setAuthenticatedSession();
+    resetRuntimeStores({
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    });
 
     const queryClient = createQueryClientMock();
     const service = createRuntimeRevalidationService({

--- a/core/shell/runtime-revalidation.ts
+++ b/core/shell/runtime-revalidation.ts
@@ -118,38 +118,54 @@ const createAuthenticationFailureResult = async (
 export const createRuntimeRevalidationService = (
   dependencies: RuntimeRevalidationDependencies,
 ) => {
+  let inflightRevalidation: Promise<RuntimeRevalidationResult> | null = null;
+
+  const performRevalidation = async (
+    _reason: RuntimeRevalidationReason,
+  ): Promise<RuntimeRevalidationResult> => {
+    const refreshedAt = new Date().toISOString();
+    const sessionState = useSessionStore.getState();
+
+    if (!sessionState.isAuthenticated) {
+      return createUnauthenticatedResult(dependencies, refreshedAt);
+    }
+
+    try {
+      const bootstrap = await syncAuthenticatedRuntime(dependencies);
+      const entitlementsVersion =
+        bootstrap.user.productContext.entitlementsVersion;
+
+      return createSuccessResult(
+        dependencies,
+        refreshedAt,
+        entitlementsVersion,
+      );
+    } catch (error) {
+      if (!isAuthenticationFailure(error)) {
+        throw error;
+      }
+
+      return createAuthenticationFailureResult(
+        dependencies,
+        refreshedAt,
+        error,
+      );
+    }
+  };
+
   return {
     revalidate: async (
-      _reason: RuntimeRevalidationReason,
+      reason: RuntimeRevalidationReason,
     ): Promise<RuntimeRevalidationResult> => {
-      const refreshedAt = new Date().toISOString();
-      const sessionState = useSessionStore.getState();
-
-      if (!sessionState.isAuthenticated) {
-        return createUnauthenticatedResult(dependencies, refreshedAt);
+      if (inflightRevalidation) {
+        return inflightRevalidation;
       }
 
-      try {
-        const bootstrap = await syncAuthenticatedRuntime(dependencies);
-        const entitlementsVersion =
-          bootstrap.user.productContext.entitlementsVersion;
+      inflightRevalidation = performRevalidation(reason).finally(() => {
+        inflightRevalidation = null;
+      });
 
-        return createSuccessResult(
-          dependencies,
-          refreshedAt,
-          entitlementsVersion,
-        );
-      } catch (error) {
-        if (!isAuthenticationFailure(error)) {
-          throw error;
-        }
-
-        return createAuthenticationFailureResult(
-          dependencies,
-          refreshedAt,
-          error,
-        );
-      }
+      return inflightRevalidation;
     },
   };
 };

--- a/core/shell/use-app-startup.test.tsx
+++ b/core/shell/use-app-startup.test.tsx
@@ -10,6 +10,10 @@ import {
   resetAppStartupRuntimeForTests,
   useAppStartup,
 } from "@/core/shell/use-app-startup";
+import {
+  makeSessionState,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 jest.mock("expo-font", () => ({
   useFonts: jest.fn(),
@@ -34,28 +38,11 @@ describe("useAppStartup", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetAppStartupRuntimeForTests();
-    useAppShellStore.setState({
-      fontsReady: false,
-      reducedMotionEnabled: false,
-      startupReady: false,
-      appState: "unknown",
-      entitlementsVersion: null,
-      pendingCheckoutReturn: null,
-      lastHandledUrl: null,
-      lastForegroundSyncAt: null,
-    });
-    useSessionStore.setState({
-      accessToken: null,
-      refreshToken: null,
-      user: null,
-      userEmail: null,
-      hydrated: true,
-      isAuthenticated: false,
-      bootstrapSession: jest.fn().mockResolvedValue(undefined),
-      signIn: jest.fn().mockResolvedValue(undefined),
-      setSession: jest.fn().mockResolvedValue(undefined),
-      updateUser: jest.fn(),
-      signOut: jest.fn().mockResolvedValue(undefined),
+    resetRuntimeStores({
+      session: makeSessionState({
+        hydrated: true,
+        isAuthenticated: false,
+      }),
     });
   });
 

--- a/core/shell/use-runtime-lifecycle.base.test.tsx
+++ b/core/shell/use-runtime-lifecycle.base.test.tsx
@@ -8,6 +8,12 @@ import { reachabilityService } from "@/core/shell/reachability-service";
 import { useRuntimeLifecycle } from "@/core/shell/use-runtime-lifecycle";
 import { useSessionStore } from "@/core/session/session-store";
 import { appLogger } from "@/core/telemetry/app-logger";
+import {
+  makeAppShellState,
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 import { createTestHookWrapper } from "@/shared/testing/test-providers";
 import { createTestQueryClient } from "@/shared/testing/test-query-client";
 
@@ -51,48 +57,6 @@ const createLinkingSubscription = (): ReturnType<
   } as unknown as ReturnType<typeof Linking.addEventListener>;
 };
 
-const resetStores = (): void => {
-  useAppShellStore.setState({
-    fontsReady: true,
-    reducedMotionEnabled: false,
-    startupReady: true,
-    appState: "unknown",
-    connectivityStatus: "unknown",
-    runtimeDegradedReason: null,
-    entitlementsVersion: null,
-    pendingCheckoutReturn: null,
-    lastHandledUrl: null,
-    lastForegroundSyncAt: null,
-    lastReachabilityCheckAt: null,
-  });
-  useSessionStore.setState({
-    accessToken: "token",
-    refreshToken: "refresh",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    userEmail: "italo@auraxis.dev",
-    authenticatedAt: "2026-04-10T11:00:00.000Z",
-    expiresAt: "2099-04-10T11:00:00.000Z",
-    authFailureReason: null,
-    lastValidatedAt: null,
-    lastInvalidatedAt: null,
-    hydrated: true,
-    isAuthenticated: true,
-    bootstrapSession: jest.fn().mockResolvedValue(undefined),
-    signIn: jest.fn().mockResolvedValue(undefined),
-    setSession: jest.fn().mockResolvedValue(undefined),
-    updateUser: jest.fn(),
-    markSessionValidated: jest.fn(),
-    dismissAuthFailure: jest.fn(),
-    invalidateSession: jest.fn().mockResolvedValue(undefined),
-    signOut: jest.fn().mockResolvedValue(undefined),
-  });
-};
-
 describe("useRuntimeLifecycle - core flow", () => {
   let appStateListener: ((state: AppStateStatus) => void) | null;
 
@@ -118,7 +82,22 @@ describe("useRuntimeLifecycle - core flow", () => {
         };
       },
     );
-    resetStores();
+    resetRuntimeStores({
+      appShell: makeAppShellState({
+        fontsReady: true,
+        startupReady: true,
+      }),
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-10T11:00:00.000Z",
+        expiresAt: "2099-04-10T11:00:00.000Z",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    });
   });
 
   it("faz probe de conectividade no startup sem disparar runtime revalidation", async () => {

--- a/core/shell/use-runtime-lifecycle.edge.test.tsx
+++ b/core/shell/use-runtime-lifecycle.edge.test.tsx
@@ -5,7 +5,12 @@ import { AppState, type AppStateStatus } from "react-native";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { reachabilityService } from "@/core/shell/reachability-service";
 import { useRuntimeLifecycle } from "@/core/shell/use-runtime-lifecycle";
-import { useSessionStore } from "@/core/session/session-store";
+import {
+  makeAppShellState,
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 import { createTestHookWrapper } from "@/shared/testing/test-providers";
 
 const mockRevalidate = jest.fn().mockResolvedValue({
@@ -39,48 +44,6 @@ const createLinkingSubscription = (): ReturnType<
   } as unknown as ReturnType<typeof Linking.addEventListener>;
 };
 
-const resetStores = (): void => {
-  useAppShellStore.setState({
-    fontsReady: true,
-    reducedMotionEnabled: false,
-    startupReady: true,
-    appState: "unknown",
-    connectivityStatus: "unknown",
-    runtimeDegradedReason: null,
-    entitlementsVersion: null,
-    pendingCheckoutReturn: null,
-    lastHandledUrl: null,
-    lastForegroundSyncAt: null,
-    lastReachabilityCheckAt: null,
-  });
-  useSessionStore.setState({
-    accessToken: "token",
-    refreshToken: "refresh",
-    user: {
-      id: "user-1",
-      name: "Italo",
-      email: "italo@auraxis.dev",
-      emailConfirmed: true,
-    },
-    userEmail: "italo@auraxis.dev",
-    authenticatedAt: "2026-04-10T11:00:00.000Z",
-    expiresAt: "2099-04-10T11:00:00.000Z",
-    authFailureReason: null,
-    lastValidatedAt: null,
-    lastInvalidatedAt: null,
-    hydrated: true,
-    isAuthenticated: true,
-    bootstrapSession: jest.fn().mockResolvedValue(undefined),
-    signIn: jest.fn().mockResolvedValue(undefined),
-    setSession: jest.fn().mockResolvedValue(undefined),
-    updateUser: jest.fn(),
-    markSessionValidated: jest.fn(),
-    dismissAuthFailure: jest.fn(),
-    invalidateSession: jest.fn().mockResolvedValue(undefined),
-    signOut: jest.fn().mockResolvedValue(undefined),
-  });
-};
-
 describe("useRuntimeLifecycle - edge cases", () => {
   let appStateListener: ((state: AppStateStatus) => void) | null;
 
@@ -106,7 +69,22 @@ describe("useRuntimeLifecycle - edge cases", () => {
         };
       },
     );
-    resetStores();
+    resetRuntimeStores({
+      appShell: makeAppShellState({
+        fontsReady: true,
+        startupReady: true,
+      }),
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-10T11:00:00.000Z",
+        expiresAt: "2099-04-10T11:00:00.000Z",
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    });
   });
 
   it("ignora links invalidos e nao duplica o processamento do mesmo retorno", async () => {

--- a/core/telemetry/operational-context.test.ts
+++ b/core/telemetry/operational-context.test.ts
@@ -5,8 +5,12 @@ import {
   buildSentryOperationalContext,
   resetOperationalContextRuntimeForTests,
 } from "@/core/telemetry/operational-context";
-import { useAppShellStore } from "@/core/shell/app-shell-store";
-import { useSessionStore } from "@/core/session/session-store";
+import {
+  makeAppShellState,
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 describe("operational telemetry context", () => {
   const originalPlatformVersion = Platform.Version;
@@ -18,44 +22,34 @@ describe("operational telemetry context", () => {
       value: "18.1",
     });
     resetOperationalContextRuntimeForTests();
-    useAppShellStore.setState({
-      fontsReady: true,
-      reducedMotionEnabled: true,
-      startupReady: true,
-      appState: "active",
-      connectivityStatus: "degraded",
-      runtimeDegradedReason: "healthcheck-failed",
-      entitlementsVersion: 3,
-      pendingCheckoutReturn: null,
-      lastHandledUrl: null,
-      lastForegroundSyncAt: "2026-04-10T13:00:00.000Z",
-      lastReachabilityCheckAt: "2026-04-10T13:05:00.000Z",
-    });
-    useSessionStore.setState({
-      accessToken: "token",
-      refreshToken: "refresh",
-      user: {
-        id: "user-1",
-        name: "Italo",
-        email: "italo@auraxis.dev",
-        emailConfirmed: true,
-      },
-      userEmail: "italo@auraxis.dev",
-      authenticatedAt: "2026-04-10T12:00:00.000Z",
-      expiresAt: "2099-04-10T12:00:00.000Z",
-      authFailureReason: null,
-      lastValidatedAt: "2026-04-10T12:05:00.000Z",
-      lastInvalidatedAt: null,
-      hydrated: true,
-      isAuthenticated: true,
-      bootstrapSession: jest.fn().mockResolvedValue(undefined),
-      signIn: jest.fn().mockResolvedValue(undefined),
-      setSession: jest.fn().mockResolvedValue(undefined),
-      updateUser: jest.fn(),
-      markSessionValidated: jest.fn(),
-      dismissAuthFailure: jest.fn(),
-      invalidateSession: jest.fn().mockResolvedValue(undefined),
-      signOut: jest.fn().mockResolvedValue(undefined),
+    resetRuntimeStores({
+      appShell: makeAppShellState({
+        fontsReady: true,
+        reducedMotionEnabled: true,
+        startupReady: true,
+        appState: "active",
+        connectivityStatus: "degraded",
+        runtimeDegradedReason: "healthcheck-failed",
+        entitlementsVersion: 3,
+        lastForegroundSyncAt: "2026-04-10T13:00:00.000Z",
+        lastReachabilityCheckAt: "2026-04-10T13:05:00.000Z",
+      }),
+      session: makeSessionState({
+        accessToken: "token",
+        refreshToken: "refresh",
+        user: makeSessionUser({
+          id: "user-1",
+          name: "Italo",
+        }),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-10T12:00:00.000Z",
+        expiresAt: "2099-04-10T12:00:00.000Z",
+        authFailureReason: null,
+        lastValidatedAt: "2026-04-10T12:05:00.000Z",
+        lastInvalidatedAt: null,
+        hydrated: true,
+        isAuthenticated: true,
+      }),
     });
   });
 

--- a/core/telemetry/use-observability-runtime-bridge.test.tsx
+++ b/core/telemetry/use-observability-runtime-bridge.test.tsx
@@ -4,6 +4,11 @@ import { syncSentryOperationalContext } from "@/app/services/sentry";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { useSessionStore } from "@/core/session/session-store";
 import { useObservabilityRuntimeBridge } from "@/core/telemetry/use-observability-runtime-bridge";
+import {
+  makeSessionState,
+  makeSessionUser,
+  resetRuntimeStores,
+} from "@/shared/testing/runtime-fixtures";
 
 jest.mock("@/app/services/sentry", () => ({
   syncSentryOperationalContext: jest.fn(),
@@ -12,39 +17,11 @@ jest.mock("@/app/services/sentry", () => ({
 describe("useObservabilityRuntimeBridge", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    useAppShellStore.setState({
-      fontsReady: false,
-      reducedMotionEnabled: false,
-      startupReady: false,
-      appState: "unknown",
-      connectivityStatus: "unknown",
-      runtimeDegradedReason: null,
-      entitlementsVersion: null,
-      pendingCheckoutReturn: null,
-      lastHandledUrl: null,
-      lastForegroundSyncAt: null,
-      lastReachabilityCheckAt: null,
-    });
-    useSessionStore.setState({
-      accessToken: null,
-      refreshToken: null,
-      user: null,
-      userEmail: null,
-      authenticatedAt: null,
-      expiresAt: null,
-      authFailureReason: null,
-      lastValidatedAt: null,
-      lastInvalidatedAt: null,
-      hydrated: false,
-      isAuthenticated: false,
-      bootstrapSession: jest.fn().mockResolvedValue(undefined),
-      signIn: jest.fn().mockResolvedValue(undefined),
-      setSession: jest.fn().mockResolvedValue(undefined),
-      updateUser: jest.fn(),
-      markSessionValidated: jest.fn(),
-      dismissAuthFailure: jest.fn(),
-      invalidateSession: jest.fn().mockResolvedValue(undefined),
-      signOut: jest.fn().mockResolvedValue(undefined),
+    resetRuntimeStores({
+      session: makeSessionState({
+        hydrated: false,
+        isAuthenticated: false,
+      }),
     });
   });
 
@@ -67,12 +44,7 @@ describe("useObservabilityRuntimeBridge", () => {
         isAuthenticated: true,
         accessToken: "token",
         refreshToken: "refresh",
-        user: {
-          id: "user-1",
-          name: "Italo",
-          email: "italo@auraxis.dev",
-          emailConfirmed: true,
-        },
+        user: makeSessionUser(),
       }));
     });
 

--- a/shared/testing/runtime-fixtures.ts
+++ b/shared/testing/runtime-fixtures.ts
@@ -1,0 +1,110 @@
+import type { SessionStateSnapshot } from "@/core/session/session-store";
+import {
+  resetSessionStore,
+  sessionStateDefaults,
+} from "@/core/session/session-store";
+import type {
+  SessionSeed,
+  SessionUser,
+  StoredSession,
+} from "@/core/session/types";
+import type { AppShellStateSnapshot } from "@/core/shell/app-shell-store";
+import {
+  appShellStateDefaults,
+  resetAppShellStore,
+} from "@/core/shell/app-shell-store";
+
+const defaultSessionUser: SessionUser = {
+  id: "user-1",
+  name: "Italo",
+  email: "italo@auraxis.dev",
+  emailConfirmed: true,
+};
+
+const defaultStoredSession: StoredSession = {
+  accessToken: "header.payload.signature",
+  refreshToken: "refresh-token",
+  user: defaultSessionUser,
+  authenticatedAt: "2026-04-08T10:00:00.000Z",
+  expiresAt: "2099-04-08T12:00:00.000Z",
+};
+
+/**
+ * Builds a canonical session user fixture for tests.
+ */
+export const makeSessionUser = (
+  overrides: Partial<SessionUser> = {},
+): SessionUser => {
+  return {
+    ...defaultSessionUser,
+    ...overrides,
+  };
+};
+
+/**
+ * Builds a stored session fixture with sensible defaults.
+ */
+export const makeStoredSession = (
+  overrides: Partial<StoredSession> = {},
+): StoredSession => {
+  const resolvedUser = overrides.user ?? makeSessionUser();
+
+  return {
+    ...defaultStoredSession,
+    ...overrides,
+    user: resolvedUser,
+  };
+};
+
+/**
+ * Builds a session seed fixture (pre-persistence) for tests.
+ */
+export const makeSessionSeed = (
+  overrides: Partial<SessionSeed> = {},
+): SessionSeed => {
+  const resolvedUser = overrides.user ?? makeSessionUser();
+
+  return {
+    accessToken: overrides.accessToken ?? "seed-access-token",
+    refreshToken: overrides.refreshToken ?? null,
+    authenticatedAt: overrides.authenticatedAt ?? null,
+    expiresAt: overrides.expiresAt ?? null,
+    ...overrides,
+    user: resolvedUser,
+  };
+};
+
+/**
+ * Builds an app shell snapshot for store hydration in tests.
+ */
+export const makeAppShellState = (
+  overrides: Partial<AppShellStateSnapshot> = {},
+): AppShellStateSnapshot => {
+  return {
+    ...appShellStateDefaults,
+    ...overrides,
+  };
+};
+
+/**
+ * Builds a session store snapshot for store hydration in tests.
+ */
+export const makeSessionState = (
+  overrides: Partial<SessionStateSnapshot> = {},
+): SessionStateSnapshot => {
+  return {
+    ...sessionStateDefaults,
+    ...overrides,
+  };
+};
+
+/**
+ * Resets runtime stores to a known base state for tests.
+ */
+export const resetRuntimeStores = (options: {
+  readonly appShell?: Partial<AppShellStateSnapshot>;
+  readonly session?: Partial<SessionStateSnapshot>;
+} = {}): void => {
+  resetAppShellStore(options.appShell);
+  resetSessionStore(options.session);
+};


### PR DESCRIPTION
## Summary
- add runtime test fixtures + store reset utilities to reduce test coupling
- refactor session/app shell setup in core tests to use shared factories
- deduplicate concurrent runtime revalidation to prevent extra fetches

## Testing
- npm run quality-check
