### PR TITLE
chore(app): add anti-duplicate-files automation

### DIFF
--- a/.github/workflows/cleanup-duplicate-files.yml
+++ b/.github/workflows/cleanup-duplicate-files.yml
@@ -1,0 +1,73 @@
+# Cleanup duplicate files — auraxis-app
+#
+# Removes macOS Finder / iCloud "duplicate" artifacts that pollute the
+# working tree with a name pattern of "<name> <digit>.<ext>" (file) or
+# "<name> <digit>" (directory). These are never authored by humans.
+#
+# When something is found, opens a chore PR that deletes them. If nothing
+# is found, the workflow exits cleanly with no PR and no noise.
+
+name: Cleanup duplicate files
+
+on:
+  schedule:
+    # Every Monday at 06:00 UTC (~03:00 BRT) — outside business hours.
+    - cron: '0 6 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  cleanup:
+    name: Scan and open cleanup PR if needed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run cleanup script
+        id: cleanup
+        run: |
+          chmod +x scripts/clean-duplicate-files.sh
+          bash scripts/clean-duplicate-files.sh
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "changes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open cleanup pull request
+        if: steps.cleanup.outputs.changes == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: chore/auto-cleanup-duplicate-files
+          delete-branch: true
+          base: main
+          title: 'chore: cleanup duplicate files (auto)'
+          commit-message: 'chore: remove macOS/iCloud duplicate files'
+          body: |
+            Automated cleanup of macOS Finder / iCloud sync duplicate artifacts.
+
+            **Pattern matched**
+            - Files: `<name> <digit>.<ext>` (e.g. `foo 2.ts`, `report 3.md`)
+            - Directories: `<name> <digit>` (e.g. `components 2/`)
+
+            **Why this exists**
+            macOS Finder and iCloud Drive create these copies on rename
+            collisions or sync conflicts. They are never intentional
+            and break Expo's bundler auto-discovery when they land
+            inside `app/`, `features/`, or `components/`.
+
+            **Validation**
+            The cleanup script refuses to delete any path tracked by git,
+            so this PR is always safe to merge.
+
+            Triggered by `.github/workflows/cleanup-duplicate-files.yml`.
+          labels: |
+            chore
+            automation

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+bash scripts/check-no-duplicate-files.sh
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test": "jest",
     "test:coverage": "jest --coverage",
     "flags:check": "node scripts/check-feature-flags.cjs",
+    "cleanup:duplicates": "bash scripts/clean-duplicate-files.sh",
+    "cleanup:duplicates:dry": "bash scripts/clean-duplicate-files.sh --dry-run",
     "contracts:sync": "node scripts/contracts-sync.cjs",
     "contracts:sync:api-local": "node scripts/contracts-sync-local-api.cjs",
     "contracts:catalog:check": "node scripts/app-contract-catalog-check.cjs",

