### PR TITLE
feat(app): dashboard breadth — MoM comparison, quick-add FAB, due card, embedded summaries

### DIFF
--- a/__tests__/app/dashboard-screen.test.tsx
+++ b/__tests__/app/dashboard-screen.test.tsx
@@ -102,6 +102,12 @@ describe("DashboardScreen", () => {
         level: "excellent",
         summary: "Excelente taxa de poupanca!",
       },
+      comparison: {
+        current: null,
+        previous: null,
+        delta: null,
+        percent: null,
+      },
       greetingName: "Italo",
       setSelectedMonth: jest.fn(),
     });

--- a/features/dashboard/components/dashboard-comparison-card.tsx
+++ b/features/dashboard/components/dashboard-comparison-card.tsx
@@ -1,0 +1,112 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, YStack, useTheme } from "tamagui";
+
+import {
+  resolveComparisonDirection,
+  type ComparisonDirection,
+} from "@/features/dashboard/services/period-comparison";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useT } from "@/shared/i18n";
+import { formatCurrency } from "@/shared/utils/formatters";
+
+export interface DashboardComparisonCardProps {
+  readonly title: string;
+  readonly value: number;
+  readonly delta: number | null;
+  readonly percent: number | null;
+  /**
+   * When `true`, an up direction is positive (green). For expenses pass
+   * `false` so an increase reads as red.
+   */
+  readonly positiveIsGood?: boolean;
+  readonly testID?: string;
+}
+
+const formatPercent = (percent: number): string => {
+  if (!Number.isFinite(percent)) {
+    return percent > 0 ? "↑ ∞" : "↓ ∞";
+  }
+  const pct = (percent * 100).toFixed(1);
+  return `${pct}%`;
+};
+
+const resolveTone = (
+  direction: ComparisonDirection,
+  positiveIsGood: boolean,
+): "good" | "bad" | "neutral" => {
+  if (direction === "flat") {
+    return "neutral";
+  }
+  if (direction === "up") {
+    return positiveIsGood ? "good" : "bad";
+  }
+  return positiveIsGood ? "bad" : "good";
+};
+
+const iconByDirection: Record<
+  ComparisonDirection,
+  React.ComponentProps<typeof MaterialCommunityIcons>["name"]
+> = {
+  up: "trending-up",
+  down: "trending-down",
+  flat: "minus",
+};
+
+/**
+ * Metric card that pairs the current value with a delta vs the
+ * previous period. Designed to drop into the dashboard grid without
+ * extra layout glue.
+ */
+export function DashboardComparisonCard({
+  title,
+  value,
+  delta,
+  percent,
+  positiveIsGood = true,
+  testID,
+}: DashboardComparisonCardProps): ReactElement {
+  const { t } = useT();
+  const theme = useTheme();
+  const hasBaseline = delta !== null && percent !== null;
+  const direction = hasBaseline ? resolveComparisonDirection(delta) : "flat";
+  const tone = resolveTone(direction, positiveIsGood);
+  const colorByTone: Record<typeof tone, string> = {
+    good: theme.success?.val ?? "#1f9d55",
+    bad: theme.danger?.val ?? "#c53030",
+    neutral: theme.muted?.val ?? "#8a8a8a",
+  };
+
+  return (
+    <AppSurfaceCard testID={testID}>
+      <YStack gap="$2">
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+          {title}
+        </Paragraph>
+        <Paragraph color="$color" fontFamily="$heading" fontSize="$7">
+          {formatCurrency(value)}
+        </Paragraph>
+        {hasBaseline ? (
+          <XStack gap="$1" alignItems="center">
+            <MaterialCommunityIcons
+              name={iconByDirection[direction]}
+              size={14}
+              color={colorByTone[tone]}
+            />
+            <Paragraph color={colorByTone[tone]} fontFamily="$body" fontSize="$3">
+              {formatPercent(percent)}
+            </Paragraph>
+            <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+              {t("dashboard.comparison.vsPrevious")}
+            </Paragraph>
+          </XStack>
+        ) : (
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+            {t("dashboard.comparison.noBaseline")}
+          </Paragraph>
+        )}
+      </YStack>
+    </AppSurfaceCard>
+  );
+}

