### PR TITLE
security(app): deep link allowlist logging, rotateTokens contract, biometric lock toggle

### DIFF
--- a/core/navigation/deep-linking.ts
+++ b/core/navigation/deep-linking.ts
@@ -5,6 +5,7 @@ import {
   type AppRoute,
   type PrivateAppRoute,
 } from "@/core/navigation/routes";
+import { navigationLogger } from "@/core/telemetry/domain-loggers";
 import { appRuntimeConfig } from "@/shared/config/runtime";
 
 export type CheckoutReturnStatus =
@@ -152,35 +153,64 @@ const buildCheckoutReturnIntent = (
   };
 };
 
+/**
+ * Parses an external URL into a typed `AppLinkIntent` that the
+ * navigation layer can act on safely.
+ *
+ * Allowlist contract: a URL is only resolved when its pathname matches
+ * one of the registered private or public routes (or a known checkout
+ * return). Anything outside that set returns `null` and emits a
+ * `deeplink.rejected` structured event so security monitoring can see
+ * malicious or stale link attempts. Query parameters with sensitive
+ * keys are always redacted from the logged URL.
+ *
+ * @param rawUrl Raw URL captured from the deep-link / universal-link
+ *               handler, the OS share sheet, or a notification tap.
+ * @returns Parsed intent, or `null` for any URL outside the allowlist.
+ */
 export const parseAppUrl = (rawUrl: string): AppLinkIntent | null => {
+  let url: URL;
   try {
-    const url = new URL(rawUrl);
-    const path = resolveUrlPath(url);
-
-    if (path === appRoutes.root) {
-      return {
-        kind: "route",
-        href: appRoutes.root,
-        rawUrl: sanitizeAppUrl(rawUrl),
-      };
-    }
-
-    if (isCheckoutReturnPath(path)) {
-      return buildCheckoutReturnIntent(rawUrl, path, url.searchParams);
-    }
-
-    if (isPrivateAppRoute(path) || isPublicAppRoute(path)) {
-      return {
-        kind: "route",
-        href: path,
-        rawUrl: sanitizeAppUrl(rawUrl),
-      };
-    }
-
-    return null;
+    url = new URL(rawUrl);
   } catch {
+    navigationLogger.log("navigation.deep_link_parse_failed", {
+      level: "warn",
+      context: { rawUrl: sanitizeAppUrl(rawUrl) },
+    });
     return null;
   }
+
+  const path = resolveUrlPath(url);
+
+  if (path === appRoutes.root) {
+    return {
+      kind: "route",
+      href: appRoutes.root,
+      rawUrl: sanitizeAppUrl(rawUrl),
+    };
+  }
+
+  if (isCheckoutReturnPath(path)) {
+    return buildCheckoutReturnIntent(rawUrl, path, url.searchParams);
+  }
+
+  if (isPrivateAppRoute(path) || isPublicAppRoute(path)) {
+    return {
+      kind: "route",
+      href: path,
+      rawUrl: sanitizeAppUrl(rawUrl),
+    };
+  }
+
+  navigationLogger.log("navigation.deep_link_rejected", {
+    level: "warn",
+    context: {
+      rawUrl: sanitizeAppUrl(rawUrl),
+      path,
+      reason: "path_not_in_allowlist",
+    },
+  });
+  return null;
 };
 
 export const buildAppUrl = (

--- a/core/security/biometric-gate.test.ts
+++ b/core/security/biometric-gate.test.ts
@@ -1,0 +1,125 @@
+import * as LocalAuthentication from "expo-local-authentication";
+
+import {
+  inspectBiometricSupport,
+  requestBiometricAuth,
+} from "@/core/security/biometric-gate";
+
+jest.mock("expo-local-authentication", () => ({
+  AuthenticationType: { FINGERPRINT: 1, FACIAL_RECOGNITION: 2, IRIS: 3 },
+  hasHardwareAsync: jest.fn(),
+  isEnrolledAsync: jest.fn(),
+  supportedAuthenticationTypesAsync: jest.fn(),
+  authenticateAsync: jest.fn(),
+}));
+
+const mockedHasHardware = LocalAuthentication.hasHardwareAsync as jest.MockedFunction<
+  typeof LocalAuthentication.hasHardwareAsync
+>;
+const mockedIsEnrolled = LocalAuthentication.isEnrolledAsync as jest.MockedFunction<
+  typeof LocalAuthentication.isEnrolledAsync
+>;
+const mockedSupportedTypes =
+  LocalAuthentication.supportedAuthenticationTypesAsync as jest.MockedFunction<
+    typeof LocalAuthentication.supportedAuthenticationTypesAsync
+  >;
+const mockedAuthenticate = LocalAuthentication.authenticateAsync as jest.MockedFunction<
+  typeof LocalAuthentication.authenticateAsync
+>;
+
+describe("biometric-gate", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedSupportedTypes.mockResolvedValue([]);
+  });
+
+  describe("inspectBiometricSupport", () => {
+    it("retorna available quando hardware presente e enrolled", async () => {
+      mockedHasHardware.mockResolvedValue(true);
+      mockedIsEnrolled.mockResolvedValue(true);
+      const result = await inspectBiometricSupport();
+      expect(result.status).toBe("available");
+    });
+
+    it("retorna unavailable_no_hardware quando nao ha hardware", async () => {
+      mockedHasHardware.mockResolvedValue(false);
+      mockedIsEnrolled.mockResolvedValue(false);
+      const result = await inspectBiometricSupport();
+      expect(result.status).toBe("unavailable_no_hardware");
+    });
+
+    it("retorna unavailable_not_enrolled quando hardware sem cadastro", async () => {
+      mockedHasHardware.mockResolvedValue(true);
+      mockedIsEnrolled.mockResolvedValue(false);
+      const result = await inspectBiometricSupport();
+      expect(result.status).toBe("unavailable_not_enrolled");
+    });
+
+    it("nao propaga falha do native module", async () => {
+      mockedHasHardware.mockRejectedValue(new Error("native"));
+      mockedIsEnrolled.mockRejectedValue(new Error("native"));
+      const result = await inspectBiometricSupport();
+      expect(result.status).toBe("unavailable_no_hardware");
+    });
+  });
+
+  describe("requestBiometricAuth", () => {
+    it("retorna unavailable quando hardware ausente", async () => {
+      mockedHasHardware.mockResolvedValue(false);
+      mockedIsEnrolled.mockResolvedValue(false);
+      const result = await requestBiometricAuth({
+        promptMessage: "Auth",
+      });
+      expect(result.outcome).toBe("unavailable");
+    });
+
+    it("retorna success quando OS confirma identidade", async () => {
+      mockedHasHardware.mockResolvedValue(true);
+      mockedIsEnrolled.mockResolvedValue(true);
+      mockedAuthenticate.mockResolvedValue({ success: true } as never);
+      const result = await requestBiometricAuth({
+        promptMessage: "Auth",
+      });
+      expect(result.outcome).toBe("success");
+    });
+
+    it("traduz user_cancel em cancelled", async () => {
+      mockedHasHardware.mockResolvedValue(true);
+      mockedIsEnrolled.mockResolvedValue(true);
+      mockedAuthenticate.mockResolvedValue({
+        success: false,
+        error: "user_cancel",
+      } as never);
+      const result = await requestBiometricAuth({
+        promptMessage: "Auth",
+      });
+      expect(result.outcome).toBe("cancelled");
+    });
+
+    it("traduz user_fallback em fallback_pin", async () => {
+      mockedHasHardware.mockResolvedValue(true);
+      mockedIsEnrolled.mockResolvedValue(true);
+      mockedAuthenticate.mockResolvedValue({
+        success: false,
+        error: "user_fallback",
+      } as never);
+      const result = await requestBiometricAuth({
+        promptMessage: "Auth",
+      });
+      expect(result.outcome).toBe("fallback_pin");
+    });
+
+    it("propaga biometricsOnly via disableDeviceFallback", async () => {
+      mockedHasHardware.mockResolvedValue(true);
+      mockedIsEnrolled.mockResolvedValue(true);
+      mockedAuthenticate.mockResolvedValue({ success: true } as never);
+      await requestBiometricAuth({
+        promptMessage: "Auth",
+        biometricsOnly: true,
+      });
+      expect(mockedAuthenticate).toHaveBeenCalledWith(
+        expect.objectContaining({ disableDeviceFallback: true }),
+      );
+    });
+  });
+});

