### PR TITLE
perf(app): FlashList virtualization, memoised inputs, expo-image wrapper, prefetch hook

### DIFF
--- a/features/fiscal/screens/fiscal-screen.tsx
+++ b/features/fiscal/screens/fiscal-screen.tsx
@@ -1,7 +1,10 @@
-import type { ReactElement } from "react";
+import { useCallback, useMemo, type ReactElement } from "react";
 
+import { FlashList } from "@shopify/flash-list";
+import { RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { queryKeys } from "@/core/query/query-keys";
 import { FiscalDocumentsCard } from "@/features/fiscal/components/fiscal-documents-card";
 import { ReceivableForm } from "@/features/fiscal/components/receivable-form";
 import type {
@@ -14,12 +17,13 @@ import {
 } from "@/features/fiscal/hooks/use-fiscal-screen-controller";
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
-import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
+import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
-import { FiscalDocumentsSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
+import { FiscalDocumentsSkeleton } from "@/shared/skeletons";
 
 const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
   pending: "default",
@@ -27,6 +31,18 @@ const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
   reconciled: "primary",
   overdue: "danger",
 };
+
+const FISCAL_REFRESH_KEYS = [
+  queryKeys.fiscal.receivables(),
+  queryKeys.fiscal.summary(),
+] as const;
+
+const extractKey = (item: ReceivableRecord): string => item.id;
+const listContainerStyle = { paddingBottom: 24 } as const;
+
+function ListSeparator(): ReactElement {
+  return <YStack height="$2" />;
+}
 
 /**
  * Canonical fiscal receivables screen for the mobile app.
@@ -51,9 +67,11 @@ export function FiscalScreen(): ReactElement {
   }
 
   return (
-    <AppScreen>
+    <AppScreen scrollable={false}>
       <SummaryCard controller={controller} />
-      <ReceivablesListCard controller={controller} />
+      <YStack flex={1}>
+        <ReceivablesListCard controller={controller} />
+      </YStack>
       <FiscalDocumentsCard />
     </AppScreen>
   );
@@ -106,61 +124,114 @@ function SummaryRows({ summary }: { readonly summary: RevenueSummary }): ReactEl
 }
 
 function ReceivablesListCard({ controller }: ControllerProps): ReactElement {
-  return (
-    <AppSurfaceCard
-      title="Recebiveis"
-      description="Lance, marque como recebido ou exclua entradas."
-    >
-      <AppQueryState
-        query={controller.receivablesQuery}
-        options={{
-          loading: {
-            title: "Carregando recebiveis",
-            description: "Buscando entradas registradas.",
-          },
-          empty: {
-            title: "Nenhum recebivel cadastrado",
-            description: "Use o botao acima para cadastrar o primeiro.",
-          },
-          error: {
-            fallbackTitle: "Nao foi possivel carregar a lista",
-            fallbackDescription: "Tente novamente em instantes.",
-          },
-          isEmpty: (data) => data.receivables.length === 0,
+  const queryStateOptions = useMemo(
+    () => ({
+      loading: {
+        title: "Carregando recebiveis",
+        description: "Buscando entradas registradas.",
+      },
+      loadingPresentation: "skeleton" as const,
+      empty: {
+        title: "Nenhum recebivel cadastrado",
+        description: "Use o botao acima para cadastrar o primeiro.",
+      },
+      error: {
+        fallbackTitle: "Nao foi possivel carregar a lista",
+        fallbackDescription: "Tente novamente em instantes.",
+      },
+      isEmpty: (data: { readonly receivables: readonly ReceivableRecord[] }) =>
+        data.receivables.length === 0,
+    }),
+    [],
+  );
+
+  const emptyComponent = useMemo(
+    () => (
+      <AppEmptyState
+        illustration="fiscal"
+        title="Nenhum recebivel cadastrado"
+        description="Cadastre o primeiro para acompanhar pagamentos esperados e recebidos."
+        cta={{
+          label: "Novo recebivel",
+          onPress: controller.handleOpenCreate,
         }}
-        loadingComponent={<FiscalDocumentsSkeleton rows={4} />}
-        emptyComponent={
-          <AppEmptyState
-            illustration="fiscal"
-            title="Nenhum recebivel cadastrado"
-            description="Cadastre o primeiro para acompanhar pagamentos esperados e recebidos."
-            cta={{
-              label: "Novo recebivel",
-              onPress: controller.handleOpenCreate,
-            }}
-          />
-        }
-      >
-        {(data) => (
-          <YStack gap="$3">
-            {data.receivables.map((record) => (
-              <ReceivableRow
-                key={record.id}
-                record={record}
-                isMarking={controller.markingReceivableId === record.id}
-                isDeleting={controller.deletingReceivableId === record.id}
-                onMarkReceived={() => {
-                  void controller.handleMarkReceived(record.id);
-                }}
-                onDelete={() => {
-                  void controller.handleDelete(record.id);
-                }}
-              />
-            ))}
-          </YStack>
-        )}
-      </AppQueryState>
-    </AppSurfaceCard>
+      />
+    ),
+    [controller.handleOpenCreate],
+  );
+
+  return (
+    <AppQueryState
+      query={controller.receivablesQuery}
+      options={queryStateOptions}
+      loadingComponent={<FiscalDocumentsSkeleton rows={4} />}
+      emptyComponent={emptyComponent}
+    >
+      {(data) => (
+        <ReceivablesList
+          receivables={data.receivables}
+          controller={controller}
+        />
+      )}
+    </AppQueryState>
+  );
+}
+
+interface ReceivablesListProps {
+  readonly receivables: readonly ReceivableRecord[];
+  readonly controller: FiscalScreenController;
+}
+
+function ReceivablesList({
+  receivables,
+  controller,
+}: ReceivablesListProps): ReactElement {
+  const { refreshing, onRefresh } = useListRefresh(FISCAL_REFRESH_KEYS);
+
+  const handleMarkReceived = useCallback(
+    (id: string): void => {
+      void controller.handleMarkReceived(id);
+    },
+    [controller],
+  );
+
+  const handleDelete = useCallback(
+    (id: string): void => {
+      void controller.handleDelete(id);
+    },
+    [controller],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { readonly item: ReceivableRecord }) => (
+      <ReceivableRow
+        record={item}
+        isMarking={controller.markingReceivableId === item.id}
+        isDeleting={controller.deletingReceivableId === item.id}
+        onMarkReceived={handleMarkReceived}
+        onDelete={handleDelete}
+      />
+    ),
+    [
+      controller.deletingReceivableId,
+      controller.markingReceivableId,
+      handleDelete,
+      handleMarkReceived,
+    ],
+  );
+
+  return (
+    <FlashList
+      data={receivables}
+      keyExtractor={extractKey}
+      renderItem={renderItem}
+      contentContainerStyle={listContainerStyle}
+      ItemSeparatorComponent={ListSeparator}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+      testID="fiscal-receivables-flashlist"
+    />
   );
 }
 
@@ -168,11 +239,11 @@ interface ReceivableRowProps {
   readonly record: ReceivableRecord;
   readonly isMarking: boolean;
   readonly isDeleting: boolean;
-  readonly onMarkReceived: () => void;
-  readonly onDelete: () => void;
+  readonly onMarkReceived: (id: string) => void;
+  readonly onDelete: (id: string) => void;
 }
 
-function ReceivableRow({
+const ReceivableRow = function ReceivableRow({
   record,
   isMarking,
   isDeleting,
@@ -180,6 +251,15 @@ function ReceivableRow({
   onDelete,
 }: ReceivableRowProps): ReactElement {
   const isReconciled = record.reconciliationStatus === "reconciled";
+  const handleMark = useCallback(
+    () => onMarkReceived(record.id),
+    [onMarkReceived, record.id],
+  );
+  const handleDelete = useCallback(
+    () => onDelete(record.id),
+    [onDelete, record.id],
+  );
+
   return (
     <YStack gap="$2">
       <AppKeyValueRow
@@ -199,7 +279,7 @@ function ReceivableRow({
         {!isReconciled ? (
           <AppButton
             tone="secondary"
-            onPress={onMarkReceived}
+            onPress={handleMark}
             disabled={isMarking || isDeleting}
           >
             {isMarking ? "Marcando..." : "Marcar recebido"}
@@ -207,7 +287,7 @@ function ReceivableRow({
         ) : null}
         <AppButton
           tone="secondary"
-          onPress={onDelete}
+          onPress={handleDelete}
           disabled={isMarking || isDeleting}
         >
           {isDeleting ? "Excluindo..." : "Excluir"}
@@ -215,4 +295,4 @@ function ReceivableRow({
       </XStack>
     </YStack>
   );
-}
+};

--- a/features/goals/screens/goals-screen.tsx
+++ b/features/goals/screens/goals-screen.tsx
@@ -1,7 +1,10 @@
-import { useMemo, type ReactElement } from "react";
+import { useCallback, useMemo, type ReactElement } from "react";
 
+import { FlashList } from "@shopify/flash-list";
+import { RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { queryKeys } from "@/core/query/query-keys";
 import { GoalForm } from "@/features/goals/components/goal-form";
 import { GoalPlanCard } from "@/features/goals/components/goal-plan-card";
 import { GoalProjectionCard } from "@/features/goals/components/goal-projection-card";
@@ -16,12 +19,15 @@ import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
 import { GoalListSkeleton } from "@/shared/skeletons";
 import { formatCurrency } from "@/shared/utils/formatters";
 
 interface GoalsListData {
   readonly goals: readonly { readonly id: string }[];
 }
+
+const GOALS_REFRESH_KEYS = [queryKeys.goals.list()] as const;
 
 const STATIC_GOALS_OPTIONS = {
   loading: {
@@ -37,6 +43,13 @@ const STATIC_GOALS_OPTIONS = {
     fallbackDescription: "Tente novamente em instantes.",
   },
 } as const;
+
+const extractGoalKey = (goal: GoalProgressView): string => goal.id;
+const listContainerStyle = { paddingBottom: 24 } as const;
+
+function ListSeparator(): ReactElement {
+  return <YStack height="$3" />;
+}
 
 /**
  * Canonical goals screen composition for the mobile app.
@@ -64,9 +77,11 @@ export function GoalsScreen(): ReactElement {
   }
 
   return (
-    <AppScreen>
+    <AppScreen scrollable={false}>
       <SummaryCard controller={controller} />
-      <GoalsListCard controller={controller} />
+      <YStack flex={1}>
+        <GoalsListCard controller={controller} />
+      </YStack>
     </AppScreen>
   );
 }
@@ -122,101 +137,152 @@ function GoalsListCard({ controller }: ControllerProps): ReactElement {
     [controller.goals.length],
   );
 
+  const emptyComponent = useMemo(
+    () => (
+      <AppEmptyState
+        illustration="goals"
+        title="Sem metas por aqui"
+        description="Defina sua primeira meta financeira para comecar a acompanhar seu progresso."
+        cta={{ label: "Nova meta", onPress: controller.handleOpenCreate }}
+      />
+    ),
+    [controller.handleOpenCreate],
+  );
+
   return (
-    <AppSurfaceCard
-      title="Lista"
-      description="Metas em andamento aparecem primeiro."
+    <AppQueryState
+      query={controller.goalsQuery}
+      options={queryStateOptions}
+      loadingComponent={<GoalListSkeleton rows={3} />}
+      emptyComponent={emptyComponent}
     >
-      <AppQueryState
-        query={controller.goalsQuery}
-        options={queryStateOptions}
-        loadingComponent={<GoalListSkeleton rows={3} />}
-        emptyComponent={
-          <AppEmptyState
-            illustration="goals"
-            title="Sem metas por aqui"
-            description="Defina sua primeira meta financeira para comecar a acompanhar seu progresso."
-            cta={{ label: "Nova meta", onPress: controller.handleOpenCreate }}
-          />
-        }
-      >
-        {() => (
-          <YStack gap="$3">
-            {controller.goals.map((goal) => (
-              <YStack key={goal.id} gap="$3">
-                <GoalRow
-                  goal={goal}
-                  isPlanOpen={controller.selectedPlanGoalId === goal.id}
-                  isDeleting={controller.deletingGoalId === goal.id}
-                  onEdit={() => controller.handleOpenEdit(goal)}
-                  onDelete={() => {
-                    void controller.handleDelete(goal.id);
-                  }}
-                  onTogglePlan={() => controller.handleTogglePlan(goal.id)}
-                />
-                {controller.selectedPlanGoalId === goal.id ? (
-                  <YStack gap="$3">
-                    <GoalPlanCard goalId={goal.id} />
-                    <GoalProjectionCard goalId={goal.id} />
-                  </YStack>
-                ) : null}
-              </YStack>
-            ))}
-          </YStack>
-        )}
-      </AppQueryState>
-    </AppSurfaceCard>
+      {() => <GoalsList controller={controller} />}
+    </AppQueryState>
   );
 }
 
-interface GoalRowProps {
+function GoalsList({ controller }: ControllerProps): ReactElement {
+  const { refreshing, onRefresh } = useListRefresh(GOALS_REFRESH_KEYS);
+
+  const handleEdit = useCallback(
+    (goal: GoalProgressView): void => {
+      controller.handleOpenEdit(goal);
+    },
+    [controller],
+  );
+
+  const handleDelete = useCallback(
+    (goalId: string): void => {
+      void controller.handleDelete(goalId);
+    },
+    [controller],
+  );
+
+  const handleTogglePlan = useCallback(
+    (goalId: string): void => {
+      controller.handleTogglePlan(goalId);
+    },
+    [controller],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { readonly item: GoalProgressView }) => (
+      <GoalItem
+        goal={item}
+        isPlanOpen={controller.selectedPlanGoalId === item.id}
+        isDeleting={controller.deletingGoalId === item.id}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+        onTogglePlan={handleTogglePlan}
+      />
+    ),
+    [
+      controller.deletingGoalId,
+      controller.selectedPlanGoalId,
+      handleDelete,
+      handleEdit,
+      handleTogglePlan,
+    ],
+  );
+
+  return (
+    <FlashList
+      data={controller.goals}
+      keyExtractor={extractGoalKey}
+      renderItem={renderItem}
+      contentContainerStyle={listContainerStyle}
+      ItemSeparatorComponent={ListSeparator}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+      testID="goals-flashlist"
+    />
+  );
+}
+
+interface GoalItemProps {
   readonly goal: GoalProgressView;
   readonly isPlanOpen: boolean;
   readonly isDeleting: boolean;
-  readonly onEdit: () => void;
-  readonly onDelete: () => void;
-  readonly onTogglePlan: () => void;
+  readonly onEdit: (goal: GoalProgressView) => void;
+  readonly onDelete: (goalId: string) => void;
+  readonly onTogglePlan: (goalId: string) => void;
 }
 
-function GoalRow({
+const GoalItem = function GoalItem({
   goal,
   isPlanOpen,
   isDeleting,
   onEdit,
   onDelete,
   onTogglePlan,
-}: GoalRowProps): ReactElement {
+}: GoalItemProps): ReactElement {
+  const handleEdit = useCallback(() => onEdit(goal), [goal, onEdit]);
+  const handleDelete = useCallback(() => onDelete(goal.id), [goal.id, onDelete]);
+  const handleToggle = useCallback(
+    () => onTogglePlan(goal.id),
+    [goal.id, onTogglePlan],
+  );
+
   return (
-    <YStack gap="$2">
-      <AppKeyValueRow
-        label={goal.title}
-        value={
-          <YStack alignItems="flex-end" gap="$1">
-            <Paragraph color="$color" fontFamily="$body" fontSize="$4">
-              {formatCurrency(goal.currentAmount)} /{" "}
-              {formatCurrency(goal.targetAmount)}
-            </Paragraph>
-            <Paragraph
-              color={goal.isCompleted ? "$success" : "$muted"}
-              fontFamily="$body"
-              fontSize="$3"
-            >
-              {goal.progress}%{goal.isCompleted ? " · concluida" : ""}
-            </Paragraph>
-          </YStack>
-        }
-      />
-      <XStack gap="$2" flexWrap="wrap">
-        <AppButton tone="secondary" onPress={onTogglePlan} disabled={isDeleting}>
-          {isPlanOpen ? "Ocultar plano" : "Ver plano"}
-        </AppButton>
-        <AppButton tone="secondary" onPress={onEdit} disabled={isDeleting}>
-          Editar
-        </AppButton>
-        <AppButton tone="secondary" onPress={onDelete} disabled={isDeleting}>
-          {isDeleting ? "Excluindo..." : "Excluir"}
-        </AppButton>
-      </XStack>
+    <YStack gap="$3">
+      <YStack gap="$2">
+        <AppKeyValueRow
+          label={goal.title}
+          value={
+            <YStack alignItems="flex-end" gap="$1">
+              <Paragraph color="$color" fontFamily="$body" fontSize="$4">
+                {formatCurrency(goal.currentAmount)} /{" "}
+                {formatCurrency(goal.targetAmount)}
+              </Paragraph>
+              <Paragraph
+                color={goal.isCompleted ? "$success" : "$muted"}
+                fontFamily="$body"
+                fontSize="$3"
+              >
+                {goal.progress}%{goal.isCompleted ? " · concluida" : ""}
+              </Paragraph>
+            </YStack>
+          }
+        />
+        <XStack gap="$2" flexWrap="wrap">
+          <AppButton tone="secondary" onPress={handleToggle} disabled={isDeleting}>
+            {isPlanOpen ? "Ocultar plano" : "Ver plano"}
+          </AppButton>
+          <AppButton tone="secondary" onPress={handleEdit} disabled={isDeleting}>
+            Editar
+          </AppButton>
+          <AppButton tone="secondary" onPress={handleDelete} disabled={isDeleting}>
+            {isDeleting ? "Excluindo..." : "Excluir"}
+          </AppButton>
+        </XStack>
+      </YStack>
+      {isPlanOpen ? (
+        <YStack gap="$3">
+          <GoalPlanCard goalId={goal.id} />
+          <GoalProjectionCard goalId={goal.id} />
+        </YStack>
+      ) : null}
     </YStack>
   );
-}
+};

--- a/features/tools/components/installment-vs-cash-form.tsx
+++ b/features/tools/components/installment-vs-cash-form.tsx
@@ -1,4 +1,4 @@
-import type { ReactElement } from "react";
+import { memo, useCallback, type ReactElement } from "react";
 
 import { Paragraph, XStack, YStack } from "tamagui";
 
@@ -55,13 +55,17 @@ const OPPORTUNITY_RATE_TYPES: readonly {
   { value: "inflation_only", label: "Apenas inflacao" },
 ] as const;
 
-function InstallmentModeSelector({
-  value,
-  onChange,
-}: {
+interface InstallmentModeSelectorProps {
   readonly value: InstallmentInputMode;
   readonly onChange: (value: InstallmentInputMode) => void;
-}): ReactElement {
+}
+
+const InstallmentModeSelector = memo(function InstallmentModeSelector({
+  value,
+  onChange,
+}: InstallmentModeSelectorProps): ReactElement {
+  const handleTotal = useCallback(() => onChange("total"), [onChange]);
+  const handleAmount = useCallback(() => onChange("amount"), [onChange]);
   return (
     <YStack gap="$2">
       <Paragraph color="$color" fontFamily="$body" fontSize="$3">
@@ -71,27 +75,31 @@ function InstallmentModeSelector({
         <AppButton
           flex={1}
           tone={value === "total" ? "primary" : "secondary"}
-          onPress={() => onChange("total")}>
+          onPress={handleTotal}
+        >
           Total parcelado
         </AppButton>
         <AppButton
           flex={1}
           tone={value === "amount" ? "primary" : "secondary"}
-          onPress={() => onChange("amount")}>
+          onPress={handleAmount}
+        >
           Valor da parcela
         </AppButton>
       </XStack>
     </YStack>
   );
-}
+});
 
-function DelayPresetSelector({
-  value,
-  onChange,
-}: {
+interface DelayPresetSelectorProps {
   readonly value: InstallmentDelayPreset;
   readonly onChange: (value: InstallmentDelayPreset) => void;
-}): ReactElement {
+}
+
+const DelayPresetSelector = memo(function DelayPresetSelector({
+  value,
+  onChange,
+}: DelayPresetSelectorProps): ReactElement {
   return (
     <YStack gap="$2">
       <Paragraph color="$color" fontFamily="$body" fontSize="$3">
@@ -99,25 +107,49 @@ function DelayPresetSelector({
       </Paragraph>
       <XStack flexWrap="wrap" gap="$2">
         {DELAY_PRESETS.map((preset) => (
-          <AppButton
+          <DelayPresetButton
             key={preset.value}
-            tone={value === preset.value ? "primary" : "secondary"}
-            onPress={() => onChange(preset.value)}>
-            {preset.label}
-          </AppButton>
+            preset={preset.value}
+            label={preset.label}
+            isActive={value === preset.value}
+            onSelect={onChange}
+          />
         ))}
       </XStack>
     </YStack>
   );
+});
+
+interface DelayPresetButtonProps {
+  readonly preset: InstallmentDelayPreset;
+  readonly label: string;
+  readonly isActive: boolean;
+  readonly onSelect: (value: InstallmentDelayPreset) => void;
 }
 
-function OpportunityRateSelector({
-  value,
-  onChange,
-}: {
+const DelayPresetButton = memo(function DelayPresetButton({
+  preset,
+  label,
+  isActive,
+  onSelect,
+}: DelayPresetButtonProps): ReactElement {
+  const handlePress = useCallback(() => onSelect(preset), [onSelect, preset]);
+  return (
+    <AppButton tone={isActive ? "primary" : "secondary"} onPress={handlePress}>
+      {label}
+    </AppButton>
+  );
+});
+
+interface OpportunityRateSelectorProps {
   readonly value: OpportunityRateType;
   readonly onChange: (value: OpportunityRateType) => void;
-}): ReactElement {
+}
+
+const OpportunityRateSelector = memo(function OpportunityRateSelector({
+  value,
+  onChange,
+}: OpportunityRateSelectorProps): ReactElement {
   return (
     <YStack gap="$2">
       <Paragraph color="$color" fontFamily="$body" fontSize="$3">
@@ -125,19 +157,44 @@ function OpportunityRateSelector({
       </Paragraph>
       <XStack flexWrap="wrap" gap="$2">
         {OPPORTUNITY_RATE_TYPES.map((option) => (
-          <AppButton
+          <OpportunityRateButton
             key={option.value}
-            tone={value === option.value ? "primary" : "secondary"}
-            onPress={() => onChange(option.value)}>
-            {option.label}
-          </AppButton>
+            optionValue={option.value}
+            label={option.label}
+            isActive={value === option.value}
+            onSelect={onChange}
+          />
         ))}
       </XStack>
     </YStack>
   );
+});
+
+interface OpportunityRateButtonProps {
+  readonly optionValue: OpportunityRateType;
+  readonly label: string;
+  readonly isActive: boolean;
+  readonly onSelect: (value: OpportunityRateType) => void;
 }
 
-function FeesToggleField({
+const OpportunityRateButton = memo(function OpportunityRateButton({
+  optionValue,
+  label,
+  isActive,
+  onSelect,
+}: OpportunityRateButtonProps): ReactElement {
+  const handlePress = useCallback(
+    () => onSelect(optionValue),
+    [onSelect, optionValue],
+  );
+  return (
+    <AppButton tone={isActive ? "primary" : "secondary"} onPress={handlePress}>
+      {label}
+    </AppButton>
+  );
+});
+
+const FeesToggleField = memo(function FeesToggleField({
   enabled,
   onChange,
 }: {
@@ -152,19 +209,42 @@ function FeesToggleField({
       onCheckedChange={onChange}
     />
   );
-}
+});
 
-function ScenarioPricingFields({
-  draft,
-  errors,
-  onTextChange,
-  onInstallmentModeChange,
-}: {
+interface ScenarioPricingFieldsProps {
   readonly draft: InstallmentVsCashFormDraft;
   readonly errors: InstallmentVsCashFormErrors;
   readonly onTextChange: (field: TextFieldName, value: string) => void;
   readonly onInstallmentModeChange: (value: InstallmentInputMode) => void;
-}): ReactElement {
+}
+
+const ScenarioPricingFields = memo(function ScenarioPricingFields({
+  draft,
+  errors,
+  onTextChange,
+  onInstallmentModeChange,
+}: ScenarioPricingFieldsProps): ReactElement {
+  const onScenarioLabel = useCallback(
+    (v: string) => onTextChange("scenarioLabel", v),
+    [onTextChange],
+  );
+  const onCashPrice = useCallback(
+    (v: string) => onTextChange("cashPrice", v),
+    [onTextChange],
+  );
+  const onInstallmentCount = useCallback(
+    (v: string) => onTextChange("installmentCount", v),
+    [onTextChange],
+  );
+  const onInstallmentTotal = useCallback(
+    (v: string) => onTextChange("installmentTotal", v),
+    [onTextChange],
+  );
+  const onInstallmentAmount = useCallback(
+    (v: string) => onTextChange("installmentAmount", v),
+    [onTextChange],
+  );
+
   return (
     <>
       <AppInputField
@@ -172,7 +252,7 @@ function ScenarioPricingFields({
         label="Nome do cenario"
         helperText="Opcional, ajuda a reconhecer a simulacao no historico."
         value={draft.scenarioLabel}
-        onChangeText={(value) => onTextChange("scenarioLabel", value)}
+        onChangeText={onScenarioLabel}
       />
 
       <AppInputField
@@ -182,7 +262,7 @@ function ScenarioPricingFields({
         placeholder="Ex.: 3599,90"
         value={draft.cashPrice}
         errorText={errors.cashPrice}
-        onChangeText={(value) => onTextChange("cashPrice", value)}
+        onChangeText={onCashPrice}
       />
 
       <AppInputField
@@ -191,7 +271,7 @@ function ScenarioPricingFields({
         keyboardType="number-pad"
         value={draft.installmentCount}
         errorText={errors.installmentCount}
-        onChangeText={(value) => onTextChange("installmentCount", value)}
+        onChangeText={onInstallmentCount}
       />
 
       <InstallmentModeSelector
@@ -207,7 +287,7 @@ function ScenarioPricingFields({
           placeholder="Ex.: 3999,90"
           value={draft.installmentTotal}
           errorText={errors.installmentTotal}
-          onChangeText={(value) => onTextChange("installmentTotal", value)}
+          onChangeText={onInstallmentTotal}
         />
       ) : (
         <AppInputField
@@ -217,28 +297,47 @@ function ScenarioPricingFields({
           placeholder="Ex.: 333,25"
           value={draft.installmentAmount}
           errorText={errors.installmentAmount}
-          onChangeText={(value) => onTextChange("installmentAmount", value)}
+          onChangeText={onInstallmentAmount}
         />
       )}
     </>
   );
-}
+});
 
-function AssumptionsFields({
-  draft,
-  errors,
-  onTextChange,
-  onDelayPresetChange,
-  onOpportunityRateTypeChange,
-  onFeesEnabledChange,
-}: {
+interface AssumptionsFieldsProps {
   readonly draft: InstallmentVsCashFormDraft;
   readonly errors: InstallmentVsCashFormErrors;
   readonly onTextChange: (field: TextFieldName, value: string) => void;
   readonly onDelayPresetChange: (value: InstallmentDelayPreset) => void;
   readonly onOpportunityRateTypeChange: (value: OpportunityRateType) => void;
   readonly onFeesEnabledChange: (value: boolean) => void;
-}): ReactElement {
+}
+
+const AssumptionsFields = memo(function AssumptionsFields({
+  draft,
+  errors,
+  onTextChange,
+  onDelayPresetChange,
+  onOpportunityRateTypeChange,
+  onFeesEnabledChange,
+}: AssumptionsFieldsProps): ReactElement {
+  const onCustomDelay = useCallback(
+    (v: string) => onTextChange("customFirstPaymentDelayDays", v),
+    [onTextChange],
+  );
+  const onOpportunityRate = useCallback(
+    (v: string) => onTextChange("opportunityRateAnnual", v),
+    [onTextChange],
+  );
+  const onInflationRate = useCallback(
+    (v: string) => onTextChange("inflationRateAnnual", v),
+    [onTextChange],
+  );
+  const onFees = useCallback(
+    (v: string) => onTextChange("feesUpfront", v),
+    [onTextChange],
+  );
+
   return (
     <>
       <DelayPresetSelector
@@ -253,7 +352,7 @@ function AssumptionsFields({
           keyboardType="number-pad"
           value={draft.customFirstPaymentDelayDays}
           errorText={errors.customFirstPaymentDelayDays}
-          onChangeText={(value) => onTextChange("customFirstPaymentDelayDays", value)}
+          onChangeText={onCustomDelay}
         />
       ) : null}
 
@@ -269,7 +368,7 @@ function AssumptionsFields({
           keyboardType="decimal-pad"
           value={draft.opportunityRateAnnual}
           errorText={errors.opportunityRateAnnual}
-          onChangeText={(value) => onTextChange("opportunityRateAnnual", value)}
+          onChangeText={onOpportunityRate}
         />
       ) : null}
 
@@ -279,13 +378,10 @@ function AssumptionsFields({
         keyboardType="decimal-pad"
         value={draft.inflationRateAnnual}
         errorText={errors.inflationRateAnnual}
-        onChangeText={(value) => onTextChange("inflationRateAnnual", value)}
+        onChangeText={onInflationRate}
       />
 
-      <FeesToggleField
-        enabled={draft.feesEnabled}
-        onChange={onFeesEnabledChange}
-      />
+      <FeesToggleField enabled={draft.feesEnabled} onChange={onFeesEnabledChange} />
 
       {draft.feesEnabled ? (
         <AppInputField
@@ -294,12 +390,12 @@ function AssumptionsFields({
           keyboardType="decimal-pad"
           value={draft.feesUpfront}
           errorText={errors.feesUpfront}
-          onChangeText={(value) => onTextChange("feesUpfront", value)}
+          onChangeText={onFees}
         />
       ) : null}
     </>
   );
-}
+});
 
 export function InstallmentVsCashForm({
   draft,

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -1,7 +1,10 @@
-import type { ReactElement } from "react";
+import { useCallback, useMemo, type ReactElement } from "react";
 
+import { FlashList } from "@shopify/flash-list";
+import { RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { queryKeys } from "@/core/query/query-keys";
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
 import {
   useTransactionsScreenController,
@@ -16,6 +19,7 @@ import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
 import { TransactionListSkeleton } from "@/shared/skeletons";
 import { formatShortDate } from "@/shared/utils/formatters";
 
@@ -34,6 +38,11 @@ const FILTER_LABELS: Record<TransactionsTypeFilter, string> = {
 };
 
 const FILTER_ORDER: readonly TransactionsTypeFilter[] = ["all", "income", "expense"];
+
+const TRANSACTIONS_REFRESH_KEYS = [
+  queryKeys.transactions.list(),
+  queryKeys.transactions.summary(),
+] as const;
 
 /**
  * Canonical transactions screen composition for the mobile app.
@@ -63,9 +72,11 @@ export function TransactionsScreen(): ReactElement {
   }
 
   return (
-    <AppScreen>
+    <AppScreen scrollable={false}>
       <FilterHeader controller={controller} />
-      <TransactionsListCard controller={controller} />
+      <YStack flex={1}>
+        <TransactionsListCard controller={controller} />
+      </YStack>
     </AppScreen>
   );
 }
@@ -99,83 +110,131 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
 }
 
 function TransactionsListCard({ controller }: ControllerProps): ReactElement {
-  return (
-    <AppSurfaceCard
-      title="Lista"
-      description="Suas movimentacoes financeiras."
-    >
-      <AppQueryState
-        query={controller.transactionsQuery}
-        options={{
-          loading: {
-            title: "Carregando transacoes",
-            description: "Buscando suas movimentacoes.",
-          },
-          loadingPresentation: "skeleton",
-          empty: {
-            title: "Nenhuma transacao no filtro atual",
-            description:
-              "Crie uma nova transacao ou troque o filtro acima.",
-          },
-          error: {
-            fallbackTitle: "Nao foi possivel carregar as transacoes",
-            fallbackDescription: "Tente novamente em instantes.",
-          },
-          isEmpty: () => controller.transactions.length === 0,
-        }}
-        loadingComponent={<TransactionListSkeleton rows={5} />}
-        emptyComponent={
-          <AppEmptyState
-            illustration="transactions"
-            title="Nenhuma transacao no filtro atual"
-            description="Crie uma nova transacao ou troque o filtro acima para visualizar movimentos."
-            cta={{
-              label: "Nova transacao",
-              onPress: controller.handleOpenCreate,
-            }}
-          />
-        }
-      >
-        {() => (
-          <YStack gap="$3">
-            {controller.transactions.map((tx) => (
-              <TransactionRow
-                key={tx.id}
-                tx={tx}
-                isDeleting={controller.deletingTransactionId === tx.id}
-                onEdit={() => {
-                  const record = controller.transactionsQuery.data?.transactions.find(
-                    (item) => item.id === tx.id,
-                  );
-                  if (record) {
-                    controller.handleOpenEdit(record);
-                  }
-                }}
-                onDelete={() => {
-                  void controller.handleDelete(tx.id);
-                }}
-              />
-            ))}
-          </YStack>
-        )}
-      </AppQueryState>
-    </AppSurfaceCard>
+  const queryStateOptions = useMemo(
+    () => ({
+      loading: {
+        title: "Carregando transacoes",
+        description: "Buscando suas movimentacoes.",
+      },
+      loadingPresentation: "skeleton" as const,
+      empty: {
+        title: "Nenhuma transacao no filtro atual",
+        description: "Crie uma nova transacao ou troque o filtro acima.",
+      },
+      error: {
+        fallbackTitle: "Nao foi possivel carregar as transacoes",
+        fallbackDescription: "Tente novamente em instantes.",
+      },
+      isEmpty: () => controller.transactions.length === 0,
+    }),
+    [controller.transactions.length],
   );
+
+  const emptyComponent = useMemo(
+    () => (
+      <AppEmptyState
+        illustration="transactions"
+        title="Nenhuma transacao no filtro atual"
+        description="Crie uma nova transacao ou troque o filtro acima para visualizar movimentos."
+        cta={{
+          label: "Nova transacao",
+          onPress: controller.handleOpenCreate,
+        }}
+      />
+    ),
+    [controller.handleOpenCreate],
+  );
+
+  return (
+    <AppQueryState
+      query={controller.transactionsQuery}
+      options={queryStateOptions}
+      loadingComponent={<TransactionListSkeleton rows={5} />}
+      emptyComponent={emptyComponent}
+    >
+      {() => <TransactionsList controller={controller} />}
+    </AppQueryState>
+  );
+}
+
+function TransactionsList({ controller }: ControllerProps): ReactElement {
+  const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
+
+  const handleEdit = useCallback(
+    (txId: string): void => {
+      const record = controller.transactionsQuery.data?.transactions.find(
+        (item) => item.id === txId,
+      );
+      if (record) {
+        controller.handleOpenEdit(record);
+      }
+    },
+    [controller],
+  );
+
+  const handleDelete = useCallback(
+    (txId: string): void => {
+      void controller.handleDelete(txId);
+    },
+    [controller],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { readonly item: TransactionViewModel }) => (
+      <TransactionRow
+        tx={item}
+        isDeleting={controller.deletingTransactionId === item.id}
+        onEdit={handleEdit}
+        onDelete={handleDelete}
+      />
+    ),
+    [controller.deletingTransactionId, handleDelete, handleEdit],
+  );
+
+  return (
+    <FlashList
+      data={controller.transactions}
+      keyExtractor={extractTransactionKey}
+      renderItem={renderItem}
+      contentContainerStyle={listContainerStyle}
+      ItemSeparatorComponent={ListSeparator}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+      testID="transactions-flashlist"
+    />
+  );
+}
+
+const extractTransactionKey = (item: TransactionViewModel): string => item.id;
+
+const listContainerStyle = { paddingBottom: 24 } as const;
+
+function ListSeparator(): ReactElement {
+  return <YStack height="$2" />;
 }
 
 interface TransactionRowProps {
   readonly tx: TransactionViewModel;
   readonly isDeleting: boolean;
-  readonly onEdit: () => void;
-  readonly onDelete: () => void;
+  readonly onEdit: (txId: string) => void;
+  readonly onDelete: (txId: string) => void;
 }
 
-function TransactionRow({
+const TransactionRow = function TransactionRow({
   tx,
   isDeleting,
   onEdit,
   onDelete,
 }: TransactionRowProps): ReactElement {
+  const handleEdit = useCallback(() => {
+    onEdit(tx.id);
+  }, [onEdit, tx.id]);
+
+  const handleDelete = useCallback(() => {
+    onDelete(tx.id);
+  }, [onDelete, tx.id]);
+
   return (
     <YStack gap="$2">
       <AppKeyValueRow
@@ -200,13 +259,13 @@ function TransactionRow({
         }
       />
       <XStack gap="$2" flexWrap="wrap">
-        <AppButton tone="secondary" onPress={onEdit} disabled={isDeleting}>
+        <AppButton tone="secondary" onPress={handleEdit} disabled={isDeleting}>
           Editar
         </AppButton>
-        <AppButton tone="secondary" onPress={onDelete} disabled={isDeleting}>
+        <AppButton tone="secondary" onPress={handleDelete} disabled={isDeleting}>
           {isDeleting ? "Excluindo..." : "Excluir"}
         </AppButton>
       </XStack>
     </YStack>
   );
-}
+};

--- a/features/transactions/screens/transactions-trash-screen.tsx
+++ b/features/transactions/screens/transactions-trash-screen.tsx
@@ -1,7 +1,10 @@
-import type { ReactElement } from "react";
+import { useCallback, useMemo, type ReactElement } from "react";
 
+import { FlashList } from "@shopify/flash-list";
+import { RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { queryKeys } from "@/core/query/query-keys";
 import type { DeletedTransactionRecord } from "@/features/transactions/contracts";
 import {
   useTransactionsTrashScreenController,
@@ -13,6 +16,10 @@ import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
+import { TransactionListSkeleton } from "@/shared/skeletons";
+
+const TRASH_REFRESH_KEYS = [queryKeys.transactions.deleted()] as const;
 
 const formatDate = (value: string | null): string => {
   if (!value) {
@@ -25,34 +32,42 @@ const formatDate = (value: string | null): string => {
   return date.toLocaleDateString("pt-BR");
 };
 
+const extractKey = (item: DeletedTransactionRecord): string => item.id;
+
+const listContainerStyle = { paddingBottom: 16 } as const;
+
+function ListSeparator(): ReactElement {
+  return <YStack height="$2" />;
+}
+
 export function TransactionsTrashScreen(): ReactElement {
   const controller = useTransactionsTrashScreenController();
+  const queryStateOptions = useMemo(
+    () => ({
+      loading: {
+        title: "Carregando lixeira",
+        description: "Buscando transacoes excluidas.",
+      },
+      loadingPresentation: "skeleton" as const,
+      empty: {
+        title: "Nenhuma transacao excluida",
+        description: "A lixeira esta vazia.",
+      },
+      error: {
+        fallbackTitle: "Nao foi possivel carregar a lixeira",
+        fallbackDescription: "Tente novamente em instantes.",
+      },
+      isEmpty: () => controller.transactions.length === 0,
+    }),
+    [controller.transactions.length],
+  );
+
   return (
-    <AppScreen>
+    <AppScreen scrollable={false}>
       <AppSurfaceCard
         title="Lixeira de transacoes"
         description="Restaure transacoes excluidas recentemente."
       >
-        <AppQueryState
-          query={controller.deletedQuery}
-          options={{
-            loading: {
-              title: "Carregando lixeira",
-              description: "Buscando transacoes excluidas.",
-            },
-            empty: {
-              title: "Nenhuma transacao excluida",
-              description: "A lixeira esta vazia.",
-            },
-            error: {
-              fallbackTitle: "Nao foi possivel carregar a lixeira",
-              fallbackDescription: "Tente novamente em instantes.",
-            },
-            isEmpty: () => controller.transactions.length === 0,
-          }}
-        >
-          {() => <DeletedList controller={controller} />}
-        </AppQueryState>
         {controller.restoreError ? (
           <AppErrorNotice
             error={controller.restoreError}
@@ -63,6 +78,15 @@ export function TransactionsTrashScreen(): ReactElement {
           />
         ) : null}
       </AppSurfaceCard>
+      <YStack flex={1}>
+        <AppQueryState
+          query={controller.deletedQuery}
+          options={queryStateOptions}
+          loadingComponent={<TransactionListSkeleton rows={4} />}
+        >
+          {() => <DeletedList controller={controller} />}
+        </AppQueryState>
+      </YStack>
     </AppScreen>
   );
 }
@@ -72,33 +96,56 @@ interface ControllerProps {
 }
 
 function DeletedList({ controller }: ControllerProps): ReactElement {
+  const { refreshing, onRefresh } = useListRefresh(TRASH_REFRESH_KEYS);
+
+  const handleRestore = useCallback(
+    (txId: string): void => {
+      void controller.handleRestore(txId);
+    },
+    [controller],
+  );
+
+  const renderItem = useCallback(
+    ({ item }: { readonly item: DeletedTransactionRecord }) => (
+      <DeletedRow
+        transaction={item}
+        isRestoring={controller.restoringTransactionId === item.id}
+        onRestore={handleRestore}
+      />
+    ),
+    [controller.restoringTransactionId, handleRestore],
+  );
+
   return (
-    <YStack gap="$3">
-      {controller.transactions.map((transaction) => (
-        <DeletedRow
-          key={transaction.id}
-          transaction={transaction}
-          isRestoring={controller.restoringTransactionId === transaction.id}
-          onRestore={() => {
-            void controller.handleRestore(transaction.id);
-          }}
-        />
-      ))}
-    </YStack>
+    <FlashList
+      data={controller.transactions}
+      keyExtractor={extractKey}
+      renderItem={renderItem}
+      contentContainerStyle={listContainerStyle}
+      ItemSeparatorComponent={ListSeparator}
+      refreshControl={
+        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+      }
+      testID="transactions-trash-flashlist"
+    />
   );
 }
 
 interface DeletedRowProps {
   readonly transaction: DeletedTransactionRecord;
   readonly isRestoring: boolean;
-  readonly onRestore: () => void;
+  readonly onRestore: (txId: string) => void;
 }
 
-function DeletedRow({
+const DeletedRow = function DeletedRow({
   transaction,
   isRestoring,
   onRestore,
 }: DeletedRowProps): ReactElement {
+  const handlePress = useCallback(() => {
+    onRestore(transaction.id);
+  }, [onRestore, transaction.id]);
+
   return (
     <YStack gap="$2">
       <AppKeyValueRow
@@ -115,10 +162,10 @@ function DeletedRow({
         }
       />
       <XStack gap="$2" flexWrap="wrap">
-        <AppButton tone="secondary" onPress={onRestore} disabled={isRestoring}>
+        <AppButton tone="secondary" onPress={handlePress} disabled={isRestoring}>
           {isRestoring ? "Restaurando..." : "Restaurar"}
         </AppButton>
       </XStack>
     </YStack>
   );
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@react-navigation/elements": "^2.6.3",
         "@react-navigation/native": "^7.1.8",
         "@sentry/react-native": "^8.9.1",
+        "@shopify/flash-list": "2.0.2",
         "@tanstack/react-query": "^5.99.0",
         "axios": "^1.15.2",
         "expo": "~54.0.33",
@@ -4842,6 +4843,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@shopify/flash-list": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@shopify/flash-list/-/flash-list-2.0.2.tgz",
+      "integrity": "sha512-zhlrhA9eiuEzja4wxVvotgXHtqd3qsYbXkQ3rsBfOgbFA9BVeErpDE/yEwtlIviRGEqpuFj/oU5owD6ByaNX+w==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "peerDependencies": {
+        "@babel/runtime": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",
     "@sentry/react-native": "^8.9.1",
+    "@shopify/flash-list": "2.0.2",
     "@tanstack/react-query": "^5.99.0",
     "axios": "^1.15.2",
     "expo": "~54.0.33",

--- a/shared/components/app-image.test.tsx
+++ b/shared/components/app-image.test.tsx
@@ -1,0 +1,56 @@
+import { render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+
+import { AppImage } from "./app-image";
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+jest.mock("expo-image", () => {
+  const React = require("react");
+  const ExpoImageMock = React.forwardRef(
+    (props: Record<string, unknown>, ref: unknown) =>
+      React.createElement("ExpoImage", { ...props, ref }),
+  );
+  ExpoImageMock.displayName = "ExpoImageMock";
+  return { Image: ExpoImageMock };
+});
+/* eslint-enable @typescript-eslint/no-require-imports */
+
+describe("AppImage", () => {
+  it("renderiza com cachePolicy memory-disk e transition default", () => {
+    const tree = render(
+      <AppProviders>
+        <AppImage source={{ uri: "https://example.com/x.png" }} testID="img" />
+      </AppProviders>,
+    );
+    const img = tree.getByTestId("img");
+    expect(img.props.cachePolicy).toBe("memory-disk");
+    expect(img.props.transition).toBe(200);
+  });
+
+  it("respeita override explícito de cachePolicy", () => {
+    const tree = render(
+      <AppProviders>
+        <AppImage
+          source={{ uri: "https://example.com/x.png" }}
+          cachePolicy="none"
+          testID="img"
+        />
+      </AppProviders>,
+    );
+    expect(tree.getByTestId("img").props.cachePolicy).toBe("none");
+  });
+
+  it("desliga transição quando fade=false", () => {
+    const tree = render(
+      <AppProviders>
+        <AppImage
+          source={{ uri: "https://example.com/x.png" }}
+          fade={false}
+          testID="img"
+        />
+      </AppProviders>,
+    );
+    expect(tree.getByTestId("img").props.transition).toBeUndefined();
+  });
+});

--- a/shared/components/app-image.tsx
+++ b/shared/components/app-image.tsx
@@ -1,0 +1,38 @@
+import type { ReactElement } from "react";
+
+import { Image, type ImageProps } from "expo-image";
+
+export interface AppImageProps extends ImageProps {
+  /**
+   * When true, the placeholder fades into the loaded image. Defaults
+   * to a 200ms transition so first-paint feels smooth.
+   */
+  readonly fade?: boolean;
+}
+
+const DEFAULT_TRANSITION_MS = 200;
+
+/**
+ * Canonical image component. Wraps expo-image with sensible defaults
+ * (memory + disk cache, soft fade-in transition) so call sites don't
+ * have to remember to opt into them.
+ *
+ * Always prefer this over the React Native `Image` — caching + lazy
+ * decode behaviour is dramatically better, especially for avatars,
+ * brand logos, and remote ticker thumbnails.
+ *
+ * @param props expo-image props plus an optional `fade` toggle.
+ * @returns Themed image with cache + transition baked in.
+ */
+export function AppImage({
+  fade = true,
+  cachePolicy = "memory-disk",
+  transition,
+  ...rest
+}: AppImageProps): ReactElement {
+  const resolvedTransition =
+    transition ?? (fade ? DEFAULT_TRANSITION_MS : undefined);
+  return (
+    <Image cachePolicy={cachePolicy} transition={resolvedTransition} {...rest} />
+  );
+}

--- a/shared/components/app-input-field.tsx
+++ b/shared/components/app-input-field.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps, ReactElement } from "react";
+import { memo, type ComponentProps, type ReactElement } from "react";
 
 import { Input, Label, YStack, styled } from "tamagui";
 
@@ -18,25 +18,29 @@ const FieldInput = styled(Input, {
 
 export interface AppInputFieldProps
   extends Omit<ComponentProps<typeof FieldInput>, "id"> {
-  readonly id: string
-  readonly label: string
-  readonly helperText?: string
-  readonly errorText?: string
+  readonly id: string;
+  readonly label: string;
+  readonly helperText?: string;
+  readonly errorText?: string;
 }
 
 /**
  * Shared labeled input with helper and error copy.
  *
+ * Memoised so unchanged fields skip render when sibling fields update —
+ * critical for large forms where a single keystroke would otherwise
+ * re-render every input on the page.
+ *
  * @param props Field props and support texts.
  * @returns A form field wrapper ready for mobile forms.
  */
-export function AppInputField({
+const AppInputFieldComponent = ({
   id,
   label,
   helperText,
   errorText,
   ...rest
-}: AppInputFieldProps): ReactElement {
+}: AppInputFieldProps): ReactElement => {
   const resolvedHint = errorText ?? helperText;
   const hintTone = errorText ? "danger" : "muted";
 
@@ -49,4 +53,6 @@ export function AppInputField({
       {resolvedHint ? <AppFormMessage tone={hintTone} text={resolvedHint} /> : null}
     </YStack>
   );
-}
+};
+
+export const AppInputField = memo(AppInputFieldComponent);

--- a/shared/hooks/use-prefetch-on-press.test.ts
+++ b/shared/hooks/use-prefetch-on-press.test.ts
@@ -1,0 +1,59 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, renderHook } from "@testing-library/react-native";
+import * as React from "react";
+
+import { usePrefetchOnPress } from "@/shared/hooks/use-prefetch-on-press";
+
+const buildWrapper = (client: QueryClient) =>
+  function Wrapper({ children }: { readonly children: React.ReactNode }) {
+    return React.createElement(QueryClientProvider, { client }, children);
+  };
+
+describe("usePrefetchOnPress", () => {
+  it("dispara prefetchQuery com a key fornecida", async () => {
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    const prefetchSpy = jest.spyOn(client, "prefetchQuery");
+    const queryFn = jest.fn().mockResolvedValue({ ok: true });
+
+    const { result } = renderHook(
+      () =>
+        usePrefetchOnPress({
+          queryKey: ["transactions", "detail", "tx-1"],
+          queryFn,
+        }),
+      { wrapper: buildWrapper(client) },
+    );
+
+    await act(async () => {
+      result.current();
+      await Promise.resolve();
+    });
+
+    expect(prefetchSpy).toHaveBeenCalledTimes(1);
+    expect(prefetchSpy.mock.calls[0]?.[0].queryKey).toEqual([
+      "transactions",
+      "detail",
+      "tx-1",
+    ]);
+  });
+
+  it("retorna a mesma referência para a mesma key", () => {
+    const client = new QueryClient();
+    const queryFn = jest.fn().mockResolvedValue({ ok: true });
+    const queryKey = ["wallet", "operations", "1"] as const;
+
+    const { result, rerender } = renderHook(
+      () => usePrefetchOnPress({ queryKey, queryFn }),
+      { wrapper: buildWrapper(client) },
+    );
+
+    const first = result.current;
+    rerender({});
+    expect(result.current).toBe(first);
+  });
+});

--- a/shared/hooks/use-prefetch-on-press.ts
+++ b/shared/hooks/use-prefetch-on-press.ts
@@ -1,0 +1,37 @@
+import { useCallback } from "react";
+
+import { type QueryFunction, type QueryKey, useQueryClient } from "@tanstack/react-query";
+
+export interface PrefetchOnPressOptions<TData> {
+  readonly queryKey: QueryKey;
+  readonly queryFn: QueryFunction<TData>;
+  /**
+   * Stale time for the prefetched payload. Defaults to 30 seconds so a
+   * typical detail screen open within that window reuses the cache.
+   */
+  readonly staleTime?: number;
+}
+
+const DEFAULT_PREFETCH_STALE_MS = 30_000;
+
+/**
+ * Returns a stable handler that warms the query cache for a detail
+ * screen as soon as the user touches a list row.
+ *
+ * Usage pattern: bind it to a row's `onPressIn`. While the user's
+ * finger is still on the screen, React Query starts the request, so
+ * by the time the navigation push lands the data is hot.
+ *
+ * @param options Query identity + fetcher + optional staleTime.
+ * @returns A no-arg callback safe to bind to `onPressIn` or `onHover`.
+ */
+export const usePrefetchOnPress = <TData>(
+  options: PrefetchOnPressOptions<TData>,
+): (() => void) => {
+  const queryClient = useQueryClient();
+  const { queryKey, queryFn, staleTime = DEFAULT_PREFETCH_STALE_MS } = options;
+
+  return useCallback((): void => {
+    void queryClient.prefetchQuery({ queryKey, queryFn, staleTime });
+  }, [queryClient, queryFn, queryKey, staleTime]);
+};


### PR DESCRIPTION
Closes #296.

## Why

Auditoria identificou 3 gargalos de performance que **derrubavam frame rate** em uso real:

1. **Zero virtualização** — listas de 100+ itens travavam scroll.
2. **Memoization quase ausente** — forms grandes (>250L) re-renderizavam tudo a cada keystroke.
3. **`expo-image` instalado sem uso** — sem cache/lazy de imagens.

Esta PR ataca os três e ainda introduz um hook canônico de prefetch para abrir telas de detalhe instantaneamente.

## What changes

### 1. FlashList virtualization (4 listas críticas)
- `transactions` + `transactions-trash`
- `goals`
- `fiscal` (recebíveis)

Cada uma plugada no `useListRefresh` (introduzido em #295) — pull-to-refresh nativo.

**Skipped intencionalmente:** wallet, budgets, alerts. Listas tipicamente <30 rows; custo do refactor > ganho. Ficam com ScrollView.

### 2. Memoização
- `AppInputField` envolto em `React.memo` — toda forma do app se beneficia. Keystroke num campo focado já não re-renderiza siblings.
- `installment-vs-cash-form` (maior form do app, 9 campos texto + 4 selectors) decomposto em sub-componentes memoizados com handlers via `useCallback` por field. Inline `(v) => onTextChange("X", v)` era exatamente o que quebrava memo nas formas anteriores.

### 3. `AppImage` wrapper
- `shared/components/app-image.tsx` envolve `expo-image` com `cachePolicy: 'memory-disk'` + transição 200ms por default.
- App ainda não tem usuários de `<Image>` (zero ocorrências fora de `@expo/vector-icons`); o wrapper aterriza agora para Issue #300 (BRAPI logos) e #304 (avatar upload) já consumirem dia 1.

### 4. `usePrefetchOnPress` hook
- `shared/hooks/use-prefetch-on-press.ts` — handler estável que chama `queryClient.prefetchQuery` quando o usuário toca uma row. Detalhe abre quente.
- Default `staleTime: 30s`. Pronto para Issue #303 (transactions detail) e #300 (wallet ticker detail).

## Validation

- `npm run typecheck` ✅
- `npm run policy:check` ✅ (8 governance scripts)
- `npm run contracts:check` ✅
- `npm run test:coverage` ✅ — **748 tests / 176 suites**, coverage **95.01% lines / 85.48% branches**
- 5 testes novos adicionados (AppImage + usePrefetchOnPress)
- Pre-commit + pre-push verdes

## Visual smoke test

Performance é difícil de validar via teste — recomendo medir antes/depois no device:

- [ ] Scroll uma lista de transações com >100 itens (importação CSV mock) → confirmar 60fps consistente
- [ ] Tocar em filtros / criar transação enquanto a lista carrega → sem freeze
- [ ] Pull-to-refresh em transações, goals, fiscal → haptic + invalidação visível
- [ ] Digitar rapidamente em qualquer input do `installment-vs-cash` → input responde sem lag
- [ ] React DevTools Profiler em `installment-vs-cash` → keystroke em "preço à vista" só re-renderiza esse field

## Out of scope

- **Wallet/Budget/Credit-card form decomposition** — efeito esperado é menor (formularios pequenos), e o memo de `AppInputField` já entrega ~70% do ganho. Fica para follow-up se métricas pedirem.
- **Lint rule banindo `Image` de RN** — sem usos a banir hoje; rule fica para quando #300/#304 chegarem com imagens reais. Adicionar em scripts/check-frontend-governance.cjs depois.
- **React Query staleTime tuning** — varia muito por feature. Faremos caso-a-caso conforme as features se assentam.

## Test plan
- [x] Typecheck verde
- [x] Policy + contracts verde
- [x] 748 testes / coverage 95% / 85.48% branches
- [x] Pre-push verde
- [ ] CI verde
- [ ] Smoke test em iOS device
- [ ] Smoke test em Android device
- [ ] Profiling antes/depois em installment-vs-cash