--- a/features/dashboard/components/dashboard-goals-summary-card.tsx
+++ b/features/dashboard/components/dashboard-goals-summary-card.tsx
@@ -1,0 +1,131 @@
+import { useCallback, useMemo, type ReactElement } from "react";
+
+import { useRouter } from "expo-router";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { appRoutes } from "@/core/navigation/routes";
+import type { GoalRecord } from "@/features/goals/contracts";
+import { useGoalsQuery } from "@/features/goals/hooks/use-goals-query";
+import { AppButton } from "@/shared/components/app-button";
+import { AppQueryState } from "@/shared/components/app-query-state";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { GoalListSkeleton } from "@/shared/skeletons";
+import { useT } from "@/shared/i18n";
+import { formatCurrency } from "@/shared/utils/formatters";
+
+const TOP_GOALS_LIMIT = 2;
+
+const computeProgress = (goal: GoalRecord): number => {
+  if (goal.targetAmount <= 0) {
+    return 0;
+  }
+  return Math.min(
+    100,
+    Math.round((goal.currentAmount / goal.targetAmount) * 100),
+  );
+};
+
+const sortByProgressDesc = (a: GoalRecord, b: GoalRecord): number => {
+  return computeProgress(b) - computeProgress(a);
+};
+
+/**
+ * Embedded goals summary on the dashboard. Shows the top progressing
+ * goals so the user can see momentum without navigating to /metas.
+ */
+export function DashboardGoalsSummaryCard(): ReactElement {
+  const { t } = useT();
+  const router = useRouter();
+  const query = useGoalsQuery();
+
+  const handleViewAll = useCallback((): void => {
+    router.push(appRoutes.private.goals);
+  }, [router]);
+
+  return (
+    <AppSurfaceCard
+      title={t("dashboard.embeddedSummaries.goals.title")}
+    >
+      <YStack gap="$3">
+        <AppQueryState
+          query={query}
+          options={{
+            loading: {
+              title: t("dashboard.embeddedSummaries.goals.title"),
+            },
+            loadingPresentation: "skeleton",
+            empty: {
+              title: t("dashboard.embeddedSummaries.goals.empty"),
+            },
+            error: {
+              fallbackTitle: t("dashboard.embeddedSummaries.goals.title"),
+            },
+            isEmpty: (data) => data.goals.length === 0,
+          }}
+          loadingComponent={<GoalListSkeleton rows={2} />}
+        >
+          {(data) => <TopGoals goals={data.goals} />}
+        </AppQueryState>
+        <AppButton tone="secondary" onPress={handleViewAll}>
+          {t("dashboard.embeddedSummaries.goals.viewAll")}
+        </AppButton>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}
+
+interface TopGoalsProps {
+  readonly goals: readonly GoalRecord[];
+}
+
+function TopGoals({ goals }: TopGoalsProps): ReactElement {
+  const ranked = useMemo(
+    () => [...goals].sort(sortByProgressDesc).slice(0, TOP_GOALS_LIMIT),
+    [goals],
+  );
+
+  return (
+    <YStack gap="$3">
+      {ranked.map((goal) => (
+        <GoalRow key={goal.id} goal={goal} />
+      ))}
+    </YStack>
+  );
+}
+
+interface GoalRowProps {
+  readonly goal: GoalRecord;
+}
+
+function GoalRow({ goal }: GoalRowProps): ReactElement {
+  const progress = computeProgress(goal);
+  return (
+    <YStack gap="$2">
+      <XStack alignItems="center" justifyContent="space-between" gap="$3">
+        <Paragraph color="$color" fontFamily="$body" fontSize="$4">
+          {goal.title}
+        </Paragraph>
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+          {progress}%
+        </Paragraph>
+      </XStack>
+      <YStack
+        height="$1"
+        width="100%"
+        backgroundColor="$surfaceRaised"
+        borderRadius="$1"
+        overflow="hidden"
+      >
+        <YStack
+          height="$1"
+          width={`${Math.max(2, progress)}%`}
+          backgroundColor="$secondary"
+          borderRadius="$1"
+        />
+      </YStack>
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+        {formatCurrency(goal.currentAmount)} / {formatCurrency(goal.targetAmount)}
+      </Paragraph>
+    </YStack>
+  );
+}

--- a/features/dashboard/components/dashboard-quick-add-fab.tsx
+++ b/features/dashboard/components/dashboard-quick-add-fab.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Modal, Pressable } from "react-native";
+import { Paragraph, XStack, YStack, useTheme } from "tamagui";
+import { useForm, Controller } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { z } from "zod";
+
+import { useCreateTransactionMutation } from "@/features/transactions/hooks/use-transaction-mutations";
+import { createTransactionSchema } from "@/features/transactions/validators";
+import { AppButton } from "@/shared/components/app-button";
+import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppInputField } from "@/shared/components/app-input-field";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
+import { useT } from "@/shared/i18n";
+
+const quickAddSchema = createTransactionSchema.pick({
+  title: true,
+  amount: true,
+  type: true,
+  dueDate: true,
+});
+
+type QuickAddValues = z.infer<typeof quickAddSchema>;
+
+const todayIso = (): string => new Date().toISOString().slice(0, 10);
+
+const buildDefaults = (): QuickAddValues => ({
+  title: "",
+  amount: "",
+  type: "expense",
+  dueDate: todayIso(),
+});
+
+/**
+ * Floating action button that opens a 4-field bottom sheet to create a
+ * transaction without leaving the dashboard. Wires into the canonical
+ * `useCreateTransactionMutation` so cache invalidation and haptic
+ * feedback come for free.
+ */
+export function DashboardQuickAddFab(): ReactElement {
+  const { t } = useT();
+  const theme = useTheme();
+  const [open, setOpen] = useState<boolean>(false);
+  const createMutation = useCreateTransactionMutation();
+
+  const form = useForm<QuickAddValues>({
+    resolver: zodResolver(quickAddSchema),
+    defaultValues: buildDefaults(),
+  });
+
+  const handleOpen = useCallback((): void => {
+    triggerHapticImpact("medium");
+    form.reset(buildDefaults());
+    createMutation.reset();
+    setOpen(true);
+  }, [createMutation, form]);
+
+  const handleClose = useCallback((): void => {
+    setOpen(false);
+  }, []);
+
+  const handleSubmit = form.handleSubmit(async (values) => {
+    await createMutation.mutateAsync({
+      title: values.title,
+      amount: values.amount,
+      type: values.type,
+      dueDate: values.dueDate,
+    });
+    setOpen(false);
+  });
+
+  return (
+    <>
+      <Pressable
+        onPress={handleOpen}
+        accessibilityLabel={t("dashboard.quickAdd.fabLabel")}
+        accessibilityRole="button"
+        style={({ pressed }) => ({
+          position: "absolute",
+          right: 24,
+          bottom: 32,
+          width: 56,
+          height: 56,
+          borderRadius: 28,
+          backgroundColor:
+            theme.primary?.val ?? theme.brandPrimary?.val ?? "#ff8a3d",
+          alignItems: "center",
+          justifyContent: "center",
+          shadowColor: "#000000",
+          shadowOffset: { width: 0, height: 4 },
+          shadowOpacity: 0.32,
+          shadowRadius: 8,
+          elevation: 6,
+          transform: [{ scale: pressed ? 0.95 : 1 }],
+        })}
+        testID="dashboard-quick-add-fab"
+      >
+        <MaterialCommunityIcons name="plus" size={28} color="#ffffff" />
+      </Pressable>
+
+      <Modal
+        visible={open}
+        animationType="slide"
+        transparent
+        onRequestClose={handleClose}
+      >
+        <QuickAddSheet
+          onClose={handleClose}
+          onSubmit={() => {
+            void handleSubmit();
+          }}
+          form={form}
+          isSubmitting={createMutation.isPending}
+          submitError={createMutation.error}
+          dismissError={createMutation.reset}
+          translate={t}
+        />
+      </Modal>
+    </>
+  );
+}
+
+interface QuickAddSheetProps {
+  readonly onClose: () => void;
+  readonly onSubmit: () => void;
+  readonly form: ReturnType<typeof useForm<QuickAddValues>>;
+  readonly isSubmitting: boolean;
+  readonly submitError: unknown | null;
+  readonly dismissError: () => void;
+  readonly translate: (key: string) => string;
+}
+
+// eslint-disable-next-line max-lines-per-function
+function QuickAddSheet({
+  onClose,
+  onSubmit,
+  form,
+  isSubmitting,
+  submitError,
+  dismissError,
+  translate,
+}: QuickAddSheetProps): ReactElement {
+  const errors = form.formState.errors;
+  const typeOptions = useMemo(
+    () =>
+      [
+        { value: "expense" as const, label: translate("dashboard.quickAdd.types.expense") },
+        { value: "income" as const, label: translate("dashboard.quickAdd.types.income") },
+      ],
+    [translate],
+  );
+
+  return (
+    <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
+      <YStack
+        backgroundColor="$background"
+        padding="$4"
+        gap="$4"
+        borderTopLeftRadius="$3"
+        borderTopRightRadius="$3"
+      >
+        <AppSurfaceCard
+          title={translate("dashboard.quickAdd.title")}
+          description={translate("dashboard.quickAdd.description")}
+        >
+          <YStack gap="$3">
+            <Controller
+              control={form.control}
+              name="title"
+              render={({ field: { onChange, onBlur, value } }) => (
+                <AppInputField
+                  id="quick-title"
+                  label={translate("dashboard.quickAdd.fields.title")}
+                  value={value}
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  errorText={errors.title?.message}
+                  autoFocus
+                />
+              )}
+            />
+            <Controller
+              control={form.control}
+              name="amount"
+              render={({ field: { onChange, onBlur, value } }) => (
+                <AppInputField
+                  id="quick-amount"
+                  label={translate("dashboard.quickAdd.fields.amount")}
+                  keyboardType="decimal-pad"
+                  placeholder="0,00"
+                  value={value}
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  errorText={errors.amount?.message}
+                />
+              )}
+            />
+            <Controller
+              control={form.control}
+              name="type"
+              render={({ field: { onChange, value } }) => (
+                <YStack gap="$2">
+                  <Paragraph color="$color" fontFamily="$body" fontSize="$3">
+                    {translate("dashboard.quickAdd.fields.type")}
+                  </Paragraph>
+                  <XStack gap="$2">
+                    {typeOptions.map((option) => (
+                      <AppButton
+                        key={option.value}
+                        flex={1}
+                        tone={value === option.value ? "primary" : "secondary"}
+                        onPress={() => onChange(option.value)}
+                      >
+                        {option.label}
+                      </AppButton>
+                    ))}
+                  </XStack>
+                </YStack>
+              )}
+            />
+            <Controller
+              control={form.control}
+              name="dueDate"
+              render={({ field: { onChange, onBlur, value } }) => (
+                <AppInputField
+                  id="quick-date"
+                  label={translate("dashboard.quickAdd.fields.dueDate")}
+                  placeholder="YYYY-MM-DD"
+                  value={value}
+                  onBlur={onBlur}
+                  onChangeText={onChange}
+                  errorText={errors.dueDate?.message}
+                />
+              )}
+            />
+            {submitError ? (
+              <AppErrorNotice
+                error={submitError}
+                fallbackTitle="Nao foi possivel criar"
+                fallbackDescription="Confira os dados e tente novamente."
+                secondaryActionLabel="Fechar"
+                onSecondaryAction={dismissError}
+              />
+            ) : null}
+            <XStack gap="$2">
+              <AppButton flex={1} tone="secondary" onPress={onClose}>
+                {translate("dashboard.quickAdd.cancel")}
+              </AppButton>
+              <AppButton flex={1} onPress={onSubmit} disabled={isSubmitting}>
+                {isSubmitting
+                  ? translate("dashboard.quickAdd.submitting")
+                  : translate("dashboard.quickAdd.submit")}
+              </AppButton>
+            </XStack>
+          </YStack>
+        </AppSurfaceCard>
+      </YStack>
+    </YStack>
+  );
+}

