### PR TITLE
feat(app): standalone /resend-confirmation + rich checkout outcome cards

### DIFF
--- a/app/(public)/resend-confirmation.tsx
+++ b/app/(public)/resend-confirmation.tsx
@@ -1,0 +1,1 @@
+export { ResendConfirmationScreen as default } from "@/features/auth/screens/resend-confirmation-screen";

--- a/core/navigation/routes.ts
+++ b/core/navigation/routes.ts
@@ -12,6 +12,7 @@ export const appRoutes = {
     register: "/register",
     forgotPassword: "/forgot-password",
     resetPassword: "/reset-password",
+    resendConfirmation: "/resend-confirmation",
   },
   private: {
     dashboard: "/dashboard",
@@ -129,6 +130,13 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
   {
     key: "resetPassword",
     path: appRoutes.public.resetPassword,
+    access: "public",
+    tabVisible: false,
+    supportsHostedCheckoutReturn: false,
+  },
+  {
+    key: "resendConfirmation",
+    path: appRoutes.public.resendConfirmation,
     access: "public",
     tabVisible: false,
     supportsHostedCheckoutReturn: false,

--- a/features/auth/hooks/use-resend-confirmation-screen-controller.test.ts
+++ b/features/auth/hooks/use-resend-confirmation-screen-controller.test.ts
@@ -1,0 +1,105 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import { resetSessionStore, useSessionStore } from "@/core/session/session-store";
+import {
+  useResendConfirmationMutation,
+} from "@/features/auth/hooks/use-auth-mutations";
+import { useResendConfirmationScreenController } from "@/features/auth/hooks/use-resend-confirmation-screen-controller";
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ replace: jest.fn(), push: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock("@/features/auth/hooks/use-auth-mutations", () => ({
+  useResendConfirmationMutation: jest.fn(),
+}));
+
+const mockedUseResendConfirmationMutation = jest.mocked(
+  useResendConfirmationMutation,
+);
+
+const buildMutation = (overrides: Partial<ReturnType<typeof useResendConfirmationMutation>> = {}) => {
+  return {
+    mutateAsync: jest.fn().mockResolvedValue(undefined),
+    isPending: false,
+    error: null,
+    reset: jest.fn(),
+    ...overrides,
+  } as unknown as ReturnType<typeof useResendConfirmationMutation>;
+};
+
+describe("useResendConfirmationScreenController", () => {
+  beforeEach(() => {
+    resetSessionStore();
+    mockedUseResendConfirmationMutation.mockReturnValue(buildMutation());
+  });
+
+  it("preenche email da sessao quando autenticado", () => {
+    useSessionStore.setState({ userEmail: "user@example.com" } as never);
+    const { result } = renderHook(() => useResendConfirmationScreenController());
+    expect(result.current.email).toBe("user@example.com");
+    expect(result.current.canEditEmail).toBe(false);
+  });
+
+  it("permite edicao quando nao ha email na sessao", () => {
+    useSessionStore.setState({ userEmail: null } as never);
+    const { result } = renderHook(() => useResendConfirmationScreenController());
+    expect(result.current.canEditEmail).toBe(true);
+  });
+
+  it("dispara mutation e marca sucesso", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue(undefined);
+    mockedUseResendConfirmationMutation.mockReturnValue(
+      buildMutation({ mutateAsync } as never),
+    );
+
+    const { result } = renderHook(() => useResendConfirmationScreenController());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(result.current.hasSucceeded).toBe(true);
+    });
+  });
+
+  it("aplica rate limit local de 60 segundos apos sucesso", async () => {
+    const mutateAsync = jest.fn().mockResolvedValue(undefined);
+    mockedUseResendConfirmationMutation.mockReturnValue(
+      buildMutation({ mutateAsync } as never),
+    );
+
+    const { result } = renderHook(() => useResendConfirmationScreenController());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.remainingSeconds).toBeGreaterThan(0);
+    expect(result.current.remainingSeconds).toBeLessThanOrEqual(60);
+
+    // Tentar de novo deve no-op enquanto restante > 0
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it("mantem hasSucceeded falso quando mutation falha", async () => {
+    const mutateAsync = jest.fn().mockRejectedValue(new Error("boom"));
+    mockedUseResendConfirmationMutation.mockReturnValue(
+      buildMutation({ mutateAsync } as never),
+    );
+
+    const { result } = renderHook(() => useResendConfirmationScreenController());
+
+    await act(async () => {
+      await result.current.handleSubmit();
+    });
+
+    expect(result.current.hasSucceeded).toBe(false);
+  });
+});