--- a/scripts/check-no-duplicate-files.sh
+++ b/scripts/check-no-duplicate-files.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# check-no-duplicate-files.sh
+#
+# Pre-commit guard: rejects commits that stage any file matching the
+# macOS Finder / iCloud "duplicate" pattern.
+#   <name> <digit>.<ext>     (files)
+#   <name> <digit>/          (directories)
+#
+# These artifacts are never intentional and break Expo's bundler
+# auto-discovery when committed.
+
+set -euo pipefail
+
+mapfile -t STAGED < <(git diff --cached --name-only --diff-filter=ACMR)
+
+if [[ ${#STAGED[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+OFFENDERS=()
+for path in "${STAGED[@]}"; do
+  if [[ "$path" =~ \ [0-9]+(\.[a-zA-Z0-9]+)?(/|$) ]]; then
+    OFFENDERS+=("$path")
+  fi
+done
+
+if [[ ${#OFFENDERS[@]} -gt 0 ]]; then
+  echo "✖ Refusing to commit duplicate-pattern paths (macOS Finder / iCloud artifacts):" >&2
+  printf '  %s\n' "${OFFENDERS[@]}" >&2
+  echo >&2
+  echo "Run 'bash scripts/clean-duplicate-files.sh' to remove them, then re-stage." >&2
+  exit 1
+fi
+
+exit 0

--- a/scripts/clean-duplicate-files.sh
+++ b/scripts/clean-duplicate-files.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# clean-duplicate-files.sh
+#
+# Removes macOS Finder / iCloud "duplicate" artifacts that match the pattern
+#   <name> <digit>.<ext>     (files,  e.g. "foo 2.ts", "report 3.md")
+#   <name> <digit>           (dirs,   e.g. "components 2/")
+#
+# These are generated automatically by macOS Finder, iCloud Drive sync
+# conflicts, or Time Machine — never by humans. They never belong in the repo.
+#
+# Usage:
+#   bash scripts/clean-duplicate-files.sh [--dry-run] [--root <path>]
+#
+# Environment variables:
+#   DRY_RUN=true|false   (default: false)
+#   ROOT_DIR=<path>      (default: repo root, derived from git)
+
+set -euo pipefail
+
+DRY_RUN="${DRY_RUN:-false}"
+ROOT_DIR="${ROOT_DIR:-}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN="true"; shift ;;
+    --root)    ROOT_DIR="$2"; shift 2 ;;
+    -h|--help)
+      sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "$ROOT_DIR" ]]; then
+  ROOT_DIR="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+fi
+
+if [[ ! -d "$ROOT_DIR" ]]; then
+  echo "Root directory not found: $ROOT_DIR" >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+# Directories we never traverse (large, generated, or out of scope).
+PRUNE_EXPR=(
+  -path './node_modules' -o
+  -path './.git' -o
+  -path './.expo' -o
+  -path './ios' -o
+  -path './android' -o
+  -path './coverage' -o
+  -path './dist' -o
+  -path './build' -o
+  -path './.next' -o
+  -path './.nuxt' -o
+  -path './.output'
+)
+
+# Find duplicate FILES: ' <digit>.<ext>'
+mapfile -t DUP_FILES < <(
+  find . \( "${PRUNE_EXPR[@]}" \) -prune -o -type f -print 2>/dev/null \
+    | grep -E ' [0-9]+\.[a-zA-Z0-9]+$' \
+    | sort
+)
+
+# Find duplicate DIRECTORIES: ' <digit>$'
+mapfile -t DUP_DIRS < <(
+  find . \( "${PRUNE_EXPR[@]}" \) -prune -o -type d -print 2>/dev/null \
+    | grep -E ' [0-9]+$' \
+    | sort
+)
+
+TOTAL=$(( ${#DUP_FILES[@]} + ${#DUP_DIRS[@]} ))
+
+if [[ $TOTAL -eq 0 ]]; then
+  echo "No duplicate artifacts found under $ROOT_DIR"
+  exit 0
+fi
+
+echo "Scanning $ROOT_DIR"
+echo "  Duplicate files:       ${#DUP_FILES[@]}"
+echo "  Duplicate directories: ${#DUP_DIRS[@]}"
+echo
+
+if [[ ${#DUP_FILES[@]} -gt 0 ]]; then
+  echo "Files:"
+  printf '  %s\n' "${DUP_FILES[@]}"
+  echo
+fi
+
+if [[ ${#DUP_DIRS[@]} -gt 0 ]]; then
+  echo "Directories:"
+  printf '  %s\n' "${DUP_DIRS[@]}"
+  echo
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "Dry-run mode — no changes made. Run without --dry-run to delete."
+  exit 0
+fi
+
+# Refuse to proceed if any of the targets are git-tracked. Tracked artifacts
+# may be intentional and should be removed via a real commit, not a janitor.
+TRACKED=()
+for path in "${DUP_FILES[@]}" "${DUP_DIRS[@]}"; do
+  if git ls-files --error-unmatch -- "$path" >/dev/null 2>&1; then
+    TRACKED+=("$path")
+  fi
+done
+
+if [[ ${#TRACKED[@]} -gt 0 ]]; then
+  echo "Refusing to delete: the following paths are git-tracked." >&2
+  printf '  %s\n' "${TRACKED[@]}" >&2
+  echo "Remove them via 'git rm' in a real commit if intentional." >&2
+  exit 1
+fi
+
+# Remove directories first (so their files do not re-appear in the file list
+# of subsequent runs), then files. Both lists are already pruned above so the
+# overlap is rare, but `rm -rf` on an already-removed path is a no-op.
+for dir in "${DUP_DIRS[@]}"; do
+  rm -rf -- "$dir"
+  echo "removed dir:  $dir"
+done
+
+for file in "${DUP_FILES[@]}"; do
+  rm -f -- "$file"
+  echo "removed file: $file"
+done
+
+echo
+echo "Cleanup complete: $TOTAL artifact(s) removed."


### PR DESCRIPTION
## Why

The local working tree of this repo accumulates duplicate artifacts
generated by macOS Finder and iCloud Drive sync conflicts:

- Files: `<name> <digit>.<ext>` (e.g. `foo 2.ts`, `report 3.md`)
- Directories: `<name> <digit>` (e.g. `components 2/`)

They are never authored by humans, but they break Expo's bundler
auto-discovery when they land inside `app/`, `features/`, or
`components/` — and they slowly bloat the local checkout.

## What this PR adds

### 1. Local cleanup script
`scripts/clean-duplicate-files.sh`
- Scans the repo, lists matches, removes them.
- Refuses to delete anything tracked by git (safety guard).
- Supports `--dry-run` and `DRY_RUN=true`.

### 2. Pre-commit guard
`scripts/check-no-duplicate-files.sh`
- Wired into `.husky/pre-commit` before `lint-staged`.
- Rejects any staged path matching the duplicate pattern with a
  helpful message pointing at the cleanup script.

### 3. Periodic GitHub Action
`.github/workflows/cleanup-duplicate-files.yml`
- Runs `cron: '0 6 * * 1'` (Mondays 06:00 UTC ≈ 03:00 BRT).
- Also `workflow_dispatch` for ad-hoc runs.
- When artifacts are found: opens a `chore: cleanup duplicate files (auto)`
  PR via `peter-evans/create-pull-request@v6`.
- When clean: exits silently — no noise.

### 4. npm scripts
- `npm run cleanup:duplicates` — run cleanup
- `npm run cleanup:duplicates:dry` — preview only

## Validation

Smoke-tested locally:
- 41 stray files + 28 stray directories detected and removed.
- Pre-commit guard rejects fake duplicate when staged.
- Dry-run mode behaves as expected (no deletion).

## Test plan
- [x] Cleanup script ran end-to-end on local checkout (69 artifacts removed)
- [x] Pre-commit hook fires before lint-staged
- [x] CI passes (lint, typecheck, policy, contracts, tests, coverage)
- [ ] After merge: trigger the workflow manually once via "Run workflow" to confirm it produces no PR on a clean repo