### PR TITLE
docs(app): align docs to canonical structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,10 @@ Antes de qualquer ação, leia a partir da platform:
 ```
 auraxis-app/
   app/           # Telas e navegação (Expo Router)
-  components/    # Componentes reutilizáveis
-  constants/     # Constantes e temas
-  hooks/         # Custom hooks
+  core/          # Runtime canônico (providers, telemetry, http, sessão, shell)
+  features/      # Domínios de produto (components/hooks/services por feature)
+  shared/        # Componentes, types, validators, utils e theme compartilhados
+  stores/        # Estado global de cliente
   assets/        # Imagens, fontes, ícones
   scripts/       # Utilitários de desenvolvimento
 ```

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -184,13 +184,13 @@ export interface Portfolio {
 Todo componente segue esta ordem:
 
 ```typescript
-// components/portfolio/PortfolioCard.tsx
+// features/portfolio/components/PortfolioCard.tsx
 import React, { useCallback } from 'react'
 import { Pressable, StyleSheet, Text, View } from 'react-native'
 
 // ---- 1. Imports --------------------------------------------------------
 
-import { usePortfolioCard } from '@/hooks/usePortfolioCard'
+import { usePortfolioCard } from '@/features/portfolio/hooks/use-portfolio-card'
 import { formatCurrency } from '@/utils/format'
 import type { Portfolio } from '@/types/domain/portfolio'
 import { semanticColors, semanticRadii, semanticSpacing, semanticTypography } from '@/shared/theme'
@@ -355,7 +355,7 @@ const handlePress = useCallback((id: string) => {
 ### 4.1 Estrutura canônica
 
 ```typescript
-// hooks/usePortfolios.ts
+// features/portfolio/hooks/use-portfolios.ts
 import { useCallback, useEffect, useState } from 'react'
 import { portfolioService } from '@/services/portfolioService'
 import type { Portfolio } from '@/types/domain/portfolio'
@@ -445,7 +445,7 @@ app/
 ```typescript
 // app/(auth)/_layout.tsx
 import { Redirect, Stack } from 'expo-router'
-import { useAuth } from '@/hooks/useAuth'
+import { useAuth } from '@/features/auth/hooks/use-auth'
 
 export default function AuthLayout() {
   const { isAuthenticated, isLoading } = useAuth()
@@ -817,7 +817,7 @@ const styles = StyleSheet.create({
 
 | Alvo | Ferramenta | Obrigatório |
 |:-----|:-----------|:-----------:|
-| Hooks customizados (`hooks/`) | jest-expo + `renderHook` | ✅ |
+| Hooks customizados (`features/*/hooks` ou `shared/hooks`) | jest-expo + `renderHook` | ✅ |
 | Utilitários (`utils/`) | jest-expo | ✅ |
 | Serviços HTTP | jest-expo (`jest.mock('fetch')`) | ✅ |
 | Componentes com lógica condicional | jest-expo + @testing-library/react-native | ✅ |
@@ -848,8 +848,8 @@ module.exports = {
     '\\.(png|jpg|jpeg|gif|webp)$': '<rootDir>/__mocks__/imageMock.ts',
   },
   collectCoverageFrom: [
-    'components/**/*.{ts,tsx}',
-    'hooks/**/*.{ts,tsx}',
+    'shared/components/**/*.{ts,tsx}',
+    'features/**/hooks/**/*.{ts,tsx}',
     'services/**/*.{ts,tsx}',
     'utils/**/*.{ts,tsx}',
     '!**/*.d.ts',
@@ -884,7 +884,7 @@ jest.mock('expo-secure-store', () => ({
 ### 9.4 Teste de componente
 
 ```typescript
-// components/portfolio/__tests__/PortfolioCard.test.tsx
+// features/portfolio/components/__tests__/PortfolioCard.test.tsx
 import React from 'react'
 import { render, fireEvent, screen } from '@testing-library/react-native'
 import { PortfolioCard } from '../PortfolioCard'
@@ -930,7 +930,7 @@ describe('PortfolioCard', () => {
 ### 9.5 Teste de hooks
 
 ```typescript
-// hooks/__tests__/usePortfolios.test.ts
+// features/portfolio/hooks/__tests__/use-portfolios.test.ts
 import { renderHook, waitFor } from '@testing-library/react-native'
 import { usePortfolios } from '../usePortfolios'
 import { portfolioService } from '@/services/portfolioService'
@@ -1161,7 +1161,7 @@ npm run test:coverage  # jest-expo + coverage report
 npm run test:watch     # modo watch durante desenvolvimento
 
 # Arquivo específico:
-npx jest src/hooks/useBalance.test.ts --watch
+npx jest features/wallet/hooks/use-balance.test.ts --watch
 
 # Limpar cache (quando módulos mudam):
 npx jest --clearCache
@@ -1251,7 +1251,7 @@ Workflows adicionais:
 | Arquivo de serviço | camelCase | `portfolioService.ts` |
 | Arquivo de tipo | kebab-case | `portfolio.response.ts`, `portfolio.ts` |
 | Arquivo de teste | `*.test.tsx` | `PortfolioCard.test.tsx` |
-| Diretório de testes | `__tests__/` | `components/portfolio/__tests__/` |
+| Diretório de testes | `__tests__/` | `features/portfolio/components/__tests__/` |
 | Constante global | camelCase | `colors.primary`, `spacing.md` |
 | Variável de ambiente | `EXPO_PUBLIC_*` | `EXPO_PUBLIC_API_URL` |
 | Branch git | `tipo/escopo` | `feat/portfolio-detail-screen` |
@@ -1274,12 +1274,12 @@ src/
     theme/             ← TODOS os tokens de design (ver seção 15)
     types/             ← tipos globais compartilhados
     utils/             ← funções puras agnósticas
-    constants/         ← constantes globais
+    validators/        ← validações compartilhadas
 
   features/
     auth/
       components/      ← LoginForm, PinPad (só usados por auth)
-      hooks/           ← useAuth, useSession, useOTP
+      hooks/           ← use-auth, use-session, use-otp
       screens/         ← LoginScreen, ForgotPasswordScreen
       services/        ← authService (chama a API)
       types/           ← AuthUser, LoginPayload, SessionToken
@@ -1296,13 +1296,13 @@ src/
 ```typescript
 // ✅ Feature importa de shared
 import { Button } from '@/shared/components/Button'
-import { colors } from '@/shared/theme'
+import { semanticColors } from '@/shared/theme'
 
 // ✅ Feature importa de si mesma
-import { useAuth } from '../hooks/useAuth'
+import { useAuth } from '../hooks/use-auth'
 
 // ❌ NUNCA — feature importa de outra feature
-import { useTransactions } from '@/features/transactions/hooks/useTransactions'
+import { useTransactionsQuery } from '@/features/transactions/hooks/use-transactions-query'
 // ↑ isso em features/auth/ é uma violação
 ```
 

--- a/FRONTEND_GUIDE.md
+++ b/FRONTEND_GUIDE.md
@@ -46,18 +46,19 @@ auraxis-app/
       profile.tsx             → /profile
     _layout.tsx               # Root layout (providers, fontes, splash)
     +not-found.tsx            # 404
-  components/
-    base/                     # Primitivos: Button, Input, Card, Badge, etc.
-    domain/                   # Componentes de negócio: TransactionItem, GoalCard
-    layout/                   # AppHeader, BottomTabBar, SafeWrapper
-  hooks/                      # Custom hooks (lógica reutilizável)
-  services/                   # Clientes HTTP por domínio
+  core/                       # Runtime canônico (providers, telemetry, http, sessão, shell)
+  features/
+    transactions/             # Domínio de exemplo (components/hooks/services/types)
+  shared/
+    components/               # Componentes reutilizáveis (AppButton, AppCard)
+    theme/                    # Tokens semânticos e tema
+    utils/                    # Formatadores, helpers
+    validators/               # Validadores compartilhados
   stores/                     # Estado global (Context API ou Zustand)
   types/
     api/                      # Tipos de request/response da auraxis-api
     domain/                   # Tipos de domínio (Transaction, Goal, User)
-  constants/                  # Tema, cores, fontes, strings
-  utils/                      # Formatadores, validadores, helpers
+  schemas/                    # Schemas Zod compartilhados
   assets/                     # Imagens, fontes, ícones
   scripts/                    # Utilitários de dev
   app.json                    # Config Expo (pedir aprovação antes de alterar)
@@ -151,10 +152,10 @@ export type TransactionType = 'income' | 'expense'
 ### Functional components com TypeScript explícito
 
 ```tsx
-// components/domain/TransactionItem.tsx
+// features/transactions/components/TransactionItem.tsx
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native'
 import type { Transaction } from '@/types/domain/transaction'
-import { formatCurrency, formatDate } from '@/utils/formatters'
+import { formatCurrency, formatDate } from '@/shared/utils/formatters'
 import { semanticColors, semanticSpacing, semanticTypography } from '@/shared/theme'
 
 interface Props {
@@ -218,10 +219,10 @@ const styles = StyleSheet.create({
 | `testID` em elementos de interação | Para testes com Testing Library |
 | Nomes em PascalCase com extensão `.tsx` | `TransactionItem.tsx`, não `transactionItem.js` |
 
-### Componentes base em `components/base/`
+### Componentes base em `shared/components/`
 
 ```tsx
-// components/base/Button.tsx
+// shared/components/Button.tsx
 import { ActivityIndicator, StyleSheet, Text, TouchableOpacity } from 'react-native'
 import { semanticColors } from '@/shared/theme'
 
@@ -269,9 +270,9 @@ export function Button({
 ### Prefixo `use` obrigatório, um hook = uma preocupação
 
 ```typescript
-// hooks/useTransactions.ts
+// features/transactions/hooks/use-transactions.ts
 import { useCallback, useEffect, useState } from 'react'
-import { transactionService } from '@/services/transaction.service'
+import { transactionService } from '@/features/transactions/services/transactions-service'
 import type { Transaction } from '@/types/domain/transaction'
 import type { CreateTransactionDto } from '@/types/api/transaction'
 
@@ -693,7 +694,7 @@ export function useThemeColors() {
 ### Jest + React Native Testing Library
 
 ```tsx
-// components/domain/__tests__/TransactionItem.test.tsx
+// features/transactions/components/__tests__/TransactionItem.test.tsx
 import { render, fireEvent, screen } from '@testing-library/react-native'
 import { TransactionItem } from '../TransactionItem'
 import { mockTransaction } from '@/tests/factories/transaction.factory'

--- a/steering.md
+++ b/steering.md
@@ -90,15 +90,14 @@ Para integração com backend recém-entregue:
 | Diretório | O que vai aqui |
 |:----------|:---------------|
 | `app/` | Telas (Expo Router — file-based routing) |
-| `components/` | Componentes reutilizáveis |
-| `hooks/` | Hooks customizados (prefixo `use`) |
+| `core/` | Runtime canônico (providers, telemetry, http, sessão, query, shell) |
+| `features/` | Domínios de produto (components, hooks, services e types por feature) |
+| `shared/` | Código compartilhado (`shared/components`, `shared/types`, `shared/validators`, `shared/utils`, `shared/theme`) |
 | `stores/` | Estado global de cliente |
-| `services/` | Chamadas HTTP (um arquivo por domínio de API) |
-| `utils/` | Funções puras sem side-effects |
-| `types/` | Interfaces e tipos TypeScript |
-| `types/api/` | Tipos do contrato com auraxis-api |
-| `shared/` | Código compartilhado (`shared/components`, `shared/types`, `shared/validators`, `shared/utils`) |
-| `constants/` | Constantes e temas de cor |
+| `schemas/` | Schemas de validação (Zod) |
+| `types/` | Interfaces e tipos TypeScript globais |
+| `contracts/` | Snapshots e baseline de contratos (OpenAPI, packs) |
+| `config/` | Tokens, tema Tamagui e configuração de design |
 | `__tests__/` | Testes unitários (alternativa a co-localização) |
 | `e2e/` | Testes Detox (scaffold — requer macOS runner) |
 | `__mocks__/` | Mocks globais (SVG, imagens) |
@@ -195,16 +194,16 @@ Workflows adicionais:
 ### Estrutura de arquivos
 
 ```
-components/
+shared/components/
   Button/
     Button.tsx
     Button.test.tsx       ← co-localizado com o componente
 
-hooks/
-  useBalance.ts
-  useBalance.test.ts      ← co-localizado com o hook
+features/wallet/hooks/
+  use-balance.ts
+  use-balance.test.ts      ← co-localizado com o hook
 
-utils/
+shared/utils/
   currency.ts
   currency.test.ts
 
@@ -271,7 +270,7 @@ describe('useBalance', () => {
 
 | O que | Obrigatório | Tipo |
 |:------|:-----------:|:-----|
-| Hooks customizados (`hooks/`) | ✅ | Unitário (Jest) |
+| Hooks customizados (`features/*/hooks` ou `shared/hooks`) | ✅ | Unitário (Jest) |
 | Utilitários (`utils/`) | ✅ | Unitário (Jest) |
 | Serviços HTTP | ✅ | Unitário (mock de `fetch`) |
 | Componentes com lógica condicional | ✅ | Unitário (Jest + RNTL) |

--- a/tasks.md
+++ b/tasks.md
@@ -78,7 +78,7 @@ Toda task de UI/layout no `auraxis-app` deve seguir, sem exceção:
   - Critério:
     1. `tamagui`, `@tamagui/core`, `@tamagui/config` e `@tamagui/babel-plugin` instalados.
     2. `config/tamagui-theme.ts` com tokens Auraxis (`surface`, `brand`, `text`, `status`, `border`) mapeados para `createTokens` + `createTheme`.
-    3. `TamaguiProvider` configurado no root (`components/providers/app-providers.tsx`), substituindo `PaperProvider`.
+    3. `TamaguiProvider` configurado no root (`core/providers/app-providers.tsx`), substituindo `PaperProvider`.
     4. `config/paper-theme.ts` e dependência `react-native-paper` removidos do projeto.
     5. Todas as telas existentes migradas de imports `react-native-paper` para primitivos Tamagui.
     6. `quality-check` verde (lint + typecheck + testes + policy).


### PR DESCRIPTION
## Summary
- align app docs (README/steering/guide/standards) to the canonical feature-based structure
- remove legacy references to deleted components/hooks/constants
- update task note to point to core AppProviders

## Testing
- not run (docs-only changes)
