### PR TITLE
APP FND-00: guard runtime effects in tests

### DIFF
--- a/core/providers/app-providers.tsx
+++ b/core/providers/app-providers.tsx
@@ -16,9 +16,11 @@ import { RuntimeProvider } from "@/core/providers/runtime-provider";
 export function AppProviders({
   children,
 }: PropsWithChildren): ReactElement {
+  const runtimeEnabled = process.env.NODE_ENV !== "test";
+
   return (
     <QueryClientProvider client={queryClient}>
-      <RuntimeProvider>
+      <RuntimeProvider enabled={runtimeEnabled}>
         <TamaguiProvider config={tamaguiConfig} defaultTheme="auraxis">
           <Theme name="auraxis">{children}</Theme>
         </TamaguiProvider>

--- a/core/providers/runtime-provider.tsx
+++ b/core/providers/runtime-provider.tsx
@@ -5,12 +5,17 @@ import { useRuntimeLifecycle } from "@/core/shell/use-runtime-lifecycle";
 import { useObservabilityRuntimeBridge } from "@/core/telemetry/use-observability-runtime-bridge";
 import { useNavigationTelemetry } from "@/core/telemetry/use-navigation-telemetry";
 
+interface RuntimeProviderProps extends PropsWithChildren {
+  readonly enabled?: boolean;
+}
+
 export const RuntimeProvider = ({
   children,
-}: PropsWithChildren): ReactElement => {
-  useAccessibilityPreferences();
-  useRuntimeLifecycle();
-  useNavigationTelemetry();
-  useObservabilityRuntimeBridge();
+  enabled = true,
+}: RuntimeProviderProps): ReactElement => {
+  useAccessibilityPreferences(enabled);
+  useRuntimeLifecycle(enabled);
+  useNavigationTelemetry(enabled);
+  useObservabilityRuntimeBridge(enabled);
   return <>{children}</>;
 };

--- a/core/shell/use-accessibility-preferences.ts
+++ b/core/shell/use-accessibility-preferences.ts
@@ -5,12 +5,16 @@ import { useAppShellStore } from "@/core/shell/app-shell-store";
 
 const REDUCE_MOTION_EVENT = "reduceMotionChanged";
 
-export const useAccessibilityPreferences = (): void => {
+export const useAccessibilityPreferences = (enabled = true): void => {
   const setReducedMotionEnabled = useAppShellStore(
     (state) => state.setReducedMotionEnabled,
   );
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     let subscribed = true;
 
     const syncReduceMotion = async (): Promise<void> => {
@@ -35,5 +39,5 @@ export const useAccessibilityPreferences = (): void => {
       subscribed = false;
       subscription.remove();
     };
-  }, [setReducedMotionEnabled]);
+  }, [enabled, setReducedMotionEnabled]);
 };

--- a/core/shell/use-runtime-lifecycle.ts
+++ b/core/shell/use-runtime-lifecycle.ts
@@ -175,7 +175,7 @@ const bindAppStateLifecycle = (
   return createSubscriptionTeardown(subscription);
 };
 
-export const useRuntimeLifecycle = (): void => {
+export const useRuntimeLifecycle = (enabled = true): void => {
   const queryClient = useQueryClient();
   const setAppState = useAppShellStore((state) => state.setAppState);
   const setConnectivityStatus = useAppShellStore(
@@ -316,26 +316,46 @@ export const useRuntimeLifecycle = (): void => {
   );
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     setAppState(normalizeAppState(AppState.currentState));
-  }, [setAppState]);
+  }, [enabled, setAppState]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     void syncRuntime("startup");
-  }, [syncRuntime]);
+  }, [enabled, syncRuntime]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     return bindInitialUrlLifecycle(handleIncomingUrl);
-  }, [handleIncomingUrl]);
+  }, [enabled, handleIncomingUrl]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     return bindAppStateLifecycle(
       appStateRef,
       setAppState,
       (reason) => syncRuntime(reason),
     );
-  }, [setAppState, syncRuntime]);
+  }, [enabled, setAppState, syncRuntime]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     if (!authFailureReason || !lastInvalidatedAt) {
       return;
     }
@@ -359,6 +379,7 @@ export const useRuntimeLifecycle = (): void => {
       setPendingCheckoutReturn,
     });
   }, [
+    enabled,
     authFailureReason,
     lastInvalidatedAt,
     queryClient,

--- a/core/telemetry/use-navigation-telemetry.ts
+++ b/core/telemetry/use-navigation-telemetry.ts
@@ -32,11 +32,15 @@ export const buildNavigationRouteLogEntry = (
   };
 };
 
-export const useNavigationTelemetry = (): void => {
+export const useNavigationTelemetry = (enabled = true): void => {
   const pathname = usePathname();
   const lastLoggedRouteRef = useRef<string | null>(null);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     const entry = buildNavigationRouteLogEntry(pathname);
     const route = String(entry.context?.route ?? appRoutes.root);
     if (route === lastLoggedRouteRef.current) {
@@ -47,5 +51,5 @@ export const useNavigationTelemetry = (): void => {
       context: entry.context,
     });
     lastLoggedRouteRef.current = route;
-  }, [pathname]);
+  }, [enabled, pathname]);
 };

--- a/core/telemetry/use-observability-runtime-bridge.ts
+++ b/core/telemetry/use-observability-runtime-bridge.ts
@@ -7,7 +7,7 @@ import { syncSentryOperationalContext } from "@/app/services/sentry";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { useSessionStore } from "@/core/session/session-store";
 
-export const useObservabilityRuntimeBridge = (): void => {
+export const useObservabilityRuntimeBridge = (enabled = true): void => {
   const appState = useAppShellStore((state) => state.appState);
   const connectivityStatus = useAppShellStore((state) => state.connectivityStatus);
   const runtimeDegradedReason = useAppShellStore(
@@ -42,8 +42,13 @@ export const useObservabilityRuntimeBridge = (): void => {
   );
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+
     syncSentryOperationalContext(buildSentryOperationalContext());
   }, [
+    enabled,
     appState,
     authenticatedAt,
     authFailureReason,


### PR DESCRIPTION
## Summary
- add optional runtime enable flag to core runtime hooks
- disable runtime side effects in AppProviders during Jest runs
- keep runtime behavior unchanged for real app sessions

## Testing
- npm run quality-check
