### PR TITLE
security(app): startup integrity check, SSL pinning policy scaffold, security posture doc

### DIFF
--- a/core/security/integrity-check.test.ts
+++ b/core/security/integrity-check.test.ts
@@ -1,0 +1,144 @@
+import * as Sentry from "@sentry/react-native";
+import JailMonkey from "jail-monkey";
+
+import {
+  inspectDeviceIntegrity,
+  reportDeviceIntegrity,
+  resetDeviceIntegrityReportingForTests,
+  runDeviceIntegrityCheck,
+} from "@/core/security/integrity-check";
+
+jest.mock("jail-monkey", () => ({
+  __esModule: true,
+  default: {
+    isJailBroken: jest.fn(),
+    isDebuggedMode: jest.fn(),
+    canMockLocation: jest.fn(),
+    isOnExternalStorage: jest.fn(),
+    hookDetected: jest.fn(),
+  },
+}));
+
+jest.mock("@sentry/react-native", () => ({
+  captureMessage: jest.fn(),
+}));
+
+const mockedJM = JailMonkey as jest.Mocked<typeof JailMonkey>;
+const mockedCaptureMessage = Sentry.captureMessage as jest.MockedFunction<
+  typeof Sentry.captureMessage
+>;
+
+const setAllSignals = (value: boolean): void => {
+  mockedJM.isJailBroken.mockReturnValue(value as never);
+  mockedJM.isDebuggedMode.mockReturnValue(value as never);
+  mockedJM.canMockLocation.mockReturnValue(value as never);
+  mockedJM.isOnExternalStorage.mockReturnValue(value as never);
+  mockedJM.hookDetected.mockReturnValue(value as never);
+};
+
+describe("integrity-check", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetDeviceIntegrityReportingForTests();
+  });
+
+  describe("inspectDeviceIntegrity", () => {
+    it("reports trusted when every signal is clean", async () => {
+      setAllSignals(false);
+      const snapshot = await inspectDeviceIntegrity();
+      expect(snapshot.status).toBe("trusted");
+      expect(snapshot.jailBroken).toBe(false);
+    });
+
+    it("flags compromised when isJailBroken is true", async () => {
+      setAllSignals(false);
+      mockedJM.isJailBroken.mockReturnValue(true as never);
+      const snapshot = await inspectDeviceIntegrity();
+      expect(snapshot.status).toBe("compromised");
+    });
+
+    it("flags compromised when hookDetected is true", async () => {
+      setAllSignals(false);
+      mockedJM.hookDetected.mockReturnValue(true as never);
+      const snapshot = await inspectDeviceIntegrity();
+      expect(snapshot.status).toBe("compromised");
+    });
+
+    it("does not flip on weak signals alone (canMockLocation / externalStorage)", async () => {
+      setAllSignals(false);
+      mockedJM.canMockLocation.mockReturnValue(true as never);
+      mockedJM.isOnExternalStorage.mockReturnValue(true as never);
+      const snapshot = await inspectDeviceIntegrity();
+      expect(snapshot.status).toBe("trusted");
+    });
+
+    it("never propagates a JNI bridge throw", async () => {
+      mockedJM.isJailBroken.mockImplementation(() => {
+        throw new Error("native");
+      });
+      mockedJM.isDebuggedMode.mockReturnValue(false as never);
+      mockedJM.canMockLocation.mockReturnValue(false as never);
+      mockedJM.isOnExternalStorage.mockReturnValue(false as never);
+      mockedJM.hookDetected.mockReturnValue(false as never);
+      const snapshot = await inspectDeviceIntegrity();
+      expect(snapshot.status).toBe("trusted");
+      expect(snapshot.jailBroken).toBe(false);
+    });
+  });
+
+  describe("reportDeviceIntegrity", () => {
+    it("captures a Sentry warning when device is compromised", () => {
+      reportDeviceIntegrity({
+        status: "compromised",
+        jailBroken: true,
+        debuggedMode: false,
+        canMockLocation: false,
+        externalStorage: false,
+        hookDetected: false,
+        checkedAt: "now",
+      });
+      expect(mockedCaptureMessage).toHaveBeenCalledWith(
+        "device.compromised",
+        expect.objectContaining({ level: "warning" }),
+      );
+    });
+
+    it("does not call Sentry when device is trusted", () => {
+      reportDeviceIntegrity({
+        status: "trusted",
+        jailBroken: false,
+        debuggedMode: false,
+        canMockLocation: false,
+        externalStorage: false,
+        hookDetected: false,
+        checkedAt: "now",
+      });
+      expect(mockedCaptureMessage).not.toHaveBeenCalled();
+    });
+
+    it("dedups identical compromised snapshots within the lifecycle", () => {
+      const snapshot = {
+        status: "compromised" as const,
+        jailBroken: true,
+        debuggedMode: false,
+        canMockLocation: false,
+        externalStorage: false,
+        hookDetected: false,
+        checkedAt: "now",
+      };
+      reportDeviceIntegrity(snapshot);
+      reportDeviceIntegrity(snapshot);
+      expect(mockedCaptureMessage).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("runDeviceIntegrityCheck", () => {
+    it("never throws even when every native call fails", async () => {
+      setAllSignals(false);
+      mockedJM.isJailBroken.mockImplementation(() => {
+        throw new Error("native");
+      });
+      await expect(runDeviceIntegrityCheck()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/core/security/integrity-check.ts
+++ b/core/security/integrity-check.ts
@@ -1,0 +1,154 @@
+import * as Sentry from "@sentry/react-native";
+import JailMonkey from "jail-monkey";
+
+import { startupLogger } from "@/core/telemetry/domain-loggers";
+
+export type DeviceIntegrityStatus =
+  | "trusted"
+  | "compromised"
+  | "indeterminate";
+
+export interface DeviceIntegritySnapshot {
+  readonly status: DeviceIntegrityStatus;
+  readonly jailBroken: boolean;
+  readonly debuggedMode: boolean;
+  readonly canMockLocation: boolean;
+  readonly externalStorage: boolean;
+  readonly hookDetected: boolean;
+  readonly checkedAt: string;
+}
+
+const safeBooleanAsync = async (
+  call: () => Promise<boolean> | boolean,
+): Promise<boolean> => {
+  try {
+    return Boolean(await call());
+  } catch {
+    return false;
+  }
+};
+
+/**
+ * Inspects the device for signs of jailbreak / root / hooking.
+ *
+ * Returns a snapshot rather than a boolean so the caller can decide
+ * how to react (warn, log, gate). Each native call is wrapped so a
+ * failing JNI / ObjC bridge cannot crash the startup flow.
+ *
+ * Notes on accuracy:
+ * - `jailBroken` is the strong signal — file/system probes that flag
+ *   Cydia / Magisk / suspicious binaries.
+ * - `debuggedMode` only triggers when actively attached to a debugger
+ *   in a release build, which always implies tampering.
+ * - `hookDetected` flags Frida / Substrate-style hooking on iOS.
+ * - `canMockLocation` and `externalStorage` are weak signals on
+ *   Android — a rooted device usually exposes them but a regular
+ *   developer build can too. They are reported but do not flip the
+ *   status to `compromised` on their own.
+ */
+export const inspectDeviceIntegrity = async (): Promise<DeviceIntegritySnapshot> => {
+  const [jailBroken, debuggedMode, canMockLocation, externalStorage, hookDetected] =
+    await Promise.all([
+      safeBooleanAsync(() => JailMonkey.isJailBroken()),
+      safeBooleanAsync(() => JailMonkey.isDebuggedMode()),
+      safeBooleanAsync(() => JailMonkey.canMockLocation()),
+      safeBooleanAsync(() => JailMonkey.isOnExternalStorage()),
+      safeBooleanAsync(() => JailMonkey.hookDetected()),
+    ]);
+
+  const strongSignal = jailBroken || debuggedMode || hookDetected;
+  const status: DeviceIntegrityStatus = strongSignal
+    ? "compromised"
+    : "trusted";
+
+  return {
+    status,
+    jailBroken,
+    debuggedMode,
+    canMockLocation,
+    externalStorage,
+    hookDetected,
+    checkedAt: new Date().toISOString(),
+  };
+};
+
+let lastReportedSnapshotKey: string | null = null;
+
+const buildSnapshotKey = (snapshot: DeviceIntegritySnapshot): string => {
+  return [
+    snapshot.status,
+    snapshot.jailBroken ? "j" : "",
+    snapshot.debuggedMode ? "d" : "",
+    snapshot.hookDetected ? "h" : "",
+  ].join(":");
+};
+
+/**
+ * Reports the integrity snapshot once per app lifecycle (deduplicated
+ * by signal shape). Compromised devices generate a Sentry event with
+ * tag `device.compromised: true` so monitoring can distinguish them
+ * from regular sessions; trusted devices only emit a debug log.
+ *
+ * The runtime keeps serving the user — this is a *visibility* tool,
+ * not a gate. Users on rooted devices may legitimately be developers
+ * or power users, and silently locking them out punishes a real cohort
+ * with little marginal security gain over the rest of the stack.
+ */
+export const reportDeviceIntegrity = (
+  snapshot: DeviceIntegritySnapshot,
+): void => {
+  const key = buildSnapshotKey(snapshot);
+  if (lastReportedSnapshotKey === key) {
+    return;
+  }
+  lastReportedSnapshotKey = key;
+
+  if (snapshot.status === "compromised") {
+    Sentry.captureMessage("device.compromised", {
+      level: "warning",
+      tags: {
+        "device.compromised": "true",
+        "device.jail_broken": String(snapshot.jailBroken),
+        "device.debugged_mode": String(snapshot.debuggedMode),
+        "device.hook_detected": String(snapshot.hookDetected),
+      },
+    });
+    startupLogger.log("startup.bootstrap_requested", {
+      level: "warn",
+      context: {
+        deviceCompromised: true,
+        jailBroken: snapshot.jailBroken,
+        debuggedMode: snapshot.debuggedMode,
+        hookDetected: snapshot.hookDetected,
+      },
+    });
+    return;
+  }
+
+  startupLogger.log("startup.bootstrap_requested", {
+    level: "debug",
+    context: { deviceCompromised: false },
+  });
+};
+
+/**
+ * Test utility — clears the dedup memo so subsequent
+ * {@link reportDeviceIntegrity} calls in the same suite report again.
+ */
+export const resetDeviceIntegrityReportingForTests = (): void => {
+  lastReportedSnapshotKey = null;
+};
+
+/**
+ * One-call helper used by the startup bridge: inspects the device
+ * and reports the result. Errors are swallowed so a misbehaving
+ * native module can never block the app from booting.
+ */
+export const runDeviceIntegrityCheck = async (): Promise<void> => {
+  try {
+    const snapshot = await inspectDeviceIntegrity();
+    reportDeviceIntegrity(snapshot);
+  } catch {
+    /* swallow — integrity check is best-effort and must never block boot */
+  }
+};

--- a/core/security/ssl-pinning.test.ts
+++ b/core/security/ssl-pinning.test.ts
@@ -1,0 +1,64 @@
+import {
+  isSslPinningEnforced,
+  resolveSslPinningPolicy,
+} from "@/core/security/ssl-pinning";
+
+const setEnv = (
+  enabled: string | undefined,
+  fingerprints: string | undefined,
+): void => {
+  if (enabled === undefined) {
+    delete process.env.EXPO_PUBLIC_SSL_PINNING_ENABLED;
+  } else {
+    process.env.EXPO_PUBLIC_SSL_PINNING_ENABLED = enabled;
+  }
+  if (fingerprints === undefined) {
+    delete process.env.EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS;
+  } else {
+    process.env.EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS = fingerprints;
+  }
+};
+
+describe("ssl-pinning policy", () => {
+  beforeEach(() => {
+    setEnv(undefined, undefined);
+  });
+
+  it("returns disabled when env is unset", () => {
+    const policy = resolveSslPinningPolicy();
+    expect(policy.enabled).toBe(false);
+    expect(policy.expectedFingerprints).toEqual([]);
+  });
+
+  it("ignores enabled flag without fingerprints", () => {
+    setEnv("true", undefined);
+    expect(isSslPinningEnforced()).toBe(false);
+  });
+
+  it("requires both flag and fingerprints to enforce", () => {
+    setEnv("true", "sha256/AAA===,sha256/BBB===");
+    const policy = resolveSslPinningPolicy();
+    expect(policy.enabled).toBe(true);
+    expect(policy.expectedFingerprints).toEqual([
+      "sha256/AAA===",
+      "sha256/BBB===",
+    ]);
+  });
+
+  it("treats truthy variants of the flag as enabled", () => {
+    setEnv("1", "sha256/AAA===");
+    expect(isSslPinningEnforced()).toBe(true);
+    setEnv("on", "sha256/AAA===");
+    expect(isSslPinningEnforced()).toBe(true);
+    setEnv("TRUE", "sha256/AAA===");
+    expect(isSslPinningEnforced()).toBe(true);
+  });
+
+  it("trims whitespace and skips empty entries", () => {
+    setEnv("true", "sha256/AAA=== , , sha256/BBB===");
+    expect(resolveSslPinningPolicy().expectedFingerprints).toEqual([
+      "sha256/AAA===",
+      "sha256/BBB===",
+    ]);
+  });
+});

--- a/core/security/ssl-pinning.ts
+++ b/core/security/ssl-pinning.ts
@@ -1,0 +1,83 @@
+/**
+ * SSL pinning scaffolding for the Auraxis app.
+ *
+ * Posture today:
+ * - Runtime config exposes `sslPinningEnabled` and a list of expected
+ *   SHA-256 fingerprints. Both are read from env so production builds
+ *   can enable pinning without an OTA being able to disable it
+ *   (`EXPO_PUBLIC_SSL_PINNING_ENABLED` is set at build time).
+ * - This module owns the canonical "should pinning enforce now?"
+ *   decision so call sites never have to assemble the predicate.
+ *
+ * Native enforcement (Android networkSecurityConfig + iOS ATS) lands
+ * in a follow-up release that ties the certificate fingerprint to the
+ * production deploy. Until then, the helper still returns a coherent
+ * snapshot that future axios / fetch adapters can call into without
+ * reshaping their wiring.
+ */
+
+interface RawEnvSnapshot {
+  readonly enabled: string | undefined;
+  readonly fingerprints: string | undefined;
+}
+
+const readEnv = (): RawEnvSnapshot => {
+  return {
+    enabled: process.env.EXPO_PUBLIC_SSL_PINNING_ENABLED,
+    fingerprints: process.env.EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS,
+  };
+};
+
+const parseEnabled = (raw: string | undefined): boolean => {
+  if (!raw) {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return normalized === "true" || normalized === "1" || normalized === "on";
+};
+
+const parseFingerprints = (raw: string | undefined): readonly string[] => {
+  if (!raw) {
+    return [];
+  }
+  return raw
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+};
+
+export interface SslPinningPolicy {
+  readonly enabled: boolean;
+  /**
+   * Expected SHA-256 fingerprints, in the form
+   * `sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`.
+   * Two are recommended (current + next) so a certificate roll
+   * does not cause a forced app update.
+   */
+  readonly expectedFingerprints: readonly string[];
+}
+
+/**
+ * Resolves the active SSL pinning policy from runtime env. Returns a
+ * disabled policy when the flag is off or no fingerprints are
+ * configured — the caller decides whether to fail-closed.
+ */
+export const resolveSslPinningPolicy = (): SslPinningPolicy => {
+  const env = readEnv();
+  const enabled = parseEnabled(env.enabled);
+  const fingerprints = parseFingerprints(env.fingerprints);
+
+  return {
+    enabled: enabled && fingerprints.length > 0,
+    expectedFingerprints: fingerprints,
+  };
+};
+
+/**
+ * Quick predicate for runtime branches. Equivalent to
+ * `resolveSslPinningPolicy().enabled` but cheaper to read at call
+ * sites that only need the boolean.
+ */
+export const isSslPinningEnforced = (): boolean => {
+  return resolveSslPinningPolicy().enabled;
+};

--- a/core/shell/use-app-startup.ts
+++ b/core/shell/use-app-startup.ts
@@ -17,6 +17,7 @@ import {
   performanceTracker,
   resetPerformanceTrackerForTests,
 } from "@/core/performance/performance-tracker";
+import { runDeviceIntegrityCheck } from "@/core/security/integrity-check";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { useSessionStore } from "@/core/session/session-store";
 import { startupLogger } from "@/core/telemetry/domain-loggers";
@@ -25,6 +26,7 @@ import { initI18n } from "@/shared/i18n";
 let sentryInitialized = false;
 let splashScreenPrevented = false;
 let i18nInitialized = false;
+let integrityCheckDispatched = false;
 
 const ensureI18nInitialized = (initialLocale?: "pt" | "en"): void => {
   if (i18nInitialized) {
@@ -32,6 +34,15 @@ const ensureI18nInitialized = (initialLocale?: "pt" | "en"): void => {
   }
   i18nInitialized = true;
   void initI18n(initialLocale);
+};
+
+const ensureIntegrityCheckDispatched = (): void => {
+  if (integrityCheckDispatched) {
+    return;
+  }
+  integrityCheckDispatched = true;
+  // Fire-and-forget. Best-effort; never blocks the boot path.
+  void runDeviceIntegrityCheck();
 };
 
 const ensureSentryInitialized = (): void => {
@@ -56,6 +67,7 @@ export const resetAppStartupRuntimeForTests = (): void => {
   sentryInitialized = false;
   splashScreenPrevented = false;
   i18nInitialized = false;
+  integrityCheckDispatched = false;
   resetPerformanceTrackerForTests();
 };
 
@@ -81,6 +93,7 @@ export const useAppStartup = (): AppStartupState => {
     ensureSentryInitialized();
     ensureSplashScreenPrevented();
     ensureI18nInitialized(useAppShellStore.getState().locale);
+    ensureIntegrityCheckDispatched();
     if (!startupMeasurementStarted.current) {
       performanceTracker.start("startup.total");
       startupMeasurementStarted.current = true;

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,78 @@
+# Auraxis App — Security Posture
+
+This document captures the security primitives the mobile app ships
+with today and the deliberate gaps that are tracked separately. It is
+intentionally short — for the broader incident-response and SDLC
+posture see `auraxis-platform/.context/`.
+
+## Active controls
+
+### Session and tokens
+- Access + refresh tokens persisted in `expo-secure-store` (Keychain
+  on iOS, Keystore-backed EncryptedSharedPreferences on Android).
+- `useSessionStore.rotateTokens(access, refresh, expiresAt?)` writes
+  the pair atomically; the storage layer never observes a half-rolled
+  refresh state.
+- 401 / 403 responses run through `invalidateSession()` and tear down
+  the session immediately.
+
+### Telemetry hygiene
+- All breadcrumbs and structured events route through
+  `core/telemetry/` with PII sanitisation depth 4 (recursive redact
+  of `email`, `token`, `password`, `cpf`, `ip`, etc.).
+- Sentry events have `sendDefaultPii: false` and explicitly delete
+  `user.email` and `user.ip_address` before transmission.
+
+### Deep linking
+- `core/navigation/deep-linking.ts` accepts only paths in the static
+  route registry (`isPrivateAppRoute` + `isPublicAppRoute`).
+- Rejected paths emit `navigation.deep_link_rejected` (warn) so
+  monitoring can distinguish legitimate user mistakes from probing.
+- Sensitive query params (`token`, `secret`, `password`, `email`,
+  `code`, ...) are redacted before any value reaches the logger.
+
+### Device integrity
+- `core/security/integrity-check.ts` runs once per app launch via
+  `runDeviceIntegrityCheck()` (wired in `useAppStartup`).
+- Strong signals (jailbreak, debugger attached in release, hooking
+  framework detected) flag the device as `compromised` and emit a
+  Sentry warning with `device.compromised: true`.
+- Weak signals (mock location, external storage on Android) are
+  recorded but do not flip the status alone.
+- Compromised devices are **not blocked**. Rooted devices may be
+  legitimate developer / power-user contexts; locking them out has
+  poor signal-to-noise. The control is monitoring, not enforcement.
+
+### Biometric gate
+- `core/security/biometric-gate.ts` wraps `expo-local-authentication`.
+- `inspectBiometricSupport()` and `requestBiometricAuth()` return
+  discriminated outcomes; neither ever throws to its caller.
+- User-facing toggle lives in **Profile → Security**. When the device
+  reports unsupported / not-enrolled, the toggle disables itself with
+  helper copy explaining why.
+- Application of the gate to specific flows (account deletion,
+  password change, checkout) ships incrementally per epic — see
+  `#298` follow-ups and `#304`.
+
+## Active scaffolding
+
+### SSL pinning (not yet enforcing)
+- `core/security/ssl-pinning.ts` exposes `resolveSslPinningPolicy()`
+  and `isSslPinningEnforced()` reading from
+  `EXPO_PUBLIC_SSL_PINNING_ENABLED` and
+  `EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS`.
+- The flag stays **off** in current builds because production
+  certificate fingerprints are not yet pinned at the native layer
+  (Android `networkSecurityConfig`, iOS ATS dictionary).
+- Two SHA-256 fingerprints are recommended (current + next) so a
+  certificate roll never bricks installed clients.
+- Enabling for real lands together with a deploy that ties the
+  fingerprint to the current ACM certificate. Tracked in `#298`.
+
+## Out of scope here (links)
+
+- **Backend session and refresh contracts** — see `auraxis-api`.
+- **Frontend (web) security headers and CSP** — see `auraxis-web`.
+- **CAPTCHA on login / register** — paridade com web ainda pendente
+  no app; tracking em `#298` (Cloudflare Turnstile via WebView).
+- **Penetration test cadence** — owned by platform `.context/`.

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -62,6 +62,19 @@ jest.mock("react-native-reanimated", () => {
 });
 /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any, react/display-name */
 
+// Default-mock jail-monkey: the native module ships ESM that jest does
+// not transform, and individual suites stub their own assertions.
+jest.mock("jail-monkey", () => ({
+  __esModule: true,
+  default: {
+    isJailBroken: jest.fn(() => false),
+    isDebuggedMode: jest.fn(() => false),
+    canMockLocation: jest.fn(() => false),
+    isOnExternalStorage: jest.fn(() => false),
+    hookDetected: jest.fn(() => false),
+  },
+}));
+
 // Mock global do expo-router (evita erros em testes unitários de componentes)
 jest.mock("expo-router", () => ({
   useRouter: () => ({

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "expo-system-ui": "~6.0.9",
         "expo-web-browser": "~15.0.10",
         "i18next": "^26.0.8",
+        "jail-monkey": "^2.8.5",
         "react": "19.1.6",
         "react-dom": "19.1.6",
         "react-hook-form": "^7.72.1",
@@ -13184,6 +13185,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/jail-monkey": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/jail-monkey/-/jail-monkey-2.8.5.tgz",
+      "integrity": "sha512-c91Bsfl18VyCRaoJAxB87ZC27lX23BL0EbHajFQu+h5Sa8OU/yeo33Lu8BplHPejdqxBwL31R//N/zYAb1XOSA==",
+      "license": "MIT"
     },
     "node_modules/jest": {
       "version": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "expo-system-ui": "~6.0.9",
     "expo-web-browser": "~15.0.10",
     "i18next": "^26.0.8",
+    "jail-monkey": "^2.8.5",
     "react": "19.1.6",
     "react-dom": "19.1.6",
     "react-hook-form": "^7.72.1",


### PR DESCRIPTION
Refs #298 — segundo bloco do hardening de segurança mobile.

## Why

PR #316 cobriu deep link allowlist, refresh rotation atômica e biometric lock toggle. Esta PR avança em mais 2 frentes do mesmo issue, mantendo o escopo focado para reduzir risco de regressão:

- **Detecção de jailbreak/root no startup** — visibilidade sobre dispositivos comprometidos sem bloquear usuários legítimos
- **Scaffolding de SSL pinning** — política runtime + feature flag, prontos para o dia em que a fingerprint do certificado de produção for fixada no build nativo

## What changes

### 1. Integrity check no startup
- `jail-monkey 2.8.5` instalado (**dep nativa, requer rebuild**). Lib madura, padrão da indústria em apps financeiros.
- `core/security/integrity-check.ts`:
  - `inspectDeviceIntegrity()` retorna snapshot discriminada. Cada chamada do JailMonkey é wrapped — uma JNI bridge falhando nunca derruba o boot.
  - **Strong signals** (jailbreak, debugger attached em release, hooking framework) → status `compromised`.
  - **Weak signals** (mock location, external storage Android) → registrados mas não flipam o status sozinhos (devs legítimos os exibem).
  - `reportDeviceIntegrity()` captura warning Sentry com tag `device.compromised: true` e dedup por shape de signals.
  - `runDeviceIntegrityCheck()` é o one-call helper para o startup.
- `useAppStartup` chama uma vez por boot, fire-and-forget.
- **Compromised devices NÃO são bloqueados** — decisão deliberada (dev legítimos vs marginal de segurança ruim). Documentado em `docs/security.md`.
- `jest.setup.ts` mocka `jail-monkey` globalmente (lib ships ESM raw que jest não transpila).

### 2. SSL pinning scaffolding
- `core/security/ssl-pinning.ts`:
  - `resolveSslPinningPolicy()` lê `EXPO_PUBLIC_SSL_PINNING_ENABLED` + `EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS` (comma-separated SHA-256).
  - Retorna disabled quando flag off OU sem fingerprints configuradas.
  - Recomenda 2 fingerprints (current + next) para certificate rotation sem brick.
- **Flag fica off** em todos os builds atuais — enforcement nativo (Android `networkSecurityConfig`, iOS ATS) entra junto com a fixação real da fingerprint do cert de produção. Tracking em #298.

### 3. `docs/security.md`
- Captura a postura inteira do app num único lugar: tokens, telemetria, deep links, integrity, biometria, SSL pinning. Itens deferred listados com o issue que rastreia o follow-up.

## Validation

- `npm run typecheck` ✅
- `npm run policy:check` ✅ (8 governance scripts)
- `npm run contracts:check` ✅
- `npm run test:coverage` ✅ — **784 tests / 183 suites**, coverage **94.95% lines / 85.29% branches**
- 14 testes novos (integrity-check 9, ssl-pinning 5)
- Pre-commit + pre-push verdes

## Visual smoke test

- [ ] Boot do app em device comum → log `startup.bootstrap_requested` com `deviceCompromised: false`; nenhum evento Sentry de integrity
- [ ] Boot em device jailbroken (test device com Cydia ou Magisk) → evento Sentry `device.compromised` com tag; app continua funcionando normalmente
- [ ] `EXPO_PUBLIC_SSL_PINNING_ENABLED=true` sem fingerprints → `isSslPinningEnforced()` retorna false (safe default)

## Out of scope (próximas PRs dentro de #298)

- **CAPTCHA Cloudflare Turnstile via WebView** no login (paridade com web)
- **Aplicação concreta do gate biométrico** em delete-account (#304), password change, checkout
- **Native enforcement** do SSL pinning — depende de tied deploy com cert fingerprint
- **HTTP refresh interceptor** que consome `rotateTokens` — depende de backend confirmar rotação

## Test plan
- [x] Typecheck verde
- [x] Policy + contracts verde
- [x] 784 testes / coverage 94.95% / 85.29% branches
- [x] Pre-push verde
- [ ] CI verde
- [ ] Smoke test em iOS device (boot)
- [ ] Smoke test em Android device (boot + simulador root)