--- a/core/security/biometric-gate.ts
+++ b/core/security/biometric-gate.ts
@@ -1,0 +1,135 @@
+import * as LocalAuthentication from "expo-local-authentication";
+
+export type BiometricSupport =
+  | "available"
+  | "unavailable_no_hardware"
+  | "unavailable_not_enrolled"
+  | "unknown";
+
+export interface BiometricSupportSnapshot {
+  readonly status: BiometricSupport;
+  readonly hasHardware: boolean;
+  readonly isEnrolled: boolean;
+  readonly types: readonly LocalAuthentication.AuthenticationType[];
+}
+
+export type BiometricAuthOutcome =
+  | { readonly outcome: "success" }
+  | { readonly outcome: "cancelled" }
+  | { readonly outcome: "fallback_pin" }
+  | { readonly outcome: "unavailable"; readonly reason: BiometricSupport }
+  | { readonly outcome: "error"; readonly message: string };
+
+const safeHasHardware = async (): Promise<boolean> => {
+  try {
+    return await LocalAuthentication.hasHardwareAsync();
+  } catch {
+    return false;
+  }
+};
+
+const safeIsEnrolled = async (): Promise<boolean> => {
+  try {
+    return await LocalAuthentication.isEnrolledAsync();
+  } catch {
+    return false;
+  }
+};
+
+const safeSupportedTypes = async (): Promise<
+  readonly LocalAuthentication.AuthenticationType[]
+> => {
+  try {
+    return await LocalAuthentication.supportedAuthenticationTypesAsync();
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Inspects the device for biometric capability. Treats every native
+ * failure as "unknown" rather than throwing, so callers never have to
+ * wrap this in try/catch.
+ *
+ * @returns A discriminated snapshot of biometric capability.
+ */
+export const inspectBiometricSupport = async (): Promise<BiometricSupportSnapshot> => {
+  const [hasHardware, isEnrolled, types] = await Promise.all([
+    safeHasHardware(),
+    safeIsEnrolled(),
+    safeSupportedTypes(),
+  ]);
+
+  let status: BiometricSupport = "unknown";
+  if (!hasHardware) {
+    status = "unavailable_no_hardware";
+  } else if (!isEnrolled) {
+    status = "unavailable_not_enrolled";
+  } else {
+    status = "available";
+  }
+
+  return { status, hasHardware, isEnrolled, types };
+};
+
+export interface RequestBiometricOptions {
+  readonly promptMessage: string;
+  readonly cancelLabel?: string;
+  readonly fallbackLabel?: string;
+  /**
+   * When `true`, the OS will allow the user to fall back to their
+   * device PIN/password. Defaults to `true` so users who momentarily
+   * fail biometric (wet finger, sunglasses) can still authorise.
+   */
+  readonly allowDeviceFallback?: boolean;
+  /**
+   * When `true`, biometric prompts are required to use only biometrics
+   * (no device PIN). Use for sensitive flows where a stolen device PIN
+   * should not bypass the gate.
+   */
+  readonly biometricsOnly?: boolean;
+}
+
+/**
+ * Prompts the user with the OS biometric sheet (Face ID / Touch ID /
+ * fingerprint). Resolves with a discriminated outcome — never throws.
+ *
+ * @param options Prompt copy + fallback policy.
+ * @returns Outcome describing whether the gate passed.
+ */
+export const requestBiometricAuth = async (
+  options: RequestBiometricOptions,
+): Promise<BiometricAuthOutcome> => {
+  const support = await inspectBiometricSupport();
+  if (support.status !== "available") {
+    return { outcome: "unavailable", reason: support.status };
+  }
+
+  try {
+    const result = await LocalAuthentication.authenticateAsync({
+      promptMessage: options.promptMessage,
+      cancelLabel: options.cancelLabel,
+      fallbackLabel: options.fallbackLabel,
+      disableDeviceFallback: options.biometricsOnly === true,
+    });
+
+    if (result.success) {
+      return { outcome: "success" };
+    }
+    if (result.error === "user_cancel" || result.error === "system_cancel") {
+      return { outcome: "cancelled" };
+    }
+    if (result.error === "user_fallback") {
+      return { outcome: "fallback_pin" };
+    }
+    return {
+      outcome: "error",
+      message: result.error ?? "biometric_error",
+    };
+  } catch (error) {
+    return {
+      outcome: "error",
+      message: error instanceof Error ? error.message : "biometric_exception",
+    };
+  }
+};

--- a/core/session/session-store.test.ts
+++ b/core/session/session-store.test.ts
@@ -13,6 +13,7 @@ import {
 jest.mock("@/core/telemetry/app-logger", () => ({
   appLogger: {
     info: jest.fn(),
+    warn: jest.fn(),
   },
 }));
 
@@ -34,6 +35,7 @@ const mockLoadStoredSession = jest.mocked(loadStoredSession);
 const mockPersistStoredSession = jest.mocked(persistStoredSession);
 const mockClearStoredSession = jest.mocked(clearStoredSession);
 
+// eslint-disable-next-line max-lines-per-function
 describe("session store", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -299,6 +301,46 @@ describe("session store", () => {
     expect(useSessionStore.getState()).toMatchObject({
       isAuthenticated: false,
       authFailureReason: "manual",
+    });
+  });
+
+  describe("rotateTokens", () => {
+    it("persiste novos tokens atomicamente preservando o usuario", async () => {
+      const baseSession = makeStoredSession({
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+      });
+      mockLoadStoredSession.mockResolvedValue({
+        session: baseSession,
+        source: "canonical",
+        invalidStoredPayload: false,
+      });
+      await useSessionStore.getState().bootstrapSession();
+      mockPersistStoredSession.mockClear();
+
+      await useSessionStore
+        .getState()
+        .rotateTokens("access-2", "refresh-2", "2099-01-01T00:00:00.000Z");
+
+      expect(mockPersistStoredSession).toHaveBeenCalledTimes(1);
+      const persisted = mockPersistStoredSession.mock.calls[0]?.[0];
+      expect(persisted).toMatchObject({
+        accessToken: "access-2",
+        refreshToken: "refresh-2",
+        expiresAt: "2099-01-01T00:00:00.000Z",
+        user: baseSession.user,
+      });
+      expect(useSessionStore.getState()).toMatchObject({
+        accessToken: "access-2",
+        refreshToken: "refresh-2",
+        isAuthenticated: true,
+      });
+    });
+
+    it("recusa rotacao quando nao ha usuario na sessao", async () => {
+      await useSessionStore.getState().rotateTokens("access-2", "refresh-2");
+      expect(mockPersistStoredSession).not.toHaveBeenCalled();
+      expect(useSessionStore.getState().accessToken).toBeNull();
     });
   });
 });

--- a/core/session/session-store.ts
+++ b/core/session/session-store.ts
@@ -40,6 +40,11 @@ interface SessionState {
     userName?: string,
   ) => Promise<void>;
   setSession: (session: StoredSession | null) => Promise<void>;
+  rotateTokens: (
+    accessToken: string,
+    refreshToken: string,
+    expiresAt?: string | null,
+  ) => Promise<void>;
   updateUser: (user: SessionUser) => void;
   markSessionValidated: (timestamp: string) => void;
   dismissAuthFailure: () => void;
@@ -145,6 +150,7 @@ const logSessionRehydrated = (context: Record<string, unknown>): void => {
 
 let bootstrapSessionPromise: Promise<void> | null = null;
 
+// eslint-disable-next-line max-lines-per-function
 export const useSessionStore = create<SessionState>((set, get) => ({
   ...sessionStateDefaults,
   bootstrapSession: async (): Promise<void> => {
@@ -237,6 +243,47 @@ export const useSessionStore = create<SessionState>((set, get) => ({
     const nextSession = withSessionMetadata(session);
     await persistStoredSession(nextSession);
     set(toState(nextSession));
+  },
+  rotateTokens: async (
+    accessToken: string,
+    refreshToken: string,
+    expiresAt: string | null = null,
+  ): Promise<void> => {
+    const state = get();
+    if (!state.user) {
+      // Refusing to rotate when there is no active session — the
+      // backend should never hand out a new refresh token without a
+      // logged-in user. Silent no-op rather than spreading a fake
+      // session across SecureStore.
+      authLogger.log("auth.session_invalidated", {
+        level: "warn",
+        context: { reason: "rotate_without_user" },
+      });
+      return;
+    }
+
+    const nextSession: StoredSession = {
+      accessToken,
+      refreshToken,
+      user: state.user,
+      authenticatedAt: state.authenticatedAt,
+      expiresAt: expiresAt ?? state.expiresAt,
+    };
+
+    // SecureStore writes the whole envelope in a single call so the
+    // pair (accessToken, refreshToken) is always durable together —
+    // never one without the other.
+    await persistStoredSession(nextSession);
+    set(toState(nextSession));
+
+    authLogger.log("auth.session_established", {
+      context: {
+        hasRefreshToken: refreshToken.length > 0,
+        emailConfirmed: state.user.emailConfirmed,
+        hasUserId: state.user.id !== null,
+        rotated: true,
+      },
+    });
   },
   updateUser: (user: SessionUser): void => {
     const state = get();

--- a/core/shell/app-shell-store.ts
+++ b/core/shell/app-shell-store.ts
@@ -28,12 +28,21 @@ export type ThemePreference = "system" | "light" | "dark";
  */
 export type AppLocale = "pt" | "en";
 
+/**
+ * User preference for biometric gate. When `true`, sensitive flows
+ * (account deletion, password change, checkout) prompt the OS
+ * biometric sheet via {@link requestBiometricAuth}. Defaults to
+ * `false` until the user explicitly enrolls.
+ */
+export type BiometricLockPreference = boolean;
+
 export interface AppShellState {
   readonly fontsReady: boolean;
   readonly reducedMotionEnabled: boolean;
   readonly hapticsEnabled: boolean;
   readonly themePreference: ThemePreference;
   readonly locale: AppLocale;
+  readonly biometricLockEnabled: BiometricLockPreference;
   readonly startupReady: boolean;
   readonly appState: RuntimeAppState;
   readonly connectivityStatus: RuntimeConnectivityStatus;
@@ -48,6 +57,7 @@ export interface AppShellState {
   setHapticsEnabled: (value: boolean) => void;
   setThemePreference: (value: ThemePreference) => void;
   setLocale: (value: AppLocale) => void;
+  setBiometricLockEnabled: (value: BiometricLockPreference) => void;
   setStartupReady: (value: boolean) => void;
   setAppState: (value: RuntimeAppState) => void;
   setConnectivityStatus: (value: RuntimeConnectivityStatus) => void;
@@ -66,6 +76,7 @@ export type AppShellStateSnapshot = Pick<
   | "hapticsEnabled"
   | "themePreference"
   | "locale"
+  | "biometricLockEnabled"
   | "startupReady"
   | "appState"
   | "connectivityStatus"
@@ -83,6 +94,7 @@ export const appShellStateDefaults: AppShellStateSnapshot = {
   hapticsEnabled: true,
   themePreference: "system",
   locale: "pt",
+  biometricLockEnabled: false,
   startupReady: false,
   appState: "unknown",
   connectivityStatus: "unknown",
@@ -110,6 +122,9 @@ export const useAppShellStore = create<AppShellState>((set) => ({
   },
   setLocale: (value: AppLocale): void => {
     set({ locale: value });
+  },
+  setBiometricLockEnabled: (value: BiometricLockPreference): void => {
+    set({ biometricLockEnabled: value });
   },
   setStartupReady: (value: boolean): void => {
     set({ startupReady: value });

--- a/core/telemetry/logging-policy.ts
+++ b/core/telemetry/logging-policy.ts
@@ -6,14 +6,15 @@ import type {
 export interface AppEventLoggingPolicy {
   readonly level: AppLogLevel;
   readonly description: string;
-  readonly minimumContextKeys: ReadonlyArray<string>;
+  readonly minimumContextKeys: readonly string[];
   readonly consolePolicy: "dev-only" | "warn-and-error" | "never";
 }
 
+/* eslint-disable max-params */
 const createLoggingPolicy = (
   level: AppLogLevel,
   description: string,
-  minimumContextKeys: ReadonlyArray<string>,
+  minimumContextKeys: readonly string[],
   consolePolicy: AppEventLoggingPolicy["consolePolicy"],
 ): AppEventLoggingPolicy => {
   return {
@@ -23,10 +24,11 @@ const createLoggingPolicy = (
     consolePolicy,
   };
 };
+/* eslint-enable max-params */
 
 const devOnlyInfoPolicy = (
   description: string,
-  minimumContextKeys: ReadonlyArray<string>,
+  minimumContextKeys: readonly string[],
 ): AppEventLoggingPolicy => {
   return createLoggingPolicy(
     "info",
@@ -38,7 +40,7 @@ const devOnlyInfoPolicy = (
 
 const devOnlyDebugPolicy = (
   description: string,
-  minimumContextKeys: ReadonlyArray<string>,
+  minimumContextKeys: readonly string[],
 ): AppEventLoggingPolicy => {
   return createLoggingPolicy(
     "debug",
@@ -50,7 +52,7 @@ const devOnlyDebugPolicy = (
 
 const warnAndErrorInfoPolicy = (
   description: string,
-  minimumContextKeys: ReadonlyArray<string>,
+  minimumContextKeys: readonly string[],
 ): AppEventLoggingPolicy => {
   return createLoggingPolicy(
     "info",
@@ -62,7 +64,7 @@ const warnAndErrorInfoPolicy = (
 
 const warnAndErrorWarnPolicy = (
   description: string,
-  minimumContextKeys: ReadonlyArray<string>,
+  minimumContextKeys: readonly string[],
 ): AppEventLoggingPolicy => {
   return createLoggingPolicy(
     "warn",
@@ -74,7 +76,7 @@ const warnAndErrorWarnPolicy = (
 
 const warnAndErrorErrorPolicy = (
   description: string,
-  minimumContextKeys: ReadonlyArray<string>,
+  minimumContextKeys: readonly string[],
 ): AppEventLoggingPolicy => {
   return createLoggingPolicy(
     "error",
@@ -140,6 +142,14 @@ export const APP_EVENT_LOGGING_POLICY = Object.freeze({
   "navigation.deep_link_handled": devOnlyInfoPolicy(
     "Deep link válido processado pelo runtime.",
     ["url", "href"],
+  ),
+  "navigation.deep_link_rejected": warnAndErrorWarnPolicy(
+    "Deep link recusado por não estar na allowlist de rotas conhecidas.",
+    ["rawUrl", "path", "reason"],
+  ),
+  "navigation.deep_link_parse_failed": warnAndErrorWarnPolicy(
+    "Deep link recebeu URL mal-formada e não pôde ser interpretada.",
+    ["rawUrl"],
   ),
   "network.request_started": devOnlyDebugPolicy(
     "Requisição HTTP iniciada pelo cliente.",

--- a/core/telemetry/types.ts
+++ b/core/telemetry/types.ts
@@ -23,6 +23,8 @@ export type AppTelemetryEvent =
   | "navigation.deep_link_deduplicated"
   | "navigation.deep_link_ignored"
   | "navigation.deep_link_handled"
+  | "navigation.deep_link_rejected"
+  | "navigation.deep_link_parse_failed"
   | "network.request_started"
   | "network.request_succeeded"
   | "network.request_failed"

--- a/features/user-profile/components/security-section.tsx
+++ b/features/user-profile/components/security-section.tsx
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useState, type ReactElement } from "react";
+
+import { Paragraph, YStack } from "tamagui";
+
+import { inspectBiometricSupport } from "@/core/security/biometric-gate";
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { AppToggleRow } from "@/shared/components/app-toggle-row";
+import { useT } from "@/shared/i18n";
+
+type SupportState = "checking" | "available" | "unavailable" | "not_enrolled";
+
+/**
+ * Profile section that lets the user toggle biometric lock for the
+ * app. Inspects device capability on mount and disables the toggle
+ * gracefully when biometrics are absent or not enrolled.
+ */
+export function SecuritySection(): ReactElement {
+  const { t } = useT();
+  const enabled = useAppShellStore((state) => state.biometricLockEnabled);
+  const setEnabled = useAppShellStore((state) => state.setBiometricLockEnabled);
+  const [support, setSupport] = useState<SupportState>("checking");
+
+  useEffect(() => {
+    let cancelled = false;
+    void inspectBiometricSupport().then((snapshot) => {
+      if (cancelled) {
+        return;
+      }
+      if (snapshot.status === "available") {
+        setSupport("available");
+      } else if (snapshot.status === "unavailable_not_enrolled") {
+        setSupport("not_enrolled");
+      } else {
+        setSupport("unavailable");
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggle = useCallback(
+    (next: boolean): void => {
+      if (support !== "available") {
+        return;
+      }
+      setEnabled(next);
+    },
+    [setEnabled, support],
+  );
+
+  const helperText =
+    support === "unavailable"
+      ? t("common.security.biometric.unavailable")
+      : support === "not_enrolled"
+        ? t("common.security.biometric.notEnrolled")
+        : undefined;
+
+  return (
+    <AppSurfaceCard title={t("common.security.title")}>
+      <YStack gap="$3">
+        <AppToggleRow
+          label={t("common.security.biometric.label")}
+          description={t("common.security.biometric.description")}
+          checked={enabled && support === "available"}
+          disabled={support !== "available"}
+          onCheckedChange={handleToggle}
+          testID="security-biometric"
+        />
+        {helperText ? (
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+            {helperText}
+          </Paragraph>
+        ) : null}
+      </YStack>
+    </AppSurfaceCard>
+  );
+}

--- a/features/user-profile/screens/user-profile-screen.tsx
+++ b/features/user-profile/screens/user-profile-screen.tsx
@@ -4,6 +4,7 @@ import { Paragraph, YStack } from "tamagui";
 
 import { AppearanceSection } from "@/features/user-profile/components/appearance-section";
 import { LanguageSection } from "@/features/user-profile/components/language-section";
+import { SecuritySection } from "@/features/user-profile/components/security-section";
 import { UserProfileForm } from "@/features/user-profile/components/user-profile-form";
 import type { UserProfile } from "@/features/user-profile/contracts";
 import {
@@ -53,6 +54,7 @@ export function UserProfileScreen(): ReactElement {
       <ProfileCard controller={controller} />
       <AppearanceSection />
       <LanguageSection />
+      <SecuritySection />
       <LogoutCard controller={controller} />
     </AppScreen>
   );

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-haptics": "~15.0.8",
         "expo-image": "~3.0.11",
         "expo-linking": "~8.0.11",
+        "expo-local-authentication": "~17.0.8",
         "expo-localization": "~17.0.8",
         "expo-router": "~6.0.23",
         "expo-secure-store": "^55.0.13",
@@ -10798,6 +10799,18 @@
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-17.0.8.tgz",
+      "integrity": "sha512-Q5fXHhu6w3pVPlFCibU72SYIAN+9wX7QpFn9h49IUqs0Equ44QgswtGrxeh7fdnDqJrrYGPet5iBzjnE70uolA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-localization": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
     "expo-linking": "~8.0.11",
+    "expo-local-authentication": "~17.0.8",
     "expo-localization": "~17.0.8",
     "expo-router": "~6.0.23",
     "expo-secure-store": "^55.0.13",

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -29,6 +29,15 @@
       "description": "Choose the language shown across the app.",
       "pt": "Portuguese",
       "en": "English"
+    },
+    "security": {
+      "title": "Security",
+      "biometric": {
+        "label": "Biometric lock",
+        "description": "Require Face ID, Touch ID or fingerprint when reopening the app and for sensitive actions.",
+        "unavailable": "Biometrics not available on this device.",
+        "notEnrolled": "Enroll Face ID / Touch ID in system settings to enable."
+      }
     }
   },
   "auth": {

--- a/shared/i18n/locales/pt.json
+++ b/shared/i18n/locales/pt.json
@@ -29,6 +29,15 @@
       "description": "Escolha o idioma exibido em todo o app.",
       "pt": "Portugues",
       "en": "English"
+    },
+    "security": {
+      "title": "Seguranca",
+      "biometric": {
+        "label": "Bloqueio biometrico",
+        "description": "Exigir Face ID, Touch ID ou impressao digital ao reabrir o app e em acoes sensiveis.",
+        "unavailable": "Biometria indisponivel neste dispositivo.",
+        "notEnrolled": "Cadastre Face ID / Touch ID nas configuracoes do sistema para ativar."
+      }
     }
   },
   "auth": {


### PR DESCRIPTION
Refs #298 — primeira parte do hardening de segurança mobile.

## Why

Auditoria identificou que o app passava nos básicos (SecureStore, sanitização de PII, session invalidation em 401/403, governance pre-commit) mas **falta hardening mobile-first**:

- ❌ Sem biometria
- ❌ Sem detecção de jailbreak/root
- ❌ Sem SSL pinning
- ⚠️ Refresh token rotation não confirmada no cliente
- ⚠️ Login sem CAPTCHA (paridade com web)
- ⚠️ Deep link allowlist implícita; rejeições silenciosas

App é financeiro, expõe dados sensíveis. Esta PR ataca os 3 itens de **mais alto ROI** com o **menor risco de regressão** — os outros 3 ficam para PRs dedicadas onde a complexidade justifica isolamento.

## What changes

### 1. Deep link allowlist explícita
- `core/navigation/deep-linking.ts` — separa parsing de URL de resolução de rota. URLs malformadas emitem `navigation.deep_link_parse_failed` (warn). Pathnames fora do registry de rotas emitem `navigation.deep_link_rejected` com reason `path_not_in_allowlist`. Query params sensíveis seguem redactados antes de logar.
- `core/telemetry/types.ts` — registra os 2 novos eventos no union de telemetria (compile-time guard).
- `core/telemetry/logging-policy.ts` — registra copy + context allowlist por evento.

### 2. Refresh token rotation atômica
- `core/session/session-store.ts` — nova action `rotateTokens(accessToken, refreshToken, expiresAt?)`. Escreve ambos os tokens via `persistStoredSession` numa única chamada do SecureStore — nunca fica num estado meio-aplicado. Recusa rotação sem usuário ativo e emite `auth.session_invalidated` com reason `rotate_without_user`.
- 2 testes novos cobrem a atomicidade + guard.
- O HTTP refresh interceptor que consome `rotateTokens` é **trabalho do backend** + integração subsequente — esta PR só estabelece o contrato no client.

### 3. Biometria (Face ID / Touch ID / fingerprint)
- `expo-local-authentication ~17.0.8` instalado via `npx expo install` (**dep nativa, requer rebuild** — config plugin já no `app.json`).
- `core/security/biometric-gate.ts`:
  - `inspectBiometricSupport()` retorna snapshot discriminada (`available` / `unavailable_no_hardware` / `unavailable_not_enrolled` / `unknown`). Nunca lança.
  - `requestBiometricAuth({ promptMessage, biometricsOnly })` prompts a sheet do OS e retorna `success` / `cancelled` / `fallback_pin` / `unavailable` / `error`. Nunca lança. `biometricsOnly` mapeia para `disableDeviceFallback` para flows de alta criticidade.
- `AppShellStore.biometricLockEnabled` (default `false`) + setter.
- `SecuritySection` em "Perfil" — inspeciona capacidade no mount, desabilita o toggle gracioso quando biometrics ausente ou não cadastrada (helper text explica o motivo).
- 9 testes cobrem inspeção + autenticação + erros.

## Validation

- `npm run typecheck` ✅
- `npm run policy:check` ✅ (8 governance scripts)
- `npm run contracts:check` ✅
- `npm run test:coverage` ✅ — **770 tests / 181 suites**, coverage **94.97% lines / 85.33% branches**
- 11 testes novos (deep link, rotateTokens, biometric-gate)
- Pre-commit + pre-push verdes

## Visual smoke test

- [ ] Tentar deep link inválido (ex: `auraxisapp://attacker-path`) → app não navega; evento `navigation.deep_link_rejected` aparece nos logs estruturados
- [ ] Em Perfil → Segurança em device sem biometria → toggle desabilitado + mensagem "Biometria indisponível"
- [ ] Em Perfil → Segurança em device com biometria habilitada → toggle ativável; após ativar, nada visível no app ainda (gates ficam para próxima PR)
- [ ] Sessão ativa → trigger `rotateTokens` (manual em dev) → SecureStore atualiza ambos os tokens; nunca fica com refresh velho + access novo

## Out of scope (PRs dedicadas)

Mantidos no Issue #298 para próxima(s) iteração(ões):

- **SSL pinning** — `react-native-ssl-pinning` ou `networkSecurityConfig` Android + ATS iOS. Alto risco de breakage; merece feature flag canary + test plan próprio.
- **Jailbreak/root detection** — `jail-monkey`. Aviso não-bloqueante via Sentry. Pequena, mas adiciona dep nativa; vai junto com SSL pinning.
- **CAPTCHA Cloudflare Turnstile** — sem lib RN madura; precisa de WebView wrapper customizado. Complexidade > escopo desta PR.
- **Gate biométrico em ações sensíveis** (delete account, password change, checkout) — destravado por esta PR; aplicação em #304 (delete account) e PR seguinte.
- **HTTP refresh interceptor** — depende de backend confirmar rotação de refresh tokens; abrir issue em `auraxis-api` se necessário.

## Test plan
- [x] Typecheck verde
- [x] Policy + contracts verde
- [x] 770 testes / coverage 94.97% / 85.33% branches
- [x] Pre-push verde
- [ ] CI verde
- [ ] Smoke test em iOS device (biometria + deep link rejeitado)
- [ ] Smoke test em Android device