--- a/features/auth/hooks/use-resend-confirmation-screen-controller.ts
+++ b/features/auth/hooks/use-resend-confirmation-screen-controller.ts
@@ -1,0 +1,94 @@
+import { useRouter } from "expo-router";
+import { useCallback, useEffect, useState } from "react";
+
+import { appRoutes } from "@/core/navigation/routes";
+import { useSessionStore } from "@/core/session/session-store";
+import { useResendConfirmationMutation } from "@/features/auth/hooks/use-auth-mutations";
+
+const RATE_LIMIT_SECONDS = 60;
+
+export interface ResendConfirmationScreenController {
+  readonly email: string;
+  readonly canEditEmail: boolean;
+  readonly setEmail: (value: string) => void;
+  readonly isSubmitting: boolean;
+  readonly hasSucceeded: boolean;
+  readonly submitError: unknown | null;
+  readonly remainingSeconds: number;
+  readonly handleSubmit: () => Promise<void>;
+  readonly dismissSubmitError: () => void;
+  readonly handleBackToLogin: () => void;
+}
+
+/**
+ * Controller for the standalone /resend-confirmation screen.
+ *
+ * Pulls the user's email from the session store when available so a
+ * post-register flow doesn't have to re-type it. When the user is
+ * unauthenticated (came in via deep link) we let them edit the email.
+ *
+ * Enforces a local 60-second rate limit between submissions so a
+ * frustrated user can't accidentally hammer the endpoint — the
+ * backend already enforces its own limit; this is purely UX.
+ */
+export function useResendConfirmationScreenController(): ResendConfirmationScreenController {
+  const router = useRouter();
+  const sessionEmail = useSessionStore((state) => state.userEmail);
+  const resendMutation = useResendConfirmationMutation();
+  const [email, setEmail] = useState<string>(sessionEmail ?? "");
+  const [hasSucceeded, setHasSucceeded] = useState<boolean>(false);
+  const [lastSubmitAt, setLastSubmitAt] = useState<number | null>(null);
+  const [now, setNow] = useState<number>(() => Date.now());
+
+  const elapsed =
+    lastSubmitAt === null ? Number.POSITIVE_INFINITY : (now - lastSubmitAt) / 1000;
+  const remainingSeconds = Math.max(
+    0,
+    Math.ceil(RATE_LIMIT_SECONDS - elapsed),
+  );
+
+  useEffect(() => {
+    if (lastSubmitAt === null) {
+      return undefined;
+    }
+    const id = setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+    return () => {
+      clearInterval(id);
+    };
+  }, [lastSubmitAt]);
+
+  const handleSubmit = useCallback(async (): Promise<void> => {
+    if (remainingSeconds > 0) {
+      return;
+    }
+    setHasSucceeded(false);
+    try {
+      await resendMutation.mutateAsync();
+      setHasSucceeded(true);
+      setLastSubmitAt(Date.now());
+      setNow(Date.now());
+    } catch {
+      setHasSucceeded(false);
+    }
+  }, [remainingSeconds, resendMutation]);
+
+  return {
+    email,
+    canEditEmail: sessionEmail === null,
+    setEmail,
+    isSubmitting: resendMutation.isPending,
+    hasSucceeded,
+    submitError: resendMutation.error,
+    remainingSeconds,
+    handleSubmit,
+    dismissSubmitError: () => {
+      resendMutation.reset();
+      setHasSucceeded(false);
+    },
+    handleBackToLogin: () => {
+      router.replace(appRoutes.public.login);
+    },
+  };
+}