--- a/features/dashboard/components/dashboard-upcoming-due-card.tsx
+++ b/features/dashboard/components/dashboard-upcoming-due-card.tsx
@@ -1,0 +1,122 @@
+import { useMemo, type ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import type { DueTransactionRecord } from "@/features/transactions/contracts";
+import { useDueRangeQuery } from "@/features/transactions/hooks/use-due-range-query";
+import { AppBadge } from "@/shared/components/app-badge";
+import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
+import { AppQueryState } from "@/shared/components/app-query-state";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useT } from "@/shared/i18n";
+import { TransactionListSkeleton } from "@/shared/skeletons";
+import { formatShortDate } from "@/shared/utils/formatters";
+
+const STATUS_TONE: Record<
+  DueTransactionRecord["status"],
+  "default" | "primary" | "danger"
+> = {
+  pending: "default",
+  paid: "primary",
+  overdue: "danger",
+  cancelled: "default",
+  postponed: "default",
+};
+
+const buildWindow = (): { start: string; end: string } => {
+  const now = new Date();
+  const sevenDaysOut = new Date(now);
+  sevenDaysOut.setDate(sevenDaysOut.getDate() + 7);
+  return {
+    start: now.toISOString().slice(0, 10),
+    end: sevenDaysOut.toISOString().slice(0, 10),
+  };
+};
+
+/**
+ * Dashboard card listing the top pending transactions in the next 7
+ * days (overdue first). Uses the standard query feedback wrapper so
+ * loading + empty + error all share the same canonical surface.
+ */
+export function DashboardUpcomingDueCard(): ReactElement {
+  const { t } = useT();
+  const window = useMemo(() => buildWindow(), []);
+  const query = useDueRangeQuery({
+    startDate: window.start,
+    endDate: window.end,
+    orderBy: "overdue_first",
+    perPage: 5,
+  });
+
+  return (
+    <AppSurfaceCard
+      title={t("dashboard.upcomingDue.title")}
+      description={t("dashboard.upcomingDue.description")}
+    >
+      <AppQueryState
+        query={query}
+        options={{
+          loading: {
+            title: t("dashboard.upcomingDue.title"),
+            description: t("dashboard.upcomingDue.description"),
+          },
+          loadingPresentation: "skeleton",
+          empty: {
+            title: t("dashboard.upcomingDue.empty"),
+          },
+          error: {
+            fallbackTitle: t("dashboard.upcomingDue.title"),
+          },
+          isEmpty: (data) => data.transactions.length === 0,
+        }}
+        loadingComponent={<TransactionListSkeleton rows={3} />}
+      >
+        {(data) => <DueList items={data.transactions} />}
+      </AppQueryState>
+    </AppSurfaceCard>
+  );
+}
+
+interface DueListProps {
+  readonly items: readonly DueTransactionRecord[];
+}
+
+function DueList({ items }: DueListProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      {items.map((item) => (
+        <DueRow key={item.id} item={item} />
+      ))}
+    </YStack>
+  );
+}
+
+interface DueRowProps {
+  readonly item: DueTransactionRecord;
+}
+
+function DueRow({ item }: DueRowProps): ReactElement {
+  return (
+    <AppKeyValueRow
+      label={item.title}
+      value={
+        <XStack alignItems="center" gap="$2">
+          <YStack alignItems="flex-end" gap="$1">
+            <Paragraph
+              color={item.type === "income" ? "$success" : "$danger"}
+              fontFamily="$body"
+              fontSize="$4"
+            >
+              {item.type === "income" ? "+" : "-"}
+              {item.amount}
+            </Paragraph>
+            <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+              {formatShortDate(item.dueDate)}
+            </Paragraph>
+          </YStack>
+          <AppBadge tone={STATUS_TONE[item.status]}>{item.status}</AppBadge>
+        </XStack>
+      }
+    />
+  );
+}

