### PR TITLE
feat(app): UX foundation — haptics, domain skeletons, illustrated empty states, screen transitions

### DIFF
--- a/app/(public)/_layout.tsx
+++ b/app/(public)/_layout.tsx
@@ -16,7 +16,15 @@ function PublicLayoutContent(): ReactElement | null {
     return <Redirect href={redirectTo} />;
   }
 
-  return <Stack screenOptions={{ headerShown: false }} />;
+  return (
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: "slide_from_right",
+        animationDuration: 220,
+      }}
+    />
+  );
 }
 
 export default function PublicLayout(): ReactElement {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,7 +16,13 @@ function RootLayoutContent() {
   }
 
   return (
-    <Stack screenOptions={{ headerShown: false }}>
+    <Stack
+      screenOptions={{
+        headerShown: false,
+        animation: "slide_from_right",
+        animationDuration: 220,
+      }}
+    >
       <Stack.Screen name="index" />
       <Stack.Screen name="(public)" />
       <Stack.Screen name="(private)" />

--- a/core/query/create-api-mutation.test.tsx
+++ b/core/query/create-api-mutation.test.tsx
@@ -1,0 +1,134 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+import { ApiError } from "@/core/http/api-error";
+import { useApiMutation } from "@/core/query/create-api-mutation";
+import { triggerHapticNotification } from "@/shared/feedback/haptics";
+
+jest.mock("@/shared/feedback/haptics", () => ({
+  triggerHapticNotification: jest.fn(),
+}));
+
+const triggerHapticNotificationMock =
+  triggerHapticNotification as jest.MockedFunction<
+    typeof triggerHapticNotification
+  >;
+
+const buildWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { readonly children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+};
+
+describe("useApiMutation", () => {
+  beforeEach(() => {
+    triggerHapticNotificationMock.mockClear();
+  });
+
+  it("dispara haptic success ao concluir mutation com sucesso", async () => {
+    const fn = jest.fn().mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(() => useApiMutation(fn), {
+      wrapper: buildWrapper(),
+    });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(triggerHapticNotificationMock).toHaveBeenCalledWith("success");
+  });
+
+  it("dispara haptic error ao falhar a mutation", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValue(
+        new ApiError({
+          message: "boom",
+          status: 500,
+          code: "internal_error",
+        }),
+      );
+
+    const { result } = renderHook(() => useApiMutation(fn), {
+      wrapper: buildWrapper(),
+    });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(triggerHapticNotificationMock).toHaveBeenCalledWith("error");
+  });
+
+  it("respeita suppressHaptics: true", async () => {
+    const fn = jest.fn().mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(
+      () => useApiMutation(fn, { suppressHaptics: true }),
+      { wrapper: buildWrapper() },
+    );
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(triggerHapticNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it("preserva onSuccess do caller", async () => {
+    const fn = jest.fn().mockResolvedValue({ ok: true });
+    const onSuccess = jest.fn();
+
+    const { result } = renderHook(() => useApiMutation(fn, { onSuccess }), {
+      wrapper: buildWrapper(),
+    });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(triggerHapticNotificationMock).toHaveBeenCalledWith("success");
+  });
+
+  it("preserva onError do caller", async () => {
+    const fn = jest
+      .fn()
+      .mockRejectedValue(
+        new ApiError({
+          message: "boom",
+          status: 500,
+          code: "internal_error",
+        }),
+      );
+    const onError = jest.fn();
+
+    const { result } = renderHook(() => useApiMutation(fn, { onError }), {
+      wrapper: buildWrapper(),
+    });
+
+    result.current.mutate({});
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(triggerHapticNotificationMock).toHaveBeenCalledWith("error");
+  });
+});

--- a/core/query/create-api-mutation.ts
+++ b/core/query/create-api-mutation.ts
@@ -5,14 +5,63 @@ import {
 } from "@tanstack/react-query";
 
 import type { ApiError } from "@/core/http/api-error";
+import { triggerHapticNotification } from "@/shared/feedback/haptics";
 
+export interface AppMutationFeedbackOptions {
+  /**
+   * When `true`, suppresses the automatic success/error haptic feedback
+   * fired by every mutation. Use sparingly — appropriate for silent
+   * background syncs, optimistic UI, or rapid bulk operations where
+   * tactile noise would degrade UX.
+   */
+  readonly suppressHaptics?: boolean;
+}
+
+export type ApiMutationOptions<TData, TVariables> = Omit<
+  UseMutationOptions<TData, ApiError, TVariables>,
+  "mutationFn"
+> &
+  AppMutationFeedbackOptions;
+
+/**
+ * Standard mutation hook that adds automatic tactile feedback to every
+ * mutation outcome:
+ *
+ * - Success → soft success notification
+ * - Error → error notification
+ *
+ * User-supplied `onSuccess` / `onError` handlers are still called after
+ * the haptic fires, preserving previous behaviour. Pass
+ * `suppressHaptics: true` to opt out (e.g. for background syncs).
+ */
 export const useApiMutation = <TData, TVariables>(
   mutationFn: (variables: TVariables) => Promise<TData>,
-  options?: Omit<UseMutationOptions<TData, ApiError, TVariables>, "mutationFn">,
+  options?: ApiMutationOptions<TData, TVariables>,
 ): UseMutationResult<TData, ApiError, TVariables> => {
+  const {
+    suppressHaptics = false,
+    onSuccess: userOnSuccess,
+    onError: userOnError,
+    ...rest
+  } = options ?? {};
+
   return useMutation<TData, ApiError, TVariables>({
     mutationFn,
-    ...options,
+    ...rest,
+    // eslint-disable-next-line max-params
+    onSuccess: (data, variables, onMutateResult, context) => {
+      if (!suppressHaptics) {
+        triggerHapticNotification("success");
+      }
+      return userOnSuccess?.(data, variables, onMutateResult, context);
+    },
+    // eslint-disable-next-line max-params
+    onError: (error, variables, onMutateResult, context) => {
+      if (!suppressHaptics) {
+        triggerHapticNotification("error");
+      }
+      return userOnError?.(error, variables, onMutateResult, context);
+    },
   });
 };
 

--- a/core/shell/app-shell-store.ts
+++ b/core/shell/app-shell-store.ts
@@ -19,6 +19,7 @@ export type RuntimeDegradedReason =
 export interface AppShellState {
   readonly fontsReady: boolean;
   readonly reducedMotionEnabled: boolean;
+  readonly hapticsEnabled: boolean;
   readonly startupReady: boolean;
   readonly appState: RuntimeAppState;
   readonly connectivityStatus: RuntimeConnectivityStatus;
@@ -30,6 +31,7 @@ export interface AppShellState {
   readonly lastReachabilityCheckAt: string | null;
   setFontsReady: (value: boolean) => void;
   setReducedMotionEnabled: (value: boolean) => void;
+  setHapticsEnabled: (value: boolean) => void;
   setStartupReady: (value: boolean) => void;
   setAppState: (value: RuntimeAppState) => void;
   setConnectivityStatus: (value: RuntimeConnectivityStatus) => void;
@@ -45,6 +47,7 @@ export type AppShellStateSnapshot = Pick<
   AppShellState,
   | "fontsReady"
   | "reducedMotionEnabled"
+  | "hapticsEnabled"
   | "startupReady"
   | "appState"
   | "connectivityStatus"
@@ -59,6 +62,7 @@ export type AppShellStateSnapshot = Pick<
 export const appShellStateDefaults: AppShellStateSnapshot = {
   fontsReady: false,
   reducedMotionEnabled: false,
+  hapticsEnabled: true,
   startupReady: false,
   appState: "unknown",
   connectivityStatus: "unknown",
@@ -77,6 +81,9 @@ export const useAppShellStore = create<AppShellState>((set) => ({
   },
   setReducedMotionEnabled: (value: boolean): void => {
     set({ reducedMotionEnabled: value });
+  },
+  setHapticsEnabled: (value: boolean): void => {
+    set({ hapticsEnabled: value });
   },
   setStartupReady: (value: boolean): void => {
     set({ startupReady: value });

--- a/features/alerts/screens/alerts-screen.tsx
+++ b/features/alerts/screens/alerts-screen.tsx
@@ -9,7 +9,9 @@ import {
 import { AlertPreferenceRow } from "@/features/alerts/components/alert-preference-row";
 import { AlertRecordCard } from "@/features/alerts/components/alert-record-card";
 import { AppButton } from "@/shared/components/app-button";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import { AlertsListSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
@@ -41,6 +43,14 @@ function AlertsFeedPanel({
         },
         isEmpty: (data) => data.alerts.length === 0,
       }}
+      loadingComponent={<AlertsListSkeleton rows={4} />}
+      emptyComponent={
+        <AppEmptyState
+          illustration="alerts"
+          title="Sem alertas no momento"
+          description="Quando houver vencimentos, limites ou eventos importantes, eles aparecem aqui."
+        />
+      }
     >
       {(data) => (
         <YStack gap="$3">
@@ -83,6 +93,7 @@ function AlertsPreferencesPanel({
         },
         isEmpty: (data) => data.preferences.length === 0,
       }}
+      loadingComponent={<AlertsListSkeleton rows={3} />}
     >
       {(data) => (
         <YStack gap="$3">

--- a/features/budgets/screens/budgets-screen.tsx
+++ b/features/budgets/screens/budgets-screen.tsx
@@ -11,7 +11,9 @@ import {
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import { BudgetsListSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
@@ -114,6 +116,15 @@ function BudgetsListCard({ controller }: ControllerProps): ReactElement {
           },
           isEmpty: () => controller.budgets.length === 0,
         }}
+        loadingComponent={<BudgetsListSkeleton rows={3} />}
+        emptyComponent={
+          <AppEmptyState
+            illustration="budgets"
+            title="Sem orcamentos ativos"
+            description="Crie um orcamento por categoria para acompanhar limites e gasto realizado."
+            cta={{ label: "Novo orcamento", onPress: controller.handleOpenCreate }}
+          />
+        }
       >
         {() => (
           <YStack gap="$3">

--- a/features/dashboard/screens/dashboard-screen.tsx
+++ b/features/dashboard/screens/dashboard-screen.tsx
@@ -17,6 +17,7 @@ import type {
 } from "@/features/dashboard/services/savings-rate-calculator";
 import { AppButton } from "@/shared/components/app-button";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import { DashboardSkeleton, MetricGridSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { formatCurrency } from "@/shared/utils/formatters";
@@ -110,6 +111,7 @@ function BalanceCard({ controller }: ControllerProps): ReactElement {
           },
           loadingPresentation: "skeleton",
         }}
+        loadingComponent={<DashboardSkeleton />}
       >
         {() => (
           <YStack gap="$1">
@@ -189,8 +191,9 @@ function MonthSnapshotCard({ controller }: ControllerProps): ReactElement {
             },
             isEmpty: (data) =>
               data.series.length === 0 || controller.monthSnapshot === null,
-            loadingPresentation: "notice",
+            loadingPresentation: "skeleton",
           }}
+          loadingComponent={<MetricGridSkeleton tiles={3} />}
         >
           {() => <MonthSnapshotValues controller={controller} />}
         </AppQueryState>

--- a/features/fiscal/screens/fiscal-screen.tsx
+++ b/features/fiscal/screens/fiscal-screen.tsx
@@ -15,7 +15,9 @@ import {
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import { FiscalDocumentsSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
@@ -126,6 +128,18 @@ function ReceivablesListCard({ controller }: ControllerProps): ReactElement {
           },
           isEmpty: (data) => data.receivables.length === 0,
         }}
+        loadingComponent={<FiscalDocumentsSkeleton rows={4} />}
+        emptyComponent={
+          <AppEmptyState
+            illustration="fiscal"
+            title="Nenhum recebivel cadastrado"
+            description="Cadastre o primeiro para acompanhar pagamentos esperados e recebidos."
+            cta={{
+              label: "Novo recebivel",
+              onPress: controller.handleOpenCreate,
+            }}
+          />
+        }
       >
         {(data) => (
           <YStack gap="$3">

--- a/features/goals/screens/goals-screen.tsx
+++ b/features/goals/screens/goals-screen.tsx
@@ -11,10 +11,12 @@ import {
 } from "@/features/goals/hooks/use-goals-screen-controller";
 import type { GoalProgressView } from "@/features/goals/services/goal-progress-calculator";
 import { AppButton } from "@/shared/components/app-button";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { GoalListSkeleton } from "@/shared/skeletons";
 import { formatCurrency } from "@/shared/utils/formatters";
 
 interface GoalsListData {
@@ -125,7 +127,19 @@ function GoalsListCard({ controller }: ControllerProps): ReactElement {
       title="Lista"
       description="Metas em andamento aparecem primeiro."
     >
-      <AppQueryState query={controller.goalsQuery} options={queryStateOptions}>
+      <AppQueryState
+        query={controller.goalsQuery}
+        options={queryStateOptions}
+        loadingComponent={<GoalListSkeleton rows={3} />}
+        emptyComponent={
+          <AppEmptyState
+            illustration="goals"
+            title="Sem metas por aqui"
+            description="Defina sua primeira meta financeira para comecar a acompanhar seu progresso."
+            cta={{ label: "Nova meta", onPress: controller.handleOpenCreate }}
+          />
+        }
+      >
         {() => (
           <YStack gap="$3">
             {controller.goals.map((goal) => (

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -11,10 +11,12 @@ import {
 } from "@/features/transactions/hooks/use-transactions-screen-controller";
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { TransactionListSkeleton } from "@/shared/skeletons";
 import { formatShortDate } from "@/shared/utils/formatters";
 
 const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
@@ -121,6 +123,18 @@ function TransactionsListCard({ controller }: ControllerProps): ReactElement {
           },
           isEmpty: () => controller.transactions.length === 0,
         }}
+        loadingComponent={<TransactionListSkeleton rows={5} />}
+        emptyComponent={
+          <AppEmptyState
+            illustration="transactions"
+            title="Nenhuma transacao no filtro atual"
+            description="Crie uma nova transacao ou troque o filtro acima para visualizar movimentos."
+            cta={{
+              label: "Nova transacao",
+              onPress: controller.handleOpenCreate,
+            }}
+          />
+        }
       >
         {() => (
           <YStack gap="$3">

--- a/features/wallet/screens/wallet-screen.tsx
+++ b/features/wallet/screens/wallet-screen.tsx
@@ -13,7 +13,9 @@ import {
 } from "@/features/wallet/hooks/use-wallet-screen-controller";
 import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import { WalletEntryListSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { formatCurrency, formatPercent } from "@/shared/utils/formatters";
@@ -113,6 +115,15 @@ function AssetsListCard({
           },
           isEmpty: () => controller.entries.length === 0,
         }}
+        loadingComponent={<WalletEntryListSkeleton rows={4} />}
+        emptyComponent={
+          <AppEmptyState
+            illustration="wallet"
+            title="Sua carteira esta vazia"
+            description="Adicione seus primeiros ativos para acompanhar evolucao patrimonial."
+            cta={{ label: "Adicionar ativo", onPress: controller.handleOpenCreate }}
+          />
+        }
       >
         {() => (
           <YStack gap="$3">

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,3 +1,4 @@
+/* eslint-disable consistent-return, @typescript-eslint/no-require-imports */
 /**
  * Jest Setup — auraxis-app
  * Executado após o framework Jest ser inicializado, antes de cada suite de testes.
@@ -7,9 +8,9 @@ import { cleanup } from "@testing-library/react-native";
 
 // Estende matchers do Jest com matchers específicos para React Native
 // Ex: expect(element).toBeVisible(), expect(element).toHaveText('...')
-import '@testing-library/jest-native/extend-expect'
+import "@testing-library/jest-native/extend-expect";
 
-const originalReadableStreamCancel = globalThis.ReadableStream?.prototype?.cancel
+const originalReadableStreamCancel = globalThis.ReadableStream?.prototype?.cancel;
 
 if (typeof originalReadableStreamCancel === "function") {
   globalThis.ReadableStream.prototype.cancel = function cancelWithExpoStreamGuard(
@@ -22,25 +23,54 @@ if (typeof originalReadableStreamCancel === "function") {
         error instanceof TypeError &&
         error.message === "Cannot cancel a stream that already has a reader"
       ) {
-        return
+        return;
       }
 
-      return Promise.reject(error)
-    })
-  }
+      return Promise.reject(error);
+    });
+  };
 }
 
-jest.mock("axios", () => require("axios/dist/node/axios.cjs"))
+jest.mock("axios", () => require("axios/dist/node/axios.cjs"));
+
+// Lean mock for react-native-reanimated under jest.
+// The official `react-native-reanimated/mock` pulls in react-native-worklets,
+// which fails to initialise outside a real RN runtime. We only need
+// `Animated.View` and `FadeIn`-style entering helpers to behave as no-ops.
+/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any, react/display-name */
+jest.mock("react-native-reanimated", () => {
+  const React = require("react");
+  const { View } = require("react-native");
+  const fadeStub = { duration: () => fadeStub, delay: () => fadeStub };
+  const ForwardedView = React.forwardRef(
+    ({ children, style, ...rest }: any, ref: any) => {
+      return React.createElement(View, { style, ref, ...rest }, children);
+    },
+  );
+  return {
+    __esModule: true,
+    default: { View: ForwardedView },
+    View: ForwardedView,
+    FadeIn: fadeStub,
+    FadeOut: fadeStub,
+    SlideInRight: fadeStub,
+    SlideOutLeft: fadeStub,
+    useSharedValue: (initial: unknown) => ({ value: initial }),
+    useAnimatedStyle: () => ({}),
+    withTiming: (value: unknown) => value,
+  };
+});
+/* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any, react/display-name */
 
 // Mock global do expo-router (evita erros em testes unitários de componentes)
-jest.mock('expo-router', () => ({
+jest.mock("expo-router", () => ({
   useRouter: () => ({
     push: jest.fn(),
     replace: jest.fn(),
     back: jest.fn(),
     canGoBack: jest.fn(() => false),
   }),
-  usePathname: jest.fn(() => '/'),
+  usePathname: jest.fn(() => "/"),
   useLocalSearchParams: jest.fn(() => ({})),
   useSegments: jest.fn(() => []),
   Link: ({ children }: { children: React.ReactNode }) => children,
@@ -51,44 +81,44 @@ jest.mock('expo-router', () => ({
   Tabs: {
     Screen: () => null,
   },
-}))
+}));
 
 // Mock do expo-constants
-jest.mock('expo-constants', () => ({
+jest.mock("expo-constants", () => ({
   __esModule: true,
   default: {
-    appOwnership: 'standalone',
+    appOwnership: "standalone",
     easConfig: {
-      projectId: 'eas-project-id',
+      projectId: "eas-project-id",
     },
-    executionEnvironment: 'storeClient',
+    executionEnvironment: "storeClient",
     expoConfig: {
-      name: 'auraxis-app-test',
-      slug: 'auraxis-app',
-      version: '1.3.0',
+      name: "auraxis-app-test",
+      slug: "auraxis-app",
+      version: "1.3.0",
       extra: {
-        appEnv: 'test',
+        appEnv: "test",
       },
     },
-    nativeBuildVersion: '100',
+    nativeBuildVersion: "100",
   },
-}))
+}));
 
-const originalWarn = console.warn.bind(console)
+const originalWarn = console.warn.bind(console);
 
 beforeEach(() => {
-  jest.spyOn(console, 'warn').mockImplementation((...args) => {
-    const [msg] = args
+  jest.spyOn(console, "warn").mockImplementation((...args) => {
+    const [msg] = args;
 
     // Permite warnings de negócio, silencia apenas warnings de infra do RN
-    if (typeof msg === 'string' && msg.includes('Warning: An update to')) return
-    originalWarn(...args)
-  })
-})
+    if (typeof msg === "string" && msg.includes("Warning: An update to")) {return;}
+    originalWarn(...args);
+  });
+});
 
 afterEach(() => {
-  cleanup()
-  jest.useRealTimers()
-  jest.clearAllMocks()
-  jest.restoreAllMocks()
-})
+  cleanup();
+  jest.useRealTimers();
+  jest.clearAllMocks();
+  jest.restoreAllMocks();
+});

--- a/shared/components/app-async-state.tsx
+++ b/shared/components/app-async-state.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import type { ReactElement, ReactNode } from "react";
 
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
@@ -20,6 +20,19 @@ export type AppAsyncStateValue =
 
 export interface AppAsyncStateProps {
   readonly state: AppAsyncStateValue;
+  /**
+   * Optional override rendered in place of the default skeleton block
+   * when the query is in `loading` state with `presentation: "skeleton"`.
+   * Use this to swap in a domain-specific skeleton (transaction list,
+   * goal cards, etc.) so the placeholder mimics the real layout.
+   */
+  readonly loadingComponent?: ReactNode;
+  /**
+   * Optional override rendered in place of the default empty notice when
+   * the query resolves to an empty result. Use this to render an
+   * illustrated `<AppEmptyState />` per domain.
+   */
+  readonly emptyComponent?: ReactNode;
 }
 
 /**
@@ -28,8 +41,15 @@ export interface AppAsyncStateProps {
  * @param props Discriminated async state produced by shared query composition or feature logic.
  * @returns A single canonical feedback surface for the current async state.
  */
-export function AppAsyncState({ state }: AppAsyncStateProps): ReactElement {
+export function AppAsyncState({
+  state,
+  loadingComponent,
+  emptyComponent,
+}: AppAsyncStateProps): ReactElement {
   if (state.kind === "loading") {
+    if (loadingComponent !== undefined) {
+      return <>{loadingComponent}</>;
+    }
     if (state.presentation === "skeleton") {
       return (
         <AppSkeletonBlock
@@ -55,6 +75,9 @@ export function AppAsyncState({ state }: AppAsyncStateProps): ReactElement {
   }
 
   if (state.kind === "empty") {
+    if (emptyComponent !== undefined) {
+      return <>{emptyComponent}</>;
+    }
     return <AsyncStateNotice kind="empty" title={state.title} description={state.description} />;
   }
 

--- a/shared/components/app-button.test.tsx
+++ b/shared/components/app-button.test.tsx
@@ -1,10 +1,23 @@
 import { fireEvent, render } from "@testing-library/react-native";
 
 import { AppProviders } from "@/core/providers/app-providers";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
 
 import { AppButton } from "./app-button";
 
+jest.mock("@/shared/feedback/haptics", () => ({
+  triggerHapticImpact: jest.fn(),
+}));
+
+const triggerHapticImpactMock = triggerHapticImpact as jest.MockedFunction<
+  typeof triggerHapticImpact
+>;
+
 describe("AppButton", () => {
+  beforeEach(() => {
+    triggerHapticImpactMock.mockClear();
+  });
+
   it("dispara onPress no tone primário", () => {
     const onPress = jest.fn();
     const { getByText } = render(
@@ -25,5 +38,51 @@ describe("AppButton", () => {
     );
 
     expect(getByText("Cancelar")).toBeTruthy();
+  });
+
+  it("dispara haptic light por default no tone primário em pressIn", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <AppButton>Confirmar</AppButton>
+      </AppProviders>,
+    );
+
+    fireEvent(getByText("Confirmar"), "pressIn");
+    expect(triggerHapticImpactMock).toHaveBeenCalledWith("light");
+  });
+
+  it("não dispara haptic por default no tone secundário", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <AppButton tone="secondary">Cancelar</AppButton>
+      </AppProviders>,
+    );
+
+    fireEvent(getByText("Cancelar"), "pressIn");
+    expect(triggerHapticImpactMock).toHaveBeenCalledWith("none");
+  });
+
+  it("respeita hapticTone customizado", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <AppButton hapticTone="heavy">Apagar</AppButton>
+      </AppProviders>,
+    );
+
+    fireEvent(getByText("Apagar"), "pressIn");
+    expect(triggerHapticImpactMock).toHaveBeenCalledWith("heavy");
+  });
+
+  it("preserva onPressIn fornecido pelo caller", () => {
+    const onPressIn = jest.fn();
+    const { getByText } = render(
+      <AppProviders>
+        <AppButton onPressIn={onPressIn}>Confirmar</AppButton>
+      </AppProviders>,
+    );
+
+    fireEvent(getByText("Confirmar"), "pressIn");
+    expect(onPressIn).toHaveBeenCalledTimes(1);
+    expect(triggerHapticImpactMock).toHaveBeenCalledWith("light");
   });
 });

--- a/shared/components/app-button.tsx
+++ b/shared/components/app-button.tsx
@@ -1,8 +1,13 @@
-import type { ComponentProps, ReactElement, ReactNode } from "react";
+import { type ComponentProps, type ReactElement, type ReactNode, useCallback } from "react";
+import type { GestureResponderEvent } from "react-native";
 
 import { Button, styled } from "tamagui";
 
 import { borderWidths } from "@/config/design-tokens";
+import {
+  type HapticImpactTone,
+  triggerHapticImpact,
+} from "@/shared/feedback/haptics";
 
 const PrimaryButtonFrame = styled(Button, {
   backgroundColor: "$secondary",
@@ -22,26 +27,63 @@ const SecondaryButtonFrame = styled(Button, {
   },
 });
 
-export interface AppButtonProps
-  extends Omit<ComponentProps<typeof PrimaryButtonFrame>, "children"> {
-  readonly children: ReactNode
-  readonly tone?: "primary" | "secondary"
+type FrameProps = ComponentProps<typeof PrimaryButtonFrame>;
+
+export interface AppButtonProps extends Omit<FrameProps, "children"> {
+  readonly children: ReactNode;
+  readonly tone?: "primary" | "secondary";
+  /**
+   * Tactile feedback fired on press-in. Defaults to `"light"` for primary
+   * tone and `"none"` for secondary, matching mobile UX conventions
+   * (primary CTA = strongest signal). Pass `"none"` to opt out.
+   */
+  readonly hapticTone?: HapticImpactTone;
 }
+
+const defaultHapticTone = (
+  tone: "primary" | "secondary",
+): HapticImpactTone => {
+  return tone === "primary" ? "light" : "none";
+};
 
 /**
  * Shared button wrapper aligned to the Auraxis Tamagui theme.
  *
- * @param props Button content and behavioral props.
+ * Fires tactile feedback on press-in via {@link triggerHapticImpact} so
+ * every CTA in the app gets free haptics without each call site needing
+ * to import `expo-haptics` directly.
+ *
+ * @param props Button content, tone, and optional haptic override.
  * @returns Primary or secondary mobile button.
  */
 export function AppButton({
   children,
   tone = "primary",
+  hapticTone,
+  onPressIn,
   ...rest
 }: AppButtonProps): ReactElement {
+  const resolvedHapticTone = hapticTone ?? defaultHapticTone(tone);
+
+  const handlePressIn = useCallback(
+    (event: GestureResponderEvent): void => {
+      triggerHapticImpact(resolvedHapticTone);
+      onPressIn?.(event);
+    },
+    [onPressIn, resolvedHapticTone],
+  );
+
   if (tone === "secondary") {
-    return <SecondaryButtonFrame {...rest}>{children}</SecondaryButtonFrame>;
+    return (
+      <SecondaryButtonFrame {...rest} onPressIn={handlePressIn}>
+        {children}
+      </SecondaryButtonFrame>
+    );
   }
 
-  return <PrimaryButtonFrame {...rest}>{children}</PrimaryButtonFrame>;
+  return (
+    <PrimaryButtonFrame {...rest} onPressIn={handlePressIn}>
+      {children}
+    </PrimaryButtonFrame>
+  );
 }

--- a/shared/components/app-empty-state.test.tsx
+++ b/shared/components/app-empty-state.test.tsx
@@ -1,0 +1,53 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+
+import { AppEmptyState } from "./app-empty-state";
+
+describe("AppEmptyState", () => {
+  it("renderiza titulo e descricao para a ilustracao informada", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <AppEmptyState
+          illustration="transactions"
+          title="Nenhuma transacao"
+          description="Crie a primeira para comecar."
+          testID="empty-tx"
+        />
+      </AppProviders>,
+    );
+
+    expect(getByText("Nenhuma transacao")).toBeTruthy();
+    expect(getByText("Crie a primeira para comecar.")).toBeTruthy();
+  });
+
+  it("dispara CTA quando informada", () => {
+    const onPress = jest.fn();
+    const { getByText } = render(
+      <AppProviders>
+        <AppEmptyState
+          illustration="goals"
+          title="Sem metas"
+          cta={{ label: "Criar meta", onPress }}
+        />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByText("Criar meta"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it("renderiza customIllustration quando fornecida", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <AppEmptyState
+          illustration="generic"
+          title="Vazio"
+          customIllustration={<></>}
+        />
+      </AppProviders>,
+    );
+
+    expect(getByText("Vazio")).toBeTruthy();
+  });
+});

--- a/shared/components/app-empty-state.tsx
+++ b/shared/components/app-empty-state.tsx
@@ -1,0 +1,137 @@
+import type { ReactElement, ReactNode } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, YStack, useTheme } from "tamagui";
+
+import { AppButton } from "@/shared/components/app-button";
+import { AppHeading } from "@/shared/components/app-heading";
+import { AppStack } from "@/shared/components/app-stack";
+
+export type AppEmptyStateIllustration =
+  | "transactions"
+  | "goals"
+  | "wallet"
+  | "alerts"
+  | "budgets"
+  | "fiscal"
+  | "shared"
+  | "simulations"
+  | "generic";
+
+const ICON_BY_ILLUSTRATION: Record<
+  AppEmptyStateIllustration,
+  React.ComponentProps<typeof MaterialCommunityIcons>["name"]
+> = {
+  transactions: "receipt-text-outline",
+  goals: "trophy-outline",
+  wallet: "chart-line",
+  alerts: "bell-outline",
+  budgets: "piggy-bank-outline",
+  fiscal: "file-document-outline",
+  shared: "account-multiple-outline",
+  simulations: "calculator-variant-outline",
+  generic: "shape-outline",
+};
+
+export interface AppEmptyStateProps {
+  /**
+   * Pictogram representing the empty domain. Each option maps to a
+   * curated MaterialCommunityIcon rendered inside a soft circular badge.
+   */
+  readonly illustration: AppEmptyStateIllustration;
+  readonly title: string;
+  readonly description?: string;
+  /**
+   * Optional call to action shown right below the description.
+   */
+  readonly cta?: {
+    readonly label: string;
+    readonly onPress: () => void;
+  };
+  /**
+   * Optional custom node rendered above the title. Use to override the
+   * default icon when a feature has a more bespoke visual.
+   */
+  readonly customIllustration?: ReactNode;
+  readonly testID?: string;
+}
+
+const ILLUSTRATION_SIZE = 96;
+const ICON_SIZE = 44;
+
+/**
+ * Illustrated empty state for lists, screens and embedded panels.
+ *
+ * Uses a soft circular gradient backdrop + curated icon to feel
+ * intentional rather than the default "no data" notice. Pair with a
+ * short copy and an optional CTA so the user knows the next step.
+ *
+ * @param props Illustration variant, copy and optional CTA.
+ * @returns A friendly placeholder UI for empty data states.
+ */
+export function AppEmptyState({
+  illustration,
+  title,
+  description,
+  cta,
+  customIllustration,
+  testID,
+}: AppEmptyStateProps): ReactElement {
+  const theme = useTheme();
+  const iconColor = theme.secondary?.val ?? "#5B5BD6";
+  const backdropColor = theme.surfaceRaised?.val ?? "#F4F4F8";
+
+  return (
+    <AppStack
+      gap="$3"
+      paddingVertical="$6"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      alignItems="center"
+      justifyContent="center"
+      testID={testID}
+    >
+      {customIllustration ?? (
+        <YStack
+          alignItems="center"
+          justifyContent="center"
+          backgroundColor={backdropColor}
+          borderRadius={ILLUSTRATION_SIZE / 2}
+          height={ILLUSTRATION_SIZE}
+          width={ILLUSTRATION_SIZE}
+        >
+          <MaterialCommunityIcons
+            name={ICON_BY_ILLUSTRATION[illustration]}
+            size={ICON_SIZE}
+            color={iconColor}
+          />
+        </YStack>
+      )}
+
+      <AppHeading level={3} fontSize="$5" textAlign="center">
+        {title}
+      </AppHeading>
+
+      {description ? (
+        <Paragraph
+          color="$muted"
+          fontFamily="$body"
+          fontSize="$3"
+          textAlign="center"
+          maxWidth={320}
+        >
+          {description}
+        </Paragraph>
+      ) : null}
+
+      {cta ? (
+        <AppButton onPress={cta.onPress} hapticTone="medium">
+          {cta.label}
+        </AppButton>
+      ) : null}
+    </AppStack>
+  );
+}

--- a/shared/components/app-query-state.tsx
+++ b/shared/components/app-query-state.tsx
@@ -12,23 +12,42 @@ export interface AppQueryStateProps<TData, TError = unknown> {
   readonly query: QueryFeedbackStateInput<TData, TError>;
   readonly options: QueryFeedbackStateOptions<TData>;
   readonly children: (data: TData) => ReactNode;
+  /**
+   * Optional override for the loading state. Pass a domain-specific
+   * skeleton (e.g. `<TransactionListSkeleton />`) so the placeholder
+   * mimics the final layout instead of using the generic block.
+   */
+  readonly loadingComponent?: ReactNode;
+  /**
+   * Optional override for the empty state. Pass an illustrated
+   * `<AppEmptyState />` for richer empty UX.
+   */
+  readonly emptyComponent?: ReactNode;
 }
 
 /**
  * Composes canonical query UI states so feature screens only describe view structure.
  *
- * @param props Query object, state copy and content renderer.
+ * @param props Query object, state copy, optional overrides and content renderer.
  * @returns Either the shared async feedback or the rendered content tree.
  */
 export function AppQueryState<TData, TError = unknown>({
   query,
   options,
   children,
+  loadingComponent,
+  emptyComponent,
 }: AppQueryStateProps<TData, TError>): ReactElement {
   const state = useQueryFeedbackState(query, options);
 
   if (state.kind !== "content") {
-    return <AppAsyncState state={state} />;
+    return (
+      <AppAsyncState
+        state={state}
+        loadingComponent={loadingComponent}
+        emptyComponent={emptyComponent}
+      />
+    );
   }
 
   if (state.notice) {

--- a/shared/components/app-screen.tsx
+++ b/shared/components/app-screen.tsx
@@ -1,15 +1,54 @@
-import type { PropsWithChildren, ReactElement } from "react";
+import type { PropsWithChildren, ReactElement, ReactNode } from "react";
 
 import { SafeAreaView } from "react-native-safe-area-context";
+import Animated, { FadeIn } from "react-native-reanimated";
 import { ScrollView, YStack } from "tamagui";
 
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { motionDurations } from "@/shared/theme/motion";
+
 export interface AppScreenProps extends PropsWithChildren {
-  readonly scrollable?: boolean
-  readonly testID?: string
+  readonly scrollable?: boolean;
+  /**
+   * Toggles a soft fade-in entrance animation on the screen content.
+   * Honours the user's "Reduce Motion" preference automatically.
+   * Defaults to `true` so every screen feels alive without per-screen
+   * boilerplate.
+   */
+  readonly animateEntry?: boolean;
+  readonly testID?: string;
 }
+
+interface ContentWrapperProps {
+  readonly animateEntry: boolean;
+  readonly reducedMotion: boolean;
+  readonly children: ReactNode;
+}
+
+const ContentWrapper = ({
+  animateEntry,
+  reducedMotion,
+  children,
+}: ContentWrapperProps): ReactElement => {
+  if (!animateEntry || reducedMotion) {
+    return <>{children}</>;
+  }
+  return (
+    <Animated.View
+      style={{ flex: 1 }}
+      entering={FadeIn.duration(motionDurations.normal)}
+    >
+      {children}
+    </Animated.View>
+  );
+};
 
 /**
  * Canonical screen wrapper for Tamagui-based mobile surfaces.
+ *
+ * Applies a soft fade-in to screen content by default so navigation
+ * pushes feel polished without each screen having to wire animation
+ * itself. Disable via `animateEntry={false}` if needed.
  *
  * @param props Screen composition props.
  * @returns Safe-area aware screen with shared padding and vertical rhythm.
@@ -17,35 +56,44 @@ export interface AppScreenProps extends PropsWithChildren {
 export function AppScreen({
   children,
   scrollable = true,
+  animateEntry = true,
   testID,
 }: AppScreenProps): ReactElement {
+  const reducedMotion = useAppShellStore((state) => state.reducedMotionEnabled);
+
   if (!scrollable) {
     return (
       <SafeAreaView style={{ flex: 1 }}>
-        <YStack
-          flex={1}
-          backgroundColor="$background"
-          paddingHorizontal="$4"
-          paddingVertical="$4"
-          gap="$4"
-          testID={testID}>
-          {children}
-        </YStack>
+        <ContentWrapper animateEntry={animateEntry} reducedMotion={reducedMotion}>
+          <YStack
+            flex={1}
+            backgroundColor="$background"
+            paddingHorizontal="$4"
+            paddingVertical="$4"
+            gap="$4"
+            testID={testID}
+          >
+            {children}
+          </YStack>
+        </ContentWrapper>
       </SafeAreaView>
     );
   }
 
   return (
     <SafeAreaView style={{ flex: 1 }}>
-      <ScrollView flex={1} backgroundColor="$background" testID={testID}>
-        <YStack
-          flex={1}
-          paddingHorizontal="$4"
-          paddingVertical="$4"
-          gap="$4">
-          {children}
-        </YStack>
-      </ScrollView>
+      <ContentWrapper animateEntry={animateEntry} reducedMotion={reducedMotion}>
+        <ScrollView flex={1} backgroundColor="$background" testID={testID}>
+          <YStack
+            flex={1}
+            paddingHorizontal="$4"
+            paddingVertical="$4"
+            gap="$4"
+          >
+            {children}
+          </YStack>
+        </ScrollView>
+      </ContentWrapper>
     </SafeAreaView>
   );
 }

--- a/shared/components/app-toggle-row.test.tsx
+++ b/shared/components/app-toggle-row.test.tsx
@@ -1,10 +1,23 @@
 import { fireEvent, render } from "@testing-library/react-native";
 
 import { AppProviders } from "@/core/providers/app-providers";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
 
 import { AppToggleRow } from "./app-toggle-row";
 
+jest.mock("@/shared/feedback/haptics", () => ({
+  triggerHapticImpact: jest.fn(),
+}));
+
+const triggerHapticImpactMock = triggerHapticImpact as jest.MockedFunction<
+  typeof triggerHapticImpact
+>;
+
 describe("AppToggleRow", () => {
+  beforeEach(() => {
+    triggerHapticImpactMock.mockClear();
+  });
+
   it("renderiza label, descricao e dispara alteracao do switch", () => {
     const onCheckedChange = jest.fn();
 
@@ -26,5 +39,26 @@ describe("AppToggleRow", () => {
     fireEvent(getByTestId("notifications-switch"), "onCheckedChange", true);
 
     expect(onCheckedChange).toHaveBeenCalledWith(true);
+  });
+
+  it("dispara haptic light em cada alteracao do switch", () => {
+    const onCheckedChange = jest.fn();
+
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppToggleRow
+          label="Bloqueio biometrico"
+          checked={false}
+          testID="biometric"
+          onCheckedChange={onCheckedChange}
+        />
+      </AppProviders>,
+    );
+
+    fireEvent(getByTestId("biometric-switch"), "onCheckedChange", true);
+    fireEvent(getByTestId("biometric-switch"), "onCheckedChange", false);
+
+    expect(triggerHapticImpactMock).toHaveBeenCalledTimes(2);
+    expect(triggerHapticImpactMock).toHaveBeenCalledWith("light");
   });
 });

--- a/shared/components/app-toggle-row.tsx
+++ b/shared/components/app-toggle-row.tsx
@@ -1,6 +1,8 @@
-import type { ReactElement } from "react";
+import { type ReactElement, useCallback } from "react";
 
 import { Paragraph, Switch, XStack, YStack } from "tamagui";
+
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
 
 export interface AppToggleRowProps {
   readonly label: string;
@@ -12,7 +14,9 @@ export interface AppToggleRowProps {
 }
 
 /**
- * Shared labeled toggle row with optional support copy.
+ * Shared labeled toggle row with optional support copy. Fires a light
+ * haptic impact every time the toggle changes so the user gets a tactile
+ * confirmation alongside the visual switch animation.
  *
  * @param props Toggle state and descriptive copy.
  * @returns A reusable switch row aligned to the Tamagui theme.
@@ -25,6 +29,15 @@ export function AppToggleRow({
   testID,
   onCheckedChange,
 }: AppToggleRowProps): ReactElement {
+  const handleCheckedChange = useCallback(
+    (value: boolean | "indeterminate"): void => {
+      const next = Boolean(value);
+      triggerHapticImpact("light");
+      onCheckedChange(next);
+    },
+    [onCheckedChange],
+  );
+
   return (
     <XStack alignItems="center" justifyContent="space-between" gap="$3" testID={testID}>
       <YStack flex={1} gap="$1">
@@ -41,9 +54,7 @@ export function AppToggleRow({
         checked={checked}
         disabled={disabled}
         testID={testID ? `${testID}-switch` : undefined}
-        onCheckedChange={(value) => {
-          onCheckedChange(Boolean(value));
-        }}>
+        onCheckedChange={handleCheckedChange}>
         <Switch.Thumb />
       </Switch>
     </XStack>

--- a/shared/feedback/haptics.test.ts
+++ b/shared/feedback/haptics.test.ts
@@ -1,0 +1,110 @@
+import * as Haptics from "expo-haptics";
+
+import { resetAppShellStore, useAppShellStore } from "@/core/shell/app-shell-store";
+import {
+  haptics,
+  triggerHapticImpact,
+  triggerHapticNotification,
+} from "@/shared/feedback/haptics";
+
+jest.mock("expo-haptics", () => ({
+  ImpactFeedbackStyle: {
+    Light: "Light",
+    Medium: "Medium",
+    Heavy: "Heavy",
+  },
+  NotificationFeedbackType: {
+    Success: "Success",
+    Warning: "Warning",
+    Error: "Error",
+  },
+  impactAsync: jest.fn().mockResolvedValue(undefined),
+  notificationAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockedImpactAsync = Haptics.impactAsync as jest.MockedFunction<
+  typeof Haptics.impactAsync
+>;
+const mockedNotificationAsync = Haptics.notificationAsync as jest.MockedFunction<
+  typeof Haptics.notificationAsync
+>;
+
+describe("haptics", () => {
+  beforeEach(() => {
+    resetAppShellStore();
+    mockedImpactAsync.mockClear();
+    mockedNotificationAsync.mockClear();
+  });
+
+  describe("triggerHapticImpact", () => {
+    it.each(["light", "medium", "heavy"] as const)(
+      "dispara impacto %s quando habilitado",
+      (tone) => {
+        triggerHapticImpact(tone);
+        expect(mockedImpactAsync).toHaveBeenCalledTimes(1);
+        expect(mockedImpactAsync).toHaveBeenCalledWith(
+          tone.charAt(0).toUpperCase() + tone.slice(1),
+        );
+      },
+    );
+
+    it("nao dispara quando tone é none", () => {
+      triggerHapticImpact("none");
+      expect(mockedImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it("nao dispara quando hapticsEnabled é false", () => {
+      useAppShellStore.getState().setHapticsEnabled(false);
+      triggerHapticImpact("medium");
+      expect(mockedImpactAsync).not.toHaveBeenCalled();
+    });
+
+    it("não propaga falha do expo-haptics", async () => {
+      mockedImpactAsync.mockRejectedValueOnce(new Error("simulated"));
+      expect(() => triggerHapticImpact("light")).not.toThrow();
+      // wait microtask to let the swallowed promise settle
+      await Promise.resolve();
+    });
+  });
+
+  describe("triggerHapticNotification", () => {
+    it.each(["success", "warning", "error"] as const)(
+      "dispara notificação %s quando habilitado",
+      (tone) => {
+        triggerHapticNotification(tone);
+        expect(mockedNotificationAsync).toHaveBeenCalledTimes(1);
+        expect(mockedNotificationAsync).toHaveBeenCalledWith(
+          tone.charAt(0).toUpperCase() + tone.slice(1),
+        );
+      },
+    );
+
+    it("nao dispara quando hapticsEnabled é false", () => {
+      useAppShellStore.getState().setHapticsEnabled(false);
+      triggerHapticNotification("success");
+      expect(mockedNotificationAsync).not.toHaveBeenCalled();
+    });
+
+    it("não propaga falha do expo-haptics", async () => {
+      mockedNotificationAsync.mockRejectedValueOnce(new Error("simulated"));
+      expect(() => triggerHapticNotification("error")).not.toThrow();
+      await Promise.resolve();
+    });
+  });
+
+  describe("haptics convenience helpers", () => {
+    it("light/medium/heavy delegam para triggerHapticImpact", () => {
+      haptics.light();
+      haptics.medium();
+      haptics.heavy();
+      expect(mockedImpactAsync).toHaveBeenCalledTimes(3);
+    });
+
+    it("success/warning/error delegam para triggerHapticNotification", () => {
+      haptics.success();
+      haptics.warning();
+      haptics.error();
+      expect(mockedNotificationAsync).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/shared/feedback/haptics.ts
+++ b/shared/feedback/haptics.ts
@@ -1,0 +1,110 @@
+import * as Haptics from "expo-haptics";
+
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+
+/**
+ * Tactile feedback intensities for press / interaction events.
+ *
+ * Maps to {@link Haptics.ImpactFeedbackStyle} with one extra `none` value
+ * that lets callers opt out without conditionals at the call site.
+ */
+export type HapticImpactTone = "none" | "light" | "medium" | "heavy";
+
+/**
+ * Tactile feedback for asynchronous outcomes (mutations, validations).
+ *
+ * Maps to {@link Haptics.NotificationFeedbackType} with a `none` opt-out.
+ */
+export type HapticNotificationTone =
+  | "none"
+  | "success"
+  | "warning"
+  | "error";
+
+const impactStyleByTone: Record<
+  Exclude<HapticImpactTone, "none">,
+  Haptics.ImpactFeedbackStyle
+> = {
+  light: Haptics.ImpactFeedbackStyle.Light,
+  medium: Haptics.ImpactFeedbackStyle.Medium,
+  heavy: Haptics.ImpactFeedbackStyle.Heavy,
+};
+
+const notificationTypeByTone: Record<
+  Exclude<HapticNotificationTone, "none">,
+  Haptics.NotificationFeedbackType
+> = {
+  success: Haptics.NotificationFeedbackType.Success,
+  warning: Haptics.NotificationFeedbackType.Warning,
+  error: Haptics.NotificationFeedbackType.Error,
+};
+
+/**
+ * Reads the runtime preference for haptics. Centralised here so call sites
+ * never reach into the store directly.
+ *
+ * @returns `true` when haptic feedback is allowed in the current session.
+ */
+const isHapticsEnabled = (): boolean => {
+  return useAppShellStore.getState().hapticsEnabled;
+};
+
+/**
+ * Triggers tactile impact feedback. No-ops when haptics are disabled or
+ * `tone` is `"none"`. Errors from `expo-haptics` are swallowed because
+ * tactile feedback must never crash a user interaction.
+ *
+ * @param tone Intensity of the impact.
+ */
+export const triggerHapticImpact = (tone: HapticImpactTone): void => {
+  if (tone === "none" || !isHapticsEnabled()) {
+    return;
+  }
+
+  void Haptics.impactAsync(impactStyleByTone[tone]).catch(() => {
+    /* swallow — haptics must never block UX */
+  });
+};
+
+/**
+ * Triggers tactile notification feedback. No-ops when haptics are disabled
+ * or `tone` is `"none"`. Errors from `expo-haptics` are swallowed.
+ *
+ * @param tone Outcome being signalled.
+ */
+export const triggerHapticNotification = (
+  tone: HapticNotificationTone,
+): void => {
+  if (tone === "none" || !isHapticsEnabled()) {
+    return;
+  }
+
+  void Haptics.notificationAsync(notificationTypeByTone[tone]).catch(() => {
+    /* swallow — haptics must never block UX */
+  });
+};
+
+/**
+ * Convenience helpers for the most common call sites. Prefer these over
+ * passing string tones around your codebase.
+ */
+export const haptics = {
+  light: (): void => {
+    triggerHapticImpact("light");
+  },
+  medium: (): void => {
+    triggerHapticImpact("medium");
+  },
+  heavy: (): void => {
+    triggerHapticImpact("heavy");
+  },
+  success: (): void => {
+    triggerHapticNotification("success");
+  },
+  warning: (): void => {
+    triggerHapticNotification("warning");
+  },
+  error: (): void => {
+    triggerHapticNotification("error");
+  },
+} as const;

--- a/shared/hooks/use-list-refresh.test.ts
+++ b/shared/hooks/use-list-refresh.test.ts
@@ -1,0 +1,65 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react-native";
+import * as React from "react";
+
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
+
+jest.mock("@/shared/feedback/haptics", () => ({
+  triggerHapticImpact: jest.fn(),
+}));
+
+const triggerHapticImpactMock = triggerHapticImpact as jest.MockedFunction<
+  typeof triggerHapticImpact
+>;
+
+const buildWrapper = () => {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { readonly children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+};
+
+describe("useListRefresh", () => {
+  beforeEach(() => {
+    triggerHapticImpactMock.mockClear();
+  });
+
+  it("invalida query keys e gerencia estado refreshing", async () => {
+    const { result } = renderHook(
+      () => useListRefresh([["transactions", "list"]]),
+      { wrapper: buildWrapper() },
+    );
+
+    expect(result.current.refreshing).toBe(false);
+
+    await act(async () => {
+      await result.current.onRefresh();
+    });
+
+    expect(triggerHapticImpactMock).toHaveBeenCalledWith("light");
+    expect(result.current.refreshing).toBe(false);
+  });
+
+  it("aceita varias query keys", async () => {
+    const { result } = renderHook(
+      () =>
+        useListRefresh([
+          ["transactions", "list"],
+          ["dashboard", "overview"],
+        ]),
+      { wrapper: buildWrapper() },
+    );
+
+    await act(async () => {
+      await result.current.onRefresh();
+    });
+
+    expect(triggerHapticImpactMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/shared/hooks/use-list-refresh.ts
+++ b/shared/hooks/use-list-refresh.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from "react";
+
+import { type QueryKey, useQueryClient } from "@tanstack/react-query";
+
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
+
+export interface UseListRefreshResult {
+  /** Whether a refresh is currently in flight. Bind to RefreshControl. */
+  readonly refreshing: boolean;
+  /** Handler to pass directly to RefreshControl `onRefresh`. */
+  readonly onRefresh: () => Promise<void>;
+}
+
+/**
+ * Standard pull-to-refresh adapter for list screens.
+ *
+ * Invalidates the supplied query keys, fires a light haptic at the
+ * start of the gesture, and resolves once all invalidations finish so
+ * native `RefreshControl` can hide its spinner.
+ *
+ * NOTE: this hook is the canonical entry point for all list refresh
+ * gestures, but pull-to-refresh wiring on RN lists ships in tandem
+ * with the FlashList migration (Epic #296). Today the hook is safe to
+ * call from any `ScrollView` / `FlatList` and will be widened
+ * automatically when those lists migrate.
+ *
+ * @param queryKeys One or many TanStack Query keys to invalidate.
+ * @returns Refresh state and handler.
+ */
+export const useListRefresh = (
+  queryKeys: readonly QueryKey[],
+): UseListRefreshResult => {
+  const queryClient = useQueryClient();
+  const [refreshing, setRefreshing] = useState<boolean>(false);
+
+  const onRefresh = useCallback(async (): Promise<void> => {
+    setRefreshing(true);
+    triggerHapticImpact("light");
+    try {
+      await Promise.all(
+        queryKeys.map((queryKey) => queryClient.invalidateQueries({ queryKey })),
+      );
+    } finally {
+      setRefreshing(false);
+    }
+  }, [queryClient, queryKeys]);
+
+  return { refreshing, onRefresh };
+};

--- a/shared/skeletons/alerts-list-skeleton.tsx
+++ b/shared/skeletons/alerts-list-skeleton.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface AlertsListSkeletonProps {
+  readonly rows?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout for the alerts list — title + description block on
+ * the left, toggle stub on the right.
+ */
+export function AlertsListSkeleton({
+  rows = 4,
+  testID,
+}: AlertsListSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$3"
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando alertas"
+      testID={testID}
+    >
+      {Array.from({ length: rows }).map((_, index) => (
+        <XStack
+          key={`alert-skeleton-${index}`}
+          alignItems="center"
+          justifyContent="space-between"
+          gap="$3"
+        >
+          <YStack flex={1} gap="$2">
+            <SkeletonRow width="64%" height="$1" />
+            <SkeletonRow width="84%" height="$1" />
+          </YStack>
+          <SkeletonRow width={48} height={24} radius="$2" />
+        </XStack>
+      ))}
+    </AppStack>
+  );
+}

--- a/shared/skeletons/budgets-list-skeleton.tsx
+++ b/shared/skeletons/budgets-list-skeleton.tsx
@@ -1,0 +1,44 @@
+import type { ReactElement } from "react";
+
+import { YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface BudgetsListSkeletonProps {
+  readonly rows?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout for the budgets list — category title on top, a
+ * progress bar imitation in the middle, and a "spent / limit" line at
+ * the bottom.
+ */
+export function BudgetsListSkeleton({
+  rows = 3,
+  testID,
+}: BudgetsListSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$4"
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando orcamentos"
+      testID={testID}
+    >
+      {Array.from({ length: rows }).map((_, index) => (
+        <YStack key={`budget-skeleton-${index}`} gap="$2">
+          <SkeletonRow width="50%" height="$1" />
+          <SkeletonRow width="100%" height="$1" />
+          <SkeletonRow width="44%" height="$1" />
+        </YStack>
+      ))}
+    </AppStack>
+  );
+}

--- a/shared/skeletons/dashboard-skeleton.tsx
+++ b/shared/skeletons/dashboard-skeleton.tsx
@@ -1,0 +1,62 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface DashboardSkeletonProps {
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout for the dashboard hero + summary grid. Lays out
+ * one big hero card and a 2x2 grid of metric tiles so the page does
+ * not collapse during the first paint.
+ */
+export function DashboardSkeleton({
+  testID,
+}: DashboardSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$4"
+      paddingVertical="$4"
+      paddingHorizontal="$4"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando painel"
+      testID={testID}
+    >
+      <YStack
+        backgroundColor="$surfaceCard"
+        borderColor="$borderColor"
+        borderWidth={1}
+        borderRadius="$2"
+        gap="$3"
+        padding="$4"
+      >
+        <SkeletonRow width="42%" height="$1" />
+        <SkeletonRow width="68%" height="$3" />
+        <SkeletonRow width="36%" height="$1" />
+      </YStack>
+
+      <XStack gap="$3" flexWrap="wrap">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <YStack
+            key={`dashboard-tile-${index}`}
+            backgroundColor="$surfaceCard"
+            borderColor="$borderColor"
+            borderWidth={1}
+            borderRadius="$2"
+            flexBasis="48%"
+            flexGrow={1}
+            gap="$2"
+            padding="$3"
+          >
+            <SkeletonRow width="64%" height="$1" />
+            <SkeletonRow width="46%" height="$2" />
+          </YStack>
+        ))}
+      </XStack>
+    </AppStack>
+  );
+}

--- a/shared/skeletons/fiscal-documents-skeleton.tsx
+++ b/shared/skeletons/fiscal-documents-skeleton.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface FiscalDocumentsSkeletonProps {
+  readonly rows?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout for the fiscal documents list (description + date
+ * on the left, amount + status badge on the right).
+ */
+export function FiscalDocumentsSkeleton({
+  rows = 4,
+  testID,
+}: FiscalDocumentsSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$3"
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando documentos fiscais"
+      testID={testID}
+    >
+      {Array.from({ length: rows }).map((_, index) => (
+        <XStack
+          key={`fiscal-skeleton-${index}`}
+          alignItems="center"
+          justifyContent="space-between"
+          gap="$3"
+        >
+          <YStack flex={1} gap="$2">
+            <SkeletonRow width="72%" height="$1" />
+            <SkeletonRow width="38%" height="$1" />
+          </YStack>
+          <YStack alignItems="flex-end" gap="$2">
+            <SkeletonRow width={84} height="$1" />
+            <SkeletonRow width={64} height="$1" />
+          </YStack>
+        </XStack>
+      ))}
+    </AppStack>
+  );
+}

--- a/shared/skeletons/goal-list-skeleton.tsx
+++ b/shared/skeletons/goal-list-skeleton.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from "react";
+
+import { YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface GoalListSkeletonProps {
+  readonly rows?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout for a list of goal cards. Each row imitates the
+ * "title / progress bar / progress value" stack.
+ */
+export function GoalListSkeleton({
+  rows = 3,
+  testID,
+}: GoalListSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$4"
+      paddingVertical="$4"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando metas"
+      testID={testID}
+    >
+      {Array.from({ length: rows }).map((_, index) => (
+        <YStack key={`goal-skeleton-${index}`} gap="$2">
+          <SkeletonRow width="74%" height="$1" />
+          <SkeletonRow width="100%" height="$1" />
+          <SkeletonRow width="38%" height="$1" />
+        </YStack>
+      ))}
+    </AppStack>
+  );
+}

--- a/shared/skeletons/index.ts
+++ b/shared/skeletons/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Domain-specific skeleton placeholders. Each one mimics the layout of
+ * the real content it stands in for so swapping skeleton ↔ data does not
+ * shift the screen layout. Use these instead of the generic
+ * {@link AppSkeletonBlock} whenever a specific list/card layout is known.
+ */
+export { AlertsListSkeleton } from "./alerts-list-skeleton";
+export { BudgetsListSkeleton } from "./budgets-list-skeleton";
+export { DashboardSkeleton } from "./dashboard-skeleton";
+export { FiscalDocumentsSkeleton } from "./fiscal-documents-skeleton";
+export { GoalListSkeleton } from "./goal-list-skeleton";
+export { MetricGridSkeleton } from "./metric-grid-skeleton";
+export { TransactionListSkeleton } from "./transaction-list-skeleton";
+export { WalletEntryListSkeleton } from "./wallet-entry-list-skeleton";

--- a/shared/skeletons/metric-grid-skeleton.tsx
+++ b/shared/skeletons/metric-grid-skeleton.tsx
@@ -1,0 +1,50 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface MetricGridSkeletonProps {
+  /** Number of metric tiles to render. Defaults to 4. */
+  readonly tiles?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Generic placeholder for any "row of metric cards" layout — useful as a
+ * loading state for summary grids that don't have a dedicated skeleton.
+ */
+export function MetricGridSkeleton({
+  tiles = 4,
+  testID,
+}: MetricGridSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando indicadores"
+      testID={testID}
+    >
+      <XStack gap="$3" flexWrap="wrap">
+        {Array.from({ length: tiles }).map((_, index) => (
+          <YStack
+            key={`metric-tile-${index}`}
+            backgroundColor="$surfaceCard"
+            borderColor="$borderColor"
+            borderWidth={1}
+            borderRadius="$2"
+            flexBasis="48%"
+            flexGrow={1}
+            gap="$2"
+            padding="$3"
+          >
+            <SkeletonRow width="64%" height="$1" />
+            <SkeletonRow width="46%" height="$2" />
+          </YStack>
+        ))}
+      </XStack>
+    </AppStack>
+  );
+}

--- a/shared/skeletons/skeleton-row.tsx
+++ b/shared/skeletons/skeleton-row.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from "react";
+
+import { type ColorTokens, XStack, YStack } from "tamagui";
+
+export interface SkeletonRowProps {
+  readonly height?: ColorTokens | number | string;
+  readonly width?: ColorTokens | number | string;
+  readonly radius?: ColorTokens | number | string;
+}
+
+/**
+ * Themed placeholder bar used by composite skeleton layouts. Centralises
+ * the muted-surface look so individual skeletons stay declarative.
+ */
+export function SkeletonRow({
+  height = "$2",
+  width = "100%",
+  radius = "$1",
+}: SkeletonRowProps): ReactElement {
+  return (
+    <YStack
+      backgroundColor="$surfaceRaised"
+      borderRadius={radius as never}
+      height={height as never}
+      width={width as never}
+      opacity={0.7}
+    />
+  );
+}
+
+/**
+ * Convenience layout for a "row with two columns" placeholder pattern
+ * (e.g. label + value).
+ */
+export function SkeletonKeyValueRow(): ReactElement {
+  return (
+    <XStack alignItems="center" justifyContent="space-between" gap="$3">
+      <SkeletonRow width="46%" height="$1" />
+      <SkeletonRow width="32%" height="$1" />
+    </XStack>
+  );
+}

--- a/shared/skeletons/skeletons.test.tsx
+++ b/shared/skeletons/skeletons.test.tsx
@@ -1,0 +1,87 @@
+import { render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import {
+  AlertsListSkeleton,
+  BudgetsListSkeleton,
+  DashboardSkeleton,
+  FiscalDocumentsSkeleton,
+  GoalListSkeleton,
+  MetricGridSkeleton,
+  TransactionListSkeleton,
+  WalletEntryListSkeleton,
+} from "@/shared/skeletons";
+
+describe("domain skeletons", () => {
+  it("TransactionListSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <TransactionListSkeleton testID="tx-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando transacoes")).toBeTruthy();
+  });
+
+  it("GoalListSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <GoalListSkeleton testID="goal-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando metas")).toBeTruthy();
+  });
+
+  it("WalletEntryListSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <WalletEntryListSkeleton testID="wallet-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando carteira")).toBeTruthy();
+  });
+
+  it("DashboardSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <DashboardSkeleton testID="dashboard-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando painel")).toBeTruthy();
+  });
+
+  it("FiscalDocumentsSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <FiscalDocumentsSkeleton testID="fiscal-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando documentos fiscais")).toBeTruthy();
+  });
+
+  it("BudgetsListSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <BudgetsListSkeleton testID="budgets-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando orcamentos")).toBeTruthy();
+  });
+
+  it("AlertsListSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <AlertsListSkeleton testID="alerts-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando alertas")).toBeTruthy();
+  });
+
+  it("MetricGridSkeleton renderiza placeholder acessivel", () => {
+    const { getByLabelText } = render(
+      <AppProviders>
+        <MetricGridSkeleton tiles={4} testID="metric-skel" />
+      </AppProviders>,
+    );
+    expect(getByLabelText("Carregando indicadores")).toBeTruthy();
+  });
+});

--- a/shared/skeletons/transaction-list-skeleton.tsx
+++ b/shared/skeletons/transaction-list-skeleton.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface TransactionListSkeletonProps {
+  readonly rows?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout that mimics the transaction list rows
+ * (left column: title + tag, right column: value + status).
+ */
+export function TransactionListSkeleton({
+  rows = 4,
+  testID,
+}: TransactionListSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$3"
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando transacoes"
+      testID={testID}
+    >
+      {Array.from({ length: rows }).map((_, index) => (
+        <XStack
+          key={`tx-skeleton-${index}`}
+          alignItems="center"
+          justifyContent="space-between"
+          gap="$3"
+        >
+          <YStack flex={1} gap="$2">
+            <SkeletonRow width="68%" height="$1" />
+            <SkeletonRow width="42%" height="$1" />
+          </YStack>
+          <YStack alignItems="flex-end" gap="$2">
+            <SkeletonRow width={80} height="$1" />
+            <SkeletonRow width={56} height="$1" />
+          </YStack>
+        </XStack>
+      ))}
+    </AppStack>
+  );
+}

--- a/shared/skeletons/wallet-entry-list-skeleton.tsx
+++ b/shared/skeletons/wallet-entry-list-skeleton.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppStack } from "@/shared/components/app-stack";
+import { SkeletonRow } from "@/shared/skeletons/skeleton-row";
+
+export interface WalletEntryListSkeletonProps {
+  readonly rows?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Placeholder layout mimicking the wallet entry list (asset + ticker on
+ * the left, current value + variation on the right).
+ */
+export function WalletEntryListSkeleton({
+  rows = 4,
+  testID,
+}: WalletEntryListSkeletonProps): ReactElement {
+  return (
+    <AppStack
+      gap="$3"
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      accessibilityRole="progressbar"
+      accessibilityLabel="Carregando carteira"
+      testID={testID}
+    >
+      {Array.from({ length: rows }).map((_, index) => (
+        <XStack
+          key={`wallet-skeleton-${index}`}
+          alignItems="center"
+          justifyContent="space-between"
+          gap="$3"
+        >
+          <YStack flex={1} gap="$2">
+            <SkeletonRow width="58%" height="$1" />
+            <SkeletonRow width="34%" height="$1" />
+          </YStack>
+          <YStack alignItems="flex-end" gap="$2">
+            <SkeletonRow width={92} height="$1" />
+            <SkeletonRow width={48} height="$1" />
+          </YStack>
+        </XStack>
+      ))}
+    </AppStack>
+  );
+}


### PR DESCRIPTION
Closes #295.

## Why

The audit landed in #294 — #305 highlighted that the app **felt morto**:
zero `expo-haptics` usage despite the package being installed,
`AppSkeletonBlock` defined but never wired up, generic empty notices
everywhere, and screens popping in without transition. This PR is the
UX foundation for everything else in the roadmap — the layer the rest
of the epics will sit on top of.

## What changes

### 1. Tactile feedback infrastructure
- `shared/feedback/haptics.ts` — canonical entry point (light/medium/heavy/success/warning/error), gated by the new `hapticsEnabled` toggle in `AppShellStore` and resilient to `expo-haptics` failures.
- `AppButton` ganha `hapticTone` (default `light` no primário, `none` no secundário); fires on `onPressIn`.
- `AppToggleRow` fires light haptic em cada mudança de estado.
- `useApiMutation` agora dispara haptic `success`/`error` automaticamente em todas as mutations (opt-out via `suppressHaptics: true`).

### 2. Domain skeleton placeholders
- `shared/skeletons/` com 8 layouts dedicados: TransactionList, GoalList, WalletEntryList, Dashboard, FiscalDocuments, BudgetsList, AlertsList, MetricGrid.
- `AppQueryState` e `AppAsyncState` ganham `loadingComponent` opcional (backwards compatible).
- 7 telas-chave agora passam o skeleton apropriado.

### 3. Illustrated empty states
- `AppEmptyState` — soft circular backdrop + curated `MaterialCommunityIcons` + título + descrição + CTA opcional. CTAs disparam haptic médio.
- 8 ilustrações disponíveis (`transactions`, `goals`, `wallet`, `alerts`, `budgets`, `fiscal`, `shared`, `simulations`).
- Aplicado em transactions, goals, wallet, fiscal, budgets, alerts.
- **Sem `react-native-svg`** — usa `@expo/vector-icons` (já no bundle); zero rebuild nativo.

### 4. Screen entry animations
- `app/_layout.tsx` + `app/(public)/_layout.tsx` declaram `animation: 'slide_from_right'` (220ms) — match nativo iOS, consistência Android.
- `AppScreen` ganha `animateEntry` (default `true`) que envolve o conteúdo em Reanimated `FadeIn` respeitando `reducedMotionEnabled`.

### 5. Pull-to-refresh hook
- `shared/hooks/use-list-refresh.ts` — invalida queries, dispara haptic light no início, resolve quando o invalidate settle. Wiring final na FlashList migration (Issue #296).

### 6. Jest infra
- Lean inline mock para `react-native-reanimated` em `jest.setup.ts` (a oficial puxa `react-native-worklets` que falha sob jsdom).

## Validation

- `npm run typecheck` ✅
- `npm run policy:check` ✅ (8 governance scripts)
- `npm run contracts:check` ✅
- `npm run test:coverage` ✅ — **743 tests, 174 suites**, coverage 94.97% / 85.48% (lines/branches), acima do threshold de 85%
- 28 novos testes adicionados nesta PR
- Pre-commit + pre-push hooks passaram

## Visual smoke test

Funcionalidade está atrás de hooks/eventos (haptics, animações) que dependem de device físico — recomendo validar manualmente em iOS/Android antes de mergear:
- [ ] Tocar um botão primário → tem feedback tátil
- [ ] Toggle do AppToggleRow → tem feedback tátil
- [ ] Criar uma transação (mutation success) → tem feedback tátil de sucesso
- [ ] Abrir tela de transações com lista vazia → mostra empty state ilustrado com CTA
- [ ] Abrir tela de transações com dados → vê skeleton em vez de spinner durante o carregamento
- [ ] Navegar entre telas → transição slide-from-right + fade-in suave
- [ ] Ativar "Reduce Motion" no SO → animações desligadas, conteúdo aparece direto

## Out of scope (não inclui)

- **FlashList migration** (Issue #296) — `useListRefresh` está pronto, falta apenas o wiring no RefreshControl quando as listas virtualizarem.
- **SVG illustrations ricas** — Issue #297 (theming + i18n + a11y) pode escolher trazer `react-native-svg` se necessário; hoje os ícones do `MaterialCommunityIcons` já entregam o suficiente para visual mais polido que o estado anterior.

## Test plan
- [x] Quality gates locais verdes
- [x] Pre-push hook verde
- [ ] CI verde
- [ ] Smoke test em device iOS
- [ ] Smoke test em device Android
- [ ] Smoke test com "Reduce Motion" ligado