--- a/features/auth/screens/resend-confirmation-screen.tsx
+++ b/features/auth/screens/resend-confirmation-screen.tsx
@@ -1,0 +1,82 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, YStack } from "tamagui";
+
+import { useResendConfirmationScreenController } from "@/features/auth/hooks/use-resend-confirmation-screen-controller";
+import { AppButton } from "@/shared/components/app-button";
+import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppInputField } from "@/shared/components/app-input-field";
+import { AppScreen } from "@/shared/components/app-screen";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useT } from "@/shared/i18n";
+
+/**
+ * Standalone /resend-confirmation screen reachable via deep link or
+ * via the "I didn't receive" link inside `confirm-email-pending`.
+ * Wraps the existing resend mutation in a form with a local 60s
+ * rate limit so impatient users don't bounce off the backend limit.
+ */
+export function ResendConfirmationScreen(): ReactElement {
+  const { t } = useT();
+  const controller = useResendConfirmationScreenController();
+
+  const submitLabel = controller.isSubmitting
+    ? t("auth.resendConfirmation.submitting")
+    : controller.remainingSeconds > 0
+      ? t("auth.resendConfirmation.rateLimited", {
+          seconds: controller.remainingSeconds,
+        })
+      : t("auth.resendConfirmation.submit");
+
+  return (
+    <AppScreen>
+      <AppSurfaceCard
+        title={t("auth.resendConfirmation.title")}
+        description={t("auth.resendConfirmation.description")}
+      >
+        <YStack gap="$4">
+          <AppInputField
+            id="resend-email"
+            label={t("auth.resendConfirmation.emailLabel")}
+            value={controller.email}
+            disabled={!controller.canEditEmail}
+            autoCapitalize="none"
+            autoComplete="email"
+            keyboardType="email-address"
+            onChangeText={controller.setEmail}
+          />
+
+          <AppButton
+            onPress={() => {
+              void controller.handleSubmit();
+            }}
+            disabled={
+              controller.isSubmitting || controller.remainingSeconds > 0
+            }
+          >
+            {submitLabel}
+          </AppButton>
+
+          {controller.hasSucceeded ? (
+            <Paragraph color="$success" fontFamily="$body" fontSize="$3">
+              {t("auth.resendConfirmation.success")}
+            </Paragraph>
+          ) : null}
+
+          {controller.submitError ? (
+            <AppErrorNotice
+              error={controller.submitError}
+              fallbackTitle={t("auth.resendConfirmation.title")}
+              secondaryActionLabel="Fechar"
+              onSecondaryAction={controller.dismissSubmitError}
+            />
+          ) : null}
+
+          <AppButton tone="secondary" onPress={controller.handleBackToLogin}>
+            {t("auth.resendConfirmation.backToLogin")}
+          </AppButton>
+        </YStack>
+      </AppSurfaceCard>
+    </AppScreen>
+  );
+}