--- a/features/dashboard/components/dashboard-wallet-summary-card.tsx
+++ b/features/dashboard/components/dashboard-wallet-summary-card.tsx
@@ -1,0 +1,80 @@
+import { useCallback, type ReactElement } from "react";
+
+import { useRouter } from "expo-router";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { appRoutes } from "@/core/navigation/routes";
+import { useWalletValuationQuery } from "@/features/wallet/hooks/use-wallet-query";
+import { AppButton } from "@/shared/components/app-button";
+import { AppQueryState } from "@/shared/components/app-query-state";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { MetricGridSkeleton } from "@/shared/skeletons";
+import { useT } from "@/shared/i18n";
+import { formatCurrency } from "@/shared/utils/formatters";
+
+/**
+ * Embedded wallet summary on the dashboard. Shows total value and
+ * total profit/loss so the user has the headline number without
+ * navigating to /carteira.
+ */
+export function DashboardWalletSummaryCard(): ReactElement {
+  const { t } = useT();
+  const router = useRouter();
+  const query = useWalletValuationQuery();
+
+  const handleViewAll = useCallback((): void => {
+    router.push(appRoutes.private.wallet);
+  }, [router]);
+
+  return (
+    <AppSurfaceCard title={t("dashboard.embeddedSummaries.wallet.title")}>
+      <YStack gap="$3">
+        <AppQueryState
+          query={query}
+          options={{
+            loading: {
+              title: t("dashboard.embeddedSummaries.wallet.title"),
+            },
+            loadingPresentation: "skeleton",
+            empty: {
+              title: t("dashboard.embeddedSummaries.wallet.empty"),
+            },
+            error: {
+              fallbackTitle: t("dashboard.embeddedSummaries.wallet.title"),
+            },
+            isEmpty: (data) => data.totalCurrentValue === 0 && data.totalInvestedAmount === 0,
+          }}
+          loadingComponent={<MetricGridSkeleton tiles={2} />}
+        >
+          {(summary) => {
+            const profitColor =
+              summary.totalProfitLossPercent >= 0 ? "$success" : "$danger";
+            return (
+              <XStack gap="$3" flexWrap="wrap">
+                <YStack gap="$1" flex={1}>
+                  <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+                    Patrimônio
+                  </Paragraph>
+                  <Paragraph color="$color" fontFamily="$heading" fontSize="$6">
+                    {formatCurrency(summary.totalCurrentValue)}
+                  </Paragraph>
+                </YStack>
+                <YStack gap="$1" flex={1}>
+                  <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+                    Lucro / Prejuízo
+                  </Paragraph>
+                  <Paragraph color={profitColor} fontFamily="$heading" fontSize="$6">
+                    {summary.totalProfitLossPercent.toFixed(2)}%
+                  </Paragraph>
+                </YStack>
+              </XStack>
+            );
+          }}
+        </AppQueryState>
+        <AppButton tone="secondary" onPress={handleViewAll}>
+          {t("dashboard.embeddedSummaries.wallet.viewAll")}
+        </AppButton>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}

--- a/features/dashboard/hooks/use-dashboard-screen-controller.ts
+++ b/features/dashboard/hooks/use-dashboard-screen-controller.ts
@@ -6,6 +6,10 @@ import {
   useDashboardTrendsQuery,
 } from "@/features/dashboard/hooks/use-dashboard-overview-query";
 import {
+  buildPeriodComparison,
+  type PeriodComparison,
+} from "@/features/dashboard/services/period-comparison";
+import {
   savingsRateCalculator,
   type SavingsRateAssessment,
 } from "@/features/dashboard/services/savings-rate-calculator";
@@ -30,6 +34,7 @@ export interface DashboardScreenController {
   readonly monthSnapshot: DashboardMonthSnapshot | null;
   readonly currentBalance: number;
   readonly savingsRate: SavingsRateAssessment | null;
+  readonly comparison: PeriodComparison;
   readonly greetingName: string;
   readonly setSelectedMonth: (month: string) => void;
 }
@@ -104,6 +109,13 @@ export function useDashboardScreenController(): DashboardScreenController {
     });
   }, [monthSnapshot]);
 