--- a/features/subscription/components/checkout-outcome-card.tsx
+++ b/features/subscription/components/checkout-outcome-card.tsx
@@ -1,0 +1,140 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, YStack, useTheme } from "tamagui";
+
+import type { CheckoutOutcome } from "@/features/subscription/hooks/use-checkout-flow";
+import { AppButton } from "@/shared/components/app-button";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { useT } from "@/shared/i18n";
+
+const SUCCESS_FEATURE_KEYS: readonly string[] = [
+  "checkout.success.features.tools",
+  "checkout.success.features.wallet",
+  "checkout.success.features.support",
+];
+
+export interface CheckoutOutcomeCardProps {
+  readonly outcome: Extract<CheckoutOutcome, "completed" | "canceled" | "dismissed">;
+  readonly onPrimaryAction: () => void;
+  readonly onSecondaryAction?: () => void;
+}
+
+/**
+ * Rich celebrative / consoling card shown after the hosted checkout
+ * returns. Replaces the previous bare async-notice block with copy
+ * pulled from i18n and a clear next step (explore the app on
+ * success, retry on cancel).
+ */
+// eslint-disable-next-line max-lines-per-function
+export function CheckoutOutcomeCard({
+  outcome,
+  onPrimaryAction,
+  onSecondaryAction,
+}: CheckoutOutcomeCardProps): ReactElement {
+  const { t } = useT();
+  const theme = useTheme();
+
+  if (outcome === "completed") {
+    return (
+      <AppSurfaceCard testID="checkout-success-card">
+        <YStack gap="$3" alignItems="center">
+          <YStack
+            backgroundColor="$surfaceRaised"
+            borderRadius={48}
+            width={96}
+            height={96}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <MaterialCommunityIcons
+              name="check-decagram"
+              size={48}
+              color={theme.success?.val ?? "#1f9d55"}
+            />
+          </YStack>
+          <Paragraph
+            color="$color"
+            fontFamily="$heading"
+            fontSize="$6"
+            textAlign="center"
+          >
+            {t("checkout.success.title")}
+          </Paragraph>
+          <Paragraph
+            color="$muted"
+            fontFamily="$body"
+            fontSize="$3"
+            textAlign="center"
+          >
+            {t("checkout.success.description")}
+          </Paragraph>
+          <YStack gap="$2" width="100%">
+            {SUCCESS_FEATURE_KEYS.map((key) => (
+              <XStack key={key} gap="$2" alignItems="center">
+                <MaterialCommunityIcons
+                  name="check"
+                  size={18}
+                  color={theme.secondary?.val ?? "#5B5BD6"}
+                />
+                <Paragraph color="$color" fontFamily="$body" fontSize="$3">
+                  {t(key)}
+                </Paragraph>
+              </XStack>
+            ))}
+          </YStack>
+          <AppButton hapticTone="medium" onPress={onPrimaryAction}>
+            {t("checkout.success.cta")}
+          </AppButton>
+        </YStack>
+      </AppSurfaceCard>
+    );
+  }
+
+  return (
+    <AppSurfaceCard testID="checkout-cancel-card">
+      <YStack gap="$3" alignItems="center">
+        <YStack
+          backgroundColor="$surfaceRaised"
+          borderRadius={48}
+          width={96}
+          height={96}
+          alignItems="center"
+          justifyContent="center"
+        >
+          <MaterialCommunityIcons
+            name="close-circle-outline"
+            size={48}
+            color={theme.muted?.val ?? "#8a8a8a"}
+          />
+        </YStack>
+        <Paragraph
+          color="$color"
+          fontFamily="$heading"
+          fontSize="$6"
+          textAlign="center"
+        >
+          {t("checkout.cancel.title")}
+        </Paragraph>
+        <Paragraph
+          color="$muted"
+          fontFamily="$body"
+          fontSize="$3"
+          textAlign="center"
+        >
+          {t("checkout.cancel.description")}
+        </Paragraph>
+        <XStack gap="$2" width="100%">
+          {onSecondaryAction ? (
+            <AppButton flex={1} tone="secondary" onPress={onSecondaryAction}>
+              {t("checkout.cancel.back")}
+            </AppButton>
+          ) : null}
+          <AppButton flex={1} hapticTone="medium" onPress={onPrimaryAction}>
+            {t("checkout.cancel.retry")}
+          </AppButton>
+        </XStack>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}

--- a/features/subscription/screens/subscription-screen.tsx
+++ b/features/subscription/screens/subscription-screen.tsx
@@ -1,8 +1,11 @@
 import type { ReactElement } from "react";
 
+import { useRouter } from "expo-router";
 import { Paragraph, YStack } from "tamagui";
 
+import { appRoutes } from "@/core/navigation/routes";
 import { BillingPlanCard } from "@/features/subscription/components/billing-plan-card";
+import { CheckoutOutcomeCard } from "@/features/subscription/components/checkout-outcome-card";
 import {
   useSubscriptionScreenController,
   type SubscriptionScreenController,
@@ -175,6 +178,7 @@ function TrialCallout({ controller }: ControllerProps): ReactElement | null {
 }
 
 function CheckoutFeedback({ controller }: ControllerProps): ReactElement | null {
+  const router = useRouter();
   const outcome = controller.lastCheckoutOutcome;
   if (controller.checkoutError) {
     return (
@@ -188,11 +192,37 @@ function CheckoutFeedback({ controller }: ControllerProps): ReactElement | null 
     );
   }
 
-  if (!outcome || !(outcome in SUCCESS_NOTICE)) {
-    return null;
+  if (outcome === "opened" && SUCCESS_NOTICE.opened) {
+    const copy = SUCCESS_NOTICE.opened;
+    return (
+      <AsyncStateNotice kind="empty" title={copy.title} description={copy.description} />
+    );
   }
-  const copy = SUCCESS_NOTICE[outcome];
-  return <AsyncStateNotice kind="empty" title={copy.title} description={copy.description} />;
+
+  if (outcome === "completed") {
+    return (
+      <CheckoutOutcomeCard
+        outcome="completed"
+        onPrimaryAction={() => {
+          router.replace(appRoutes.private.dashboard);
+        }}
+      />
+    );
+  }
+
+  if (outcome === "canceled" || outcome === "dismissed") {
+    return (
+      <CheckoutOutcomeCard
+        outcome={outcome}
+        onPrimaryAction={controller.dismissCheckoutError}
+        onSecondaryAction={() => {
+          router.back();
+        }}
+      />
+    );
+  }
+
+  return null;
 }
 
 function PlansCard({ controller }: ControllerProps): ReactElement {

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -71,6 +71,34 @@
       "title": "Set new password",
       "submit": "Save new password",
       "submitting": "Saving..."
+    },
+    "resendConfirmation": {
+      "title": "Resend confirmation email",
+      "description": "We will send a new confirmation link to the email below.",
+      "emailLabel": "Email",
+      "submit": "Resend now",
+      "submitting": "Resending...",
+      "success": "Done! Check your inbox and spam folder.",
+      "rateLimited": "Wait {{seconds}}s before resending again.",
+      "backToLogin": "Back to sign in"
+    }
+  },
+  "checkout": {
+    "success": {
+      "title": "Payment confirmed!",
+      "description": "Your plan is active. Welcome to Auraxis Premium.",
+      "features": {
+        "tools": "Access to all tools",
+        "wallet": "Unlimited assets in your wallet",
+        "support": "Priority support"
+      },
+      "cta": "Explore the app"
+    },
+    "cancel": {
+      "title": "Payment not completed",
+      "description": "Your subscription was not activated. You can try again whenever you like.",
+      "retry": "Try again",
+      "back": "Back"
     }
   },
   "dashboard": {

--- a/shared/i18n/locales/pt.json
+++ b/shared/i18n/locales/pt.json
@@ -71,6 +71,34 @@
       "title": "Definir nova senha",
       "submit": "Salvar nova senha",
       "submitting": "Salvando..."
+    },
+    "resendConfirmation": {
+      "title": "Reenviar e-mail de confirmacao",
+      "description": "Vamos enviar um novo link de confirmacao para o e-mail abaixo.",
+      "emailLabel": "E-mail",
+      "submit": "Reenviar agora",
+      "submitting": "Reenviando...",
+      "success": "Pronto! Cheque sua caixa de entrada e a pasta de spam.",
+      "rateLimited": "Aguarde {{seconds}}s antes de reenviar novamente.",
+      "backToLogin": "Voltar para o login"
+    }
+  },
+  "checkout": {
+    "success": {
+      "title": "Pagamento confirmado!",
+      "description": "Seu plano foi ativado e ja esta liberado. Bem-vindo ao Auraxis Premium.",
+      "features": {
+        "tools": "Acesso a todas as ferramentas",
+        "wallet": "Carteira sem limite de ativos",
+        "support": "Suporte prioritario"
+      },
+      "cta": "Explorar o app"
+    },
+    "cancel": {
+      "title": "Pagamento nao concluido",
+      "description": "Sua assinatura nao foi ativada. Voce pode tentar novamente quando quiser.",
+      "retry": "Tentar novamente",
+      "back": "Voltar"
     }
   },
   "dashboard": {


### PR DESCRIPTION
Refs #304 — primeiro bloco da Epic.

## Why

A Epic #304 cobre 4 frentes: avatar upload, danger zone, post-checkout polish, resend confirmation. Esta PR fecha **2 das 4** — as outras 2 ficam aguardando endpoints no backend.

## What changes

### 1. `/resend-confirmation` standalone screen
Antes: a única forma de reenviar era pelo CTA dentro de `confirm-email-pending`, que exigia manter aquele estado vivo. Agora há rota dedicada acessível por deep link e por dentro do pending screen como follow-up.

- `core/navigation/routes.ts` — registra `/resend-confirmation` como public route. A allowlist de deep link já resolve via `isPublicAppRoute`.
- `features/auth/hooks/use-resend-confirmation-screen-controller.ts`:
  - Pre-popula email da sessão quando autenticado e trava o campo
  - Permite edição livre quando o usuário chega via deep link sem sessão
  - Rate limit local de **60s** entre submits, com tick visível em segundos no botão
- `features/auth/screens/resend-confirmation-screen.tsx` — view com sucesso em verde, erros via `AppErrorNotice`, CTA "Voltar para o login"
- `app/(public)/resend-confirmation.tsx` — Expo Router default export
- i18n PT + EN: `auth.resendConfirmation.*`
- **5 testes** cobrem priming, rate limit, sucesso, falha

### 2. Checkout success/cancel cards polidas
Antes: `AsyncStateNotice` simples com title/description. Agora: cards visualmente fortes com hierarquia clara e CTA óbvio.

- `features/subscription/components/checkout-outcome-card.tsx`:
  - **Success**: ícone `check-decagram` em badge circular, copy "Bem-vindo ao Auraxis Premium", 3 bullets de features (tools / wallet / support), CTA primary "Explorar o app"
  - **Cancel/dismissed**: ícone `close-circle-outline` muted, copy consoladora, par de CTAs (retry + voltar)
  - Haptic medium na CTA primary
- `features/subscription/screens/subscription-screen.tsx` — `CheckoutFeedback` agora ramifica para o card novo em outcomes `completed` / `canceled` / `dismissed`. Mantém o notice de `opened` e o `AppErrorNotice` para erro de checkout.
- i18n PT + EN: `checkout.success.*` + `checkout.cancel.*`

## Validation

- `npm run typecheck` ✅
- `npm run policy:check` ✅
- `npm run contracts:check` ✅
- `npm run test:coverage` ✅ — **814 tests / 188 suites**, coverage **94.82% lines / 85.38% branches**
- 5 testes novos
- Pre-commit + pre-push verdes

## Visual smoke test

- [ ] Deep link `auraxisapp://resend-confirmation` abre a tela; campo email editável
- [ ] Em `confirm-email-pending` (autenticado), navegar para resend → email pré-preenchido e travado
- [ ] Submit → sucesso em verde; botão fica disabled mostrando "Aguarde 60s..." em tempo real
- [ ] Após checkout returnar com `status=paid` → card celebrativo com check-decagram + features + CTA "Explorar o app"
- [ ] Após checkout returnar com `status=cancelled` → card consolador com retry/voltar

## Out of scope desta PR (deferred — backend gap)

Ficam aguardando endpoints no `auraxis-api`:

- **Avatar upload** — backend não expõe `/user/profile/avatar` nem aceita upload multipart no `PUT /user/profile`. Tracking de follow-up: precisa de spec do endpoint + integração com expo-image-picker + expo-image-manipulator (deps nativas).
- **Danger Zone (deletar conta)** — backend não expõe `DELETE /user/account` ou similar no OpenAPI exportado. UI scaffolding + biometric gate (#298) ficaria pronto, mas a tela seria vapor sem o endpoint. Open issue no `auraxis-api` antes de implementar.

Recomendo abrir tickets paralelos no `auraxis-api` para ambos antes de retomar #304.

## Test plan
- [x] Typecheck verde
- [x] Policy + contracts verde
- [x] 814 testes / coverage 94.82% / 85.38% branches
- [x] Pre-push verde
- [ ] CI verde
- [ ] Smoke test em iOS device (deep link + checkout flows)
- [ ] Smoke test em Android device