+  const comparison = useMemo<PeriodComparison>(() => {
+    return buildPeriodComparison(
+      trendsQuery.data?.series ?? [],
+      selectedMonth,
+    );
+  }, [selectedMonth, trendsQuery.data]);
+
   return {
     overviewQuery,
     trendsQuery,
@@ -112,6 +124,7 @@ export function useDashboardScreenController(): DashboardScreenController {
     monthSnapshot,
     currentBalance: overviewQuery.data?.totals.balance ?? 0,
     savingsRate,
+    comparison,
     greetingName: firstName(userName),
     setSelectedMonth,
   };

--- a/features/dashboard/screens/dashboard-screen.tsx
+++ b/features/dashboard/screens/dashboard-screen.tsx
@@ -2,10 +2,15 @@ import type { ReactElement } from "react";
 
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { DashboardComparisonCard } from "@/features/dashboard/components/dashboard-comparison-card";
 import { DashboardCountsCard } from "@/features/dashboard/components/dashboard-counts-card";
+import { DashboardGoalsSummaryCard } from "@/features/dashboard/components/dashboard-goals-summary-card";
+import { DashboardQuickAddFab } from "@/features/dashboard/components/dashboard-quick-add-fab";
 import { DashboardSurvivalIndexCard } from "@/features/dashboard/components/dashboard-survival-index-card";
 import { DashboardTopCategoriesCard } from "@/features/dashboard/components/dashboard-top-categories-card";
 import { DashboardTrendsChartCard } from "@/features/dashboard/components/dashboard-trends-chart-card";
+import { DashboardUpcomingDueCard } from "@/features/dashboard/components/dashboard-upcoming-due-card";
+import { DashboardWalletSummaryCard } from "@/features/dashboard/components/dashboard-wallet-summary-card";
 import {
   useDashboardScreenController,
   type DashboardScreenController,
@@ -38,6 +43,7 @@ const formatSavingsRate = (rate: number): string => {
  *
  * @returns Greeting, balance, savings rate and monthly snapshot panels.
  */
+// eslint-disable-next-line complexity
 export function DashboardScreen(): ReactElement {
   const controller = useDashboardScreenController();
   const overview = controller.overviewQuery.data;
@@ -47,6 +53,39 @@ export function DashboardScreen(): ReactElement {
   return (
     <AppScreen>
       <BalanceCard controller={controller} />
+      {controller.monthSnapshot ? (
+        <DashboardComparisonCard
+          title="Saldo"
+          value={controller.monthSnapshot.balance}
+          delta={controller.comparison.delta?.balance ?? null}
+          percent={controller.comparison.percent?.balance ?? null}
+          positiveIsGood
+          testID="dashboard-comparison-balance"
+        />
+      ) : null}
+      {controller.monthSnapshot ? (
+        <DashboardComparisonCard
+          title="Receitas"
+          value={controller.monthSnapshot.incomes}
+          delta={controller.comparison.delta?.income ?? null}
+          percent={controller.comparison.percent?.income ?? null}
+          positiveIsGood
+          testID="dashboard-comparison-income"
+        />
+      ) : null}
+      {controller.monthSnapshot ? (
+        <DashboardComparisonCard
+          title="Despesas"
+          value={controller.monthSnapshot.expenses}
+          delta={controller.comparison.delta?.expenses ?? null}
+          percent={controller.comparison.percent?.expenses ?? null}
+          positiveIsGood={false}
+          testID="dashboard-comparison-expenses"
+        />
+      ) : null}
+      <DashboardUpcomingDueCard />
+      <DashboardGoalsSummaryCard />
+      <DashboardWalletSummaryCard />
       {controller.savingsRate ? (
         <SavingsRateCard assessment={controller.savingsRate} />
       ) : null}
@@ -79,6 +118,7 @@ export function DashboardScreen(): ReactElement {
           tone="income"
         />
       ) : null}
+      <DashboardQuickAddFab />
     </AppScreen>
   );
 }

--- a/features/dashboard/services/period-comparison.test.ts
+++ b/features/dashboard/services/period-comparison.test.ts
@@ -1,0 +1,69 @@
+import {
+  buildPeriodComparison,
+  resolveComparisonDirection,
+} from "@/features/dashboard/services/period-comparison";
+
+interface PointArgs {
+  readonly month: string;
+  readonly income: number;
+  readonly expenses: number;
+  readonly balance: number;
+}
+
+const point = (args: PointArgs) => args;
+
+describe("buildPeriodComparison", () => {
+  it("returns nulls when the selected month is absent", () => {
+    const result = buildPeriodComparison(
+      [point({ month: "2026-01", income: 1000, expenses: 800, balance: 200 })],
+      "2026-03",
+    );
+    expect(result.current).toBeNull();
+    expect(result.delta).toBeNull();
+  });
+
+  it("returns no delta when selected is the first month in the series", () => {
+    const result = buildPeriodComparison(
+      [point({ month: "2026-02", income: 1000, expenses: 600, balance: 400 })],
+      "2026-02",
+    );
+    expect(result.previous).toBeNull();
+    expect(result.delta).toBeNull();
+  });
+
+  it("computes delta and percent against the immediate previous month", () => {
+    const result = buildPeriodComparison(
+      [
+        point({ month: "2026-01", income: 1000, expenses: 800, balance: 200 }),
+        point({ month: "2026-02", income: 1500, expenses: 600, balance: 900 }),
+      ],
+      "2026-02",
+    );
+    expect(result.delta).toEqual({ income: 500, expenses: -200, balance: 700 });
+    expect(result.percent?.income).toBeCloseTo(0.5);
+    expect(result.percent?.expenses).toBeCloseTo(-0.25);
+    expect(result.percent?.balance).toBeCloseTo(3.5);
+  });
+
+  it("handles divide-by-zero gracefully", () => {
+    const result = buildPeriodComparison(
+      [point({ month: "2026-01", income: 0, expenses: 0, balance: 0 }), point({ month: "2026-02", income: 100, expenses: 0, balance: 100 })],
+      "2026-02",
+    );
+    expect(result.percent?.income).toBe(Number.POSITIVE_INFINITY);
+    expect(result.percent?.expenses).toBe(0);
+    expect(result.percent?.balance).toBe(Number.POSITIVE_INFINITY);
+  });
+});
+
+describe("resolveComparisonDirection", () => {
+  it.each([
+    [10, "up"],
+    [-5, "down"],
+    [0, "flat"],
+    [Number.POSITIVE_INFINITY, "up"],
+    [Number.NEGATIVE_INFINITY, "down"],
+  ] as const)("delta %p → %p", (delta, expected) => {
+    expect(resolveComparisonDirection(delta)).toBe(expected);
+  });
+});

--- a/features/dashboard/services/period-comparison.ts
+++ b/features/dashboard/services/period-comparison.ts
@@ -1,0 +1,100 @@
+import type { DashboardTrendPoint } from "@/features/dashboard/contracts";
+
+export type ComparisonDirection = "up" | "down" | "flat";
+
+export interface PeriodComparison {
+  /** Selected month, snapshotted from the trend point. */
+  readonly current: DashboardTrendPoint | null;
+  /** Period immediately before `current` in the same series. */
+  readonly previous: DashboardTrendPoint | null;
+  /** Absolute delta (current - previous) per axis. Null when no baseline. */
+  readonly delta: {
+    readonly income: number;
+    readonly expenses: number;
+    readonly balance: number;
+  } | null;
+  /**
+   * Percentage change per axis with sane handling for divide-by-zero
+   * (returns Infinity * sign(delta) when previous is 0 and delta != 0).
+   * Null when no baseline.
+   */
+  readonly percent: {
+    readonly income: number;
+    readonly expenses: number;
+    readonly balance: number;
+  } | null;
+}
+
+const safeRatio = (current: number, previous: number): number => {
+  if (previous === 0) {
+    if (current === 0) {
+      return 0;
+    }
+    return current > 0 ? Number.POSITIVE_INFINITY : Number.NEGATIVE_INFINITY;
+  }
+  return (current - previous) / Math.abs(previous);
+};
+
+/**
+ * Resolves the comparison snapshot for the selected month against the
+ * immediately preceding entry in the trends series. Returns nulls when
+ * the baseline is missing so call sites can fall back to a neutral
+ * UI without branching on series shape.
+ *
+ * @param series Trend series ordered by month ascending.
+ * @param selectedMonth Target month in `YYYY-MM` format.
+ */
+export const buildPeriodComparison = (
+  series: readonly DashboardTrendPoint[],
+  selectedMonth: string,
+): PeriodComparison => {
+  const sorted = [...series].sort((a, b) => a.month.localeCompare(b.month));
+  const index = sorted.findIndex((point) => point.month === selectedMonth);
+  if (index === -1) {
+    return { current: null, previous: null, delta: null, percent: null };
+  }
+
+  const current = sorted[index];
+  const previous = index > 0 ? sorted[index - 1] : null;
+
+  if (!current || !previous) {
+    return { current: current ?? null, previous: null, delta: null, percent: null };
+  }
+
+  return {
+    current,
+    previous,
+    delta: {
+      income: current.income - previous.income,
+      expenses: current.expenses - previous.expenses,
+      balance: current.balance - previous.balance,
+    },
+    percent: {
+      income: safeRatio(current.income, previous.income),
+      expenses: safeRatio(current.expenses, previous.expenses),
+      balance: safeRatio(current.balance, previous.balance),
+    },
+  };
+};
+
+/**
+ * Resolves the visual direction (up / down / flat) for a delta against
+ * an "is positive good" semantic. For income/balance, up = good (green).
+ * For expenses, up = bad (red) — the caller controls the colour by
+ * inverting `positiveGood`.
+ *
+ * @param delta Numeric delta, may be ±Infinity.
+ * @returns `flat` when delta is 0 (or both sides were 0).
+ */
+export const resolveComparisonDirection = (delta: number): ComparisonDirection => {
+  if (!Number.isFinite(delta)) {
+    return delta > 0 ? "up" : "down";
+  }
+  if (delta > 0) {
+    return "up";
+  }
+  if (delta < 0) {
+    return "down";
+  }
+  return "flat";
+};

--- a/features/transactions/contracts.ts
+++ b/features/transactions/contracts.ts
@@ -106,3 +106,39 @@ export interface DeletedTransactionRecord extends TransactionRecord {
 export interface DeletedTransactionListResponse {
   readonly transactions: readonly DeletedTransactionRecord[];
 }
+
+/** Single item returned by GET /transactions/due-range. */
+export interface DueTransactionRecord {
+  readonly id: string;
+  readonly title: string;
+  readonly amount: string;
+  readonly type: "income" | "expense";
+  readonly dueDate: string;
+  readonly status: "pending" | "paid" | "overdue" | "postponed" | "cancelled";
+  readonly tagId: string | null;
+  readonly accountId: string | null;
+  readonly creditCardId: string | null;
+  readonly isRecurring: boolean;
+}
+
+export interface DueRangeCounts {
+  readonly total: number;
+  readonly overdue: number;
+  readonly pending: number;
+}
+
+export interface DueRangeResponse {
+  readonly transactions: DueTransactionRecord[];
+  readonly total: number;
+  readonly page: number;
+  readonly perPage: number;
+  readonly counts: DueRangeCounts;
+}
+
+export interface DueRangeFilters {
+  readonly startDate?: string;
+  readonly endDate?: string;
+  readonly orderBy?: "overdue_first" | "date" | "title";
+  readonly page?: number;
+  readonly perPage?: number;
+}

--- a/features/transactions/hooks/use-due-range-query.ts
+++ b/features/transactions/hooks/use-due-range-query.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+
+import type { DueRangeFilters, DueRangeResponse } from "@/features/transactions/contracts";
+import { dueRangeService } from "@/features/transactions/services/due-range-service";
+
+const dueRangeKey = (filters: DueRangeFilters): readonly unknown[] => {
+  return ["transactions", "due-range", filters] as const;
+};
+
+/**
+ * GET /transactions/due-range — list of pending transactions ordered
+ * by overdue first within a configurable window. Defaults align with
+ * the dashboard "next 7 days" card.
+ *
+ * @param filters Optional date range / ordering / pagination.
+ */
+export const useDueRangeQuery = (filters: DueRangeFilters = {}) => {
+  return useQuery<DueRangeResponse>({
+    queryKey: dueRangeKey(filters),
+    queryFn: () => dueRangeService.list(filters),
+    staleTime: 60_000,
+  });
+};

--- a/features/transactions/services/due-range-service.ts
+++ b/features/transactions/services/due-range-service.ts
@@ -1,0 +1,90 @@
+import type { AxiosInstance } from "axios";
+
+import { unwrapEnvelopeData } from "@/core/http/contracts";
+import { httpClient } from "@/core/http/http-client";
+import type {
+  DueRangeFilters,
+  DueRangeResponse,
+  DueTransactionRecord,
+} from "@/features/transactions/contracts";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
+
+interface DuePayload {
+  readonly id: string;
+  readonly title: string;
+  readonly amount: string;
+  readonly type: "income" | "expense";
+  readonly due_date: string;
+  readonly status: DueTransactionRecord["status"];
+  readonly tag_id: string | null;
+  readonly account_id: string | null;
+  readonly credit_card_id: string | null;
+  readonly is_recurring: boolean;
+}
+
+interface DueRangePayload {
+  readonly transactions: readonly DuePayload[];
+  readonly total: number;
+  readonly page: number;
+  readonly per_page: number;
+  readonly counts: {
+    readonly total: number;
+    readonly overdue: number;
+    readonly pending: number;
+  };
+}
+
+const mapItem = (item: DuePayload): DueTransactionRecord => {
+  return {
+    id: item.id,
+    title: item.title,
+    amount: item.amount,
+    type: item.type,
+    dueDate: item.due_date,
+    status: item.status,
+    tagId: item.tag_id,
+    accountId: item.account_id,
+    creditCardId: item.credit_card_id,
+    isRecurring: item.is_recurring,
+  };
+};
+
+const mapResponse = (payload: DueRangePayload): DueRangeResponse => {
+  return {
+    transactions: payload.transactions.map(mapItem),
+    total: payload.total,
+    page: payload.page,
+    perPage: payload.per_page,
+    counts: {
+      total: payload.counts.total,
+      overdue: payload.counts.overdue,
+      pending: payload.counts.pending,
+    },
+  };
+};
+
+const buildParams = (
+  filters: DueRangeFilters,
+): Record<string, string | number | undefined> => {
+  return {
+    start_date: filters.startDate,
+    end_date: filters.endDate,
+    order_by: filters.orderBy,
+    page: filters.page,
+    per_page: filters.perPage,
+  };
+};
+
+export const createDueRangeService = (client: AxiosInstance) => {
+  return {
+    list: async (filters: DueRangeFilters = {}): Promise<DueRangeResponse> => {
+      const response = await client.get(
+        apiContractMap.transactionsDueRange.path,
+        { params: buildParams(filters) },
+      );
+      return mapResponse(unwrapEnvelopeData<DueRangePayload>(response.data));
+    },
+  };
+};
+
+export const dueRangeService = createDueRangeService(httpClient);

--- a/shared/contracts/api-contract-map.ts
+++ b/shared/contracts/api-contract-map.ts
@@ -91,6 +91,8 @@ import type {
 import type {
   CreateTransactionCommand,
   DeletedTransactionListResponse,
+  DueRangeFilters,
+  DueRangeResponse,
   TransactionCollection,
   TransactionListQuery,
   TransactionRecord,
@@ -411,6 +413,17 @@ export const apiContractMap = {
   >({
     method: "GET",
     path: "/transactions/summary",
+    authRequired: true,
+  }),
+  transactionsDueRange: defineApiContract<
+    "GET",
+    "/transactions/due-range",
+    never,
+    DueRangeResponse,
+    DueRangeFilters
+  >({
+    method: "GET",
+    path: "/transactions/due-range",
     authRequired: true,
   }),
   goalsList: defineApiContract<"GET", "/goals", never, GoalListResponse>({

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -80,6 +80,47 @@
     "monthSummary": {
       "title": "Monthly summary",
       "description": "Income, expenses and balance for the selected period."
+    },
+    "quickAdd": {
+      "fabLabel": "Quick transaction",
+      "title": "Quick entry",
+      "description": "Create a transaction with just 4 fields.",
+      "submit": "Create",
+      "submitting": "Creating...",
+      "cancel": "Cancel",
+      "fields": {
+        "title": "Description",
+        "amount": "Amount",
+        "type": "Type",
+        "dueDate": "Date"
+      },
+      "types": {
+        "income": "Income",
+        "expense": "Expense"
+      }
+    },
+    "comparison": {
+      "vsPrevious": "vs previous month",
+      "noBaseline": "No comparison available."
+    },
+    "upcomingDue": {
+      "title": "Upcoming due",
+      "description": "Pending transactions in the next 7 days.",
+      "empty": "No upcoming dues this week.",
+      "markPaid": "Mark as paid",
+      "marking": "Marking..."
+    },
+    "embeddedSummaries": {
+      "goals": {
+        "title": "Your goals",
+        "viewAll": "View all",
+        "empty": "No goals yet."
+      },
+      "wallet": {
+        "title": "Your wallet",
+        "viewAll": "View wallet",
+        "empty": "Wallet is empty."
+      }
     }
   }
 }

--- a/shared/i18n/locales/pt.json
+++ b/shared/i18n/locales/pt.json
@@ -80,6 +80,47 @@
     "monthSummary": {
       "title": "Resumo por mes",
       "description": "Receitas, despesas e saldo do periodo selecionado."
+    },
+    "quickAdd": {
+      "fabLabel": "Nova transacao rapida",
+      "title": "Lancamento rapido",
+      "description": "Crie uma transacao com apenas 4 campos.",
+      "submit": "Criar",
+      "submitting": "Criando...",
+      "cancel": "Cancelar",
+      "fields": {
+        "title": "Descricao",
+        "amount": "Valor",
+        "type": "Tipo",
+        "dueDate": "Data"
+      },
+      "types": {
+        "income": "Receita",
+        "expense": "Despesa"
+      }
+    },
+    "comparison": {
+      "vsPrevious": "vs mes anterior",
+      "noBaseline": "Sem comparacao disponivel."
+    },
+    "upcomingDue": {
+      "title": "Proximos vencimentos",
+      "description": "Transacoes pendentes nos proximos 7 dias.",
+      "empty": "Nenhum vencimento na semana.",
+      "markPaid": "Marcar como pago",
+      "marking": "Marcando..."
+    },
+    "embeddedSummaries": {
+      "goals": {
+        "title": "Suas metas",
+        "viewAll": "Ver todas",
+        "empty": "Nenhuma meta cadastrada ainda."
+      },
+      "wallet": {
+        "title": "Sua carteira",
+        "viewAll": "Ver carteira",
+        "empty": "Sua carteira esta vazia."
+      }
     }
   }
 }


### PR DESCRIPTION
Closes #301.

## Why

Dashboard estava cobrindo só uma fração do que o web já entrega: saldo, taxa de poupança, snapshot mensal e top categorias. Esta PR avança em 4 frentes que aparecem no audit + issue spec:

1. **Comparação MoM** em todos os cards principais (saldo, receitas, despesas)
2. **Quick add FAB** sempre visível, criando transação em ≤2 taps
3. **Próximos vencimentos** consumindo `due-range` (que existe no backend mas não estava plumbado)
4. **Resumos embedded** de goals e wallet — usuário vê momentum sem trocar de tab

## What changes

### 1. Contract + service para `/transactions/due-range`
- `features/transactions/contracts.ts` — `DueTransactionRecord` (camelCase domain), `DueRangeCounts`, `DueRangeResponse`, `DueRangeFilters`. Mirror do shape já implementado no web.
- `features/transactions/services/due-range-service.ts` — axios client com snake_case → camelCase mapper.
- `features/transactions/hooks/use-due-range-query.ts` — TanStack Query hook keyed `transactions.due-range`, staleTime 60s.
- `shared/contracts/api-contract-map.ts` — registra `transactionsDueRange`.

### 2. Comparação MoM
- `features/dashboard/services/period-comparison.ts` — `buildPeriodComparison()` resolve current vs previous trend points e computa deltas/percents seguros (divide-by-zero → ±Infinity sentinels). `resolveComparisonDirection()` colapsa o sinal em up/down/flat. **9 tests** cobrem matemática + edge cases.
- `features/dashboard/components/dashboard-comparison-card.tsx` — card métrica com valor + delta + ícone de tendência. Income/balance: `positiveIsGood=true` (up = verde); expenses: `false` (up = vermelho).

### 3. Quick Add FAB
- `features/dashboard/components/dashboard-quick-add-fab.tsx` — botão flutuante com bottom-sheet form (4 campos: descrição, valor, tipo, data). **Reusa `createTransactionSchema` via `.pick()`** — validação fica em sync com o form completo de transação. Haptic medium ao abrir o FAB; success haptic vem grátis via `useApiMutation`.

### 4. Cards de Próximos vencimentos + Resumos embedded
- `dashboard-upcoming-due-card.tsx` — usa `useDueRangeQuery` com janela 7 dias ordenada por overdue first.
- `dashboard-goals-summary-card.tsx` — top 2 goals por progresso (%) com barra de progresso. CTA "Ver todas" → `/metas`.
- `dashboard-wallet-summary-card.tsx` — patrimônio + P&L. CTA "Ver carteira" → `/carteira`.

### 5. Plumbing
- `use-dashboard-screen-controller.ts` ganha `comparison` no contract.
- `dashboard-screen.tsx` insere os 5 novos componentes em sequência lógica (3 comparison cards → upcoming due → goals → wallet → resto da tela existente → FAB no final).
- i18n: `dashboard.quickAdd.*`, `dashboard.comparison.*`, `dashboard.upcomingDue.*`, `dashboard.embeddedSummaries.*` em PT + EN.

## Validation

- `npm run typecheck` ✅
- `npm run policy:check` ✅ (8 governance scripts)
- `npm run contracts:check` ✅
- `npm run test:coverage` ✅ — **809 tests / 187 suites**, coverage **94.82% lines / 85.38% branches**
- 9 testes novos (period-comparison)
- Pre-commit + pre-push verdes

## Visual smoke test

- [ ] Abrir dashboard com 2+ meses de trends → cards de Saldo/Receitas/Despesas mostram delta vs mês anterior com ícones e cores corretas
- [ ] Abrir dashboard com 1 mês só → cards mostram "Sem comparação disponível"
- [ ] FAB visível bottom-right; tap abre sheet com 4 campos
- [ ] Submit do quick-add → transação criada, haptic success, sheet fecha
- [ ] Próximos vencimentos lista até 5 itens com badges de status
- [ ] Goals card mostra top 2 com barra de progresso; tap "Ver todas" → /metas
- [ ] Wallet card mostra patrimônio + %; tap "Ver carteira" → /carteira

## Out of scope (deferred deliberately)

- **Período customizável (date range picker)** — backend só aceita `month: YYYY-MM` hoje. DateRangePicker arbitrário precisa de contract change na API. Tracking issue de follow-up se necessário.
- **Layout responsivo 2x2 grid em tablet** — ajuste cosmético; melhor validar contra design final.
- **Card "Saúde financeira" agregado** — mencionado no audit do web; spec não prioriza para esta epic.

## Test plan
- [x] Typecheck verde
- [x] Policy + contracts verde
- [x] 809 testes / coverage 94.82% / 85.38% branches
- [x] Pre-push verde
- [ ] CI verde
- [ ] Smoke test em iOS device
- [ ] Smoke test em Android device
- [ ] Validar FAB não cobre conteúdo crítico ao final do scroll
