### PR TITLE
[APP] Resync OpenAPI snapshot to api 65 paths (#345)

### DIFF
--- a/contracts/feature-contract-baseline.json
+++ b/contracts/feature-contract-baseline.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-04-08T11:55:46.602Z",
+  "generatedAt": "2026-05-02T02:14:57.014Z",
   "source": {
     "owner": "italofelipe",
     "repo": "auraxis-platform",

--- a/contracts/known-openapi-gaps.json
+++ b/contracts/known-openapi-gaps.json
@@ -27,7 +27,6 @@
     "GET /fiscal/receivables/summary",
     "GET /fiscal/fiscal-documents",
     "POST /fiscal/fiscal-documents",
-    "GET /goals/{goal_id}/projection",
     "GET /tags",
     "POST /tags",
     "PUT /tags/{tag_id}",
@@ -39,14 +38,6 @@
     "GET /credit-cards",
     "POST /credit-cards",
     "PUT /credit-cards/{credit_card_id}",
-    "DELETE /credit-cards/{credit_card_id}",
-    "GET /budgets",
-    "POST /budgets",
-    "GET /budgets/summary",
-    "GET /budgets/{budget_id}",
-    "PATCH /budgets/{budget_id}",
-    "DELETE /budgets/{budget_id}",
-    "GET /user/notification-preferences",
-    "PATCH /user/notification-preferences"
+    "DELETE /credit-cards/{credit_card_id}"
   ]
 }

--- a/contracts/openapi.snapshot.json
+++ b/contracts/openapi.snapshot.json
@@ -53,11 +53,7 @@
           },
           "opportunity_rate_type": {
             "default": "manual",
-            "enum": [
-              "manual",
-              "product_default",
-              "inflation_only"
-            ],
+            "enum": ["manual", "product_default", "inflation_only"],
             "type": "string"
           },
           "scenario_label": {
@@ -67,11 +63,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "cash_price",
-          "inflation_rate_annual",
-          "installment_count"
-        ],
+        "required": ["cash_price", "inflation_rate_annual", "installment_count"],
         "type": "object"
       },
       "InstallmentVsCashGoalBridge": {
@@ -100,10 +92,7 @@
             "type": "integer"
           },
           "selected_option": {
-            "enum": [
-              "cash",
-              "installment"
-            ],
+            "enum": ["cash", "installment"],
             "type": "string"
           },
           "target_date": {
@@ -118,10 +107,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "selected_option",
-          "title"
-        ],
+        "required": ["selected_option", "title"],
         "type": "object"
       },
       "InstallmentVsCashPlannedExpenseBridge": {
@@ -169,21 +155,12 @@
             "type": "string"
           },
           "selected_option": {
-            "enum": [
-              "cash",
-              "installment"
-            ],
+            "enum": ["cash", "installment"],
             "type": "string"
           },
           "status": {
             "default": "pending",
-            "enum": [
-              "pending",
-              "paid",
-              "cancelled",
-              "postponed",
-              "overdue"
-            ],
+            "enum": ["pending", "paid", "cancelled", "postponed", "overdue"],
             "type": "string"
           },
           "tag_id": {
@@ -204,10 +181,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "selected_option",
-          "title"
-        ],
+        "required": ["selected_option", "title"],
         "type": "object"
       },
       "InstallmentVsCashSave": {
@@ -262,11 +236,7 @@
           },
           "opportunity_rate_type": {
             "default": "manual",
-            "enum": [
-              "manual",
-              "product_default",
-              "inflation_only"
-            ],
+            "enum": ["manual", "product_default", "inflation_only"],
             "type": "string"
           },
           "scenario_label": {
@@ -276,11 +246,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "cash_price",
-          "inflation_rate_annual",
-          "installment_count"
-        ],
+        "required": ["cash_price", "inflation_rate_annual", "installment_count"],
         "type": "object"
       },
       "TransactionCreate": {
@@ -392,13 +358,7 @@
           },
           "status": {
             "description": "Status atual da transação",
-            "enum": [
-              "paid",
-              "pending",
-              "cancelled",
-              "postponed",
-              "overdue"
-            ],
+            "enum": ["paid", "pending", "cancelled", "postponed", "overdue"],
             "example": "pending",
             "type": "string"
           },
@@ -417,10 +377,7 @@
           },
           "type": {
             "description": "Tipo da transação: receita ou despesa",
-            "enum": [
-              "income",
-              "expense"
-            ],
+            "enum": ["income", "expense"],
             "example": "expense",
             "type": "string"
           },
@@ -437,12 +394,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "amount",
-          "due_date",
-          "title",
-          "type"
-        ],
+        "required": ["amount", "due_date", "title", "type"],
         "type": "object"
       },
       "TransactionCreate_7d3b606eab": {
@@ -554,13 +506,7 @@
           },
           "status": {
             "description": "Status atual da transação",
-            "enum": [
-              "paid",
-              "pending",
-              "cancelled",
-              "postponed",
-              "overdue"
-            ],
+            "enum": ["paid", "pending", "cancelled", "postponed", "overdue"],
             "example": "pending",
             "type": "string"
           },
@@ -579,10 +525,7 @@
           },
           "type": {
             "description": "Tipo da transação: receita ou despesa",
-            "enum": [
-              "income",
-              "expense"
-            ],
+            "enum": ["income", "expense"],
             "example": "expense",
             "type": "string"
           },
@@ -622,10 +565,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "email",
-          "password"
-        ],
+        "required": ["email", "password"],
         "type": "object"
       },
       "app_schemas_auth_schema_ConfirmEmailSchema": {
@@ -638,9 +578,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "token"
-        ],
+        "required": ["token"],
         "type": "object"
       },
       "app_schemas_auth_schema_ForgotPasswordSchema": {
@@ -652,9 +590,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "email"
-        ],
+        "required": ["email"],
         "type": "object"
       },
       "app_schemas_auth_schema_ResetPasswordSchema": {
@@ -674,10 +610,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "new_password",
-          "token"
-        ],
+        "required": ["new_password", "token"],
         "type": "object"
       },
       "app_schemas_user_schemas_DeleteAccountSchema": {
@@ -689,9 +622,7 @@
             "writeOnly": true
           }
         },
-        "required": [
-          "password"
-        ],
+        "required": ["password"],
         "type": "object"
       },
       "app_schemas_user_schemas_QuestionnaireAnswerSchema": {
@@ -708,9 +639,7 @@
             "type": "array"
           }
         },
-        "required": [
-          "answers"
-        ],
+        "required": ["answers"],
         "type": "object"
       },
       "app_schemas_user_schemas_SalaryIncreaseSimulationRequestSchema": {
@@ -740,12 +669,7 @@
             "type": "number"
           }
         },
-        "required": [
-          "base_date",
-          "base_salary",
-          "discounts",
-          "target_real_increase"
-        ],
+        "required": ["base_date", "base_salary", "discounts", "target_real_increase"],
         "type": "object"
       },
       "app_schemas_user_schemas_UserProfileSchema": {
@@ -763,11 +687,7 @@
           },
           "gender": {
             "description": "Gênero do usuário",
-            "enum": [
-              "masculino",
-              "feminino",
-              "outro"
-            ],
+            "enum": ["masculino", "feminino", "outro"],
             "example": "masculino",
             "type": "string"
           },
@@ -785,11 +705,7 @@
           },
           "investor_profile": {
             "description": "Perfil do investidor",
-            "enum": [
-              "conservador",
-              "explorador",
-              "entusiasta"
-            ],
+            "enum": ["conservador", "explorador", "entusiasta"],
             "example": "conservador",
             "type": "string"
           },
@@ -877,12 +793,7 @@
           },
           "investor_profile": {
             "description": "Perfil do investidor auto declarado",
-            "enum": [
-              "conservador",
-              "explorador",
-              "entusiasta",
-              null
-            ],
+            "enum": ["conservador", "explorador", "entusiasta", null],
             "example": "conservador",
             "nullable": true,
             "type": "string"
@@ -902,11 +813,7 @@
             "writeOnly": true
           }
         },
-        "required": [
-          "email",
-          "name",
-          "password"
-        ],
+        "required": ["email", "name", "password"],
         "type": "object"
       }
     },
@@ -989,10 +896,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -1031,10 +935,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1073,10 +974,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1094,9 +992,7 @@
           }
         },
         "summary": "Confirmar conta",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/email/resend": {
@@ -1132,10 +1028,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -1174,10 +1067,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1216,10 +1106,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1237,9 +1124,7 @@
           }
         },
         "summary": "Reenviar confirmacao de conta",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/login": {
@@ -1305,10 +1190,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -1347,10 +1229,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1389,10 +1268,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1434,10 +1310,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1476,10 +1349,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1518,10 +1388,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1539,9 +1406,7 @@
           }
         },
         "summary": "Autenticar usuário",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/logout": {
@@ -1577,10 +1442,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -1603,9 +1465,7 @@
           }
         ],
         "summary": "Revogar sessão atual",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/password/forgot": {
@@ -1663,10 +1523,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -1705,10 +1562,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1747,10 +1601,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1789,10 +1640,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1810,9 +1658,7 @@
           }
         },
         "summary": "Solicitar recuperação de senha",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/password/reset": {
@@ -1871,10 +1717,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -1913,10 +1756,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1955,10 +1795,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -1976,14 +1813,12 @@
           }
         },
         "summary": "Redefinir senha",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/refresh": {
       "post": {
-        "description": "Emite um novo par de tokens (access + refresh) usando um refresh token válido.\n\nRotation:\n- Cada uso invalida o refresh token anterior (replay attack prevention).\n- O novo refresh token tem TTL de 7 dias a partir da emissão.\n\nHeaders:\n- `Authorization: Bearer <refresh_token>` (obrigatório)\n- `X-API-Contract`: opcional; `v2` padroniza o envelope.",
+        "description": "Emite um novo par de tokens (access + refresh) usando um refresh token válido.\n\nRotation:\n- Cada uso invalida o refresh token anterior (replay attack prevention).\n- O novo refresh token tem TTL de 7 dias a partir da emissão.\n\nFontes aceitas para o refresh token (SEC-GAP-01):\n- Cookie httpOnly `auraxis_refresh` (recomendado, clientes novos).\n- Header `Authorization: Bearer <refresh_token>` (legado).\n\nHeaders:\n- `X-API-Contract`: opcional; `v2` padroniza o envelope.",
         "parameters": [
           {
             "description": "Opcional. Envie `v2` para o envelope padronizado.",
@@ -2017,10 +1852,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -2059,10 +1891,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2101,10 +1930,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2122,9 +1948,7 @@
           }
         },
         "summary": "Renovar access token",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
       }
     },
     "/auth/register": {
@@ -2191,10 +2015,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -2233,10 +2054,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2275,10 +2093,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2317,10 +2132,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2338,9 +2150,189 @@
           }
         },
         "summary": "Registrar usuário",
-        "tags": [
-          "Autenticação"
-        ]
+        "tags": ["Autenticação"]
+      }
+    },
+    "/auth/sessions": {
+      "delete": {
+        "parameters": [],
+        "responses": {}
+      },
+      "get": {
+        "parameters": [],
+        "responses": {}
+      }
+    },
+    "/auth/sessions/{session_id}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {}
+      }
+    },
+    "/budgets": {
+      "get": {
+        "description": "Lista todos os orçamentos ativos do usuário com valor gasto no período.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Lista de orçamentos com gasto por período"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Orçamentos"]
+      },
+      "post": {
+        "description": "Cria um novo orçamento para o usuário autenticado.",
+        "parameters": [],
+        "responses": {
+          "201": {
+            "description": "Orçamento criado com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Orçamentos"]
+      }
+    },
+    "/budgets/summary": {
+      "get": {
+        "description": "Retorna total orçado vs total gasto no período atual (orçamentos ativos).",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Resumo de orçamentos vs gastos"
+          },
+          "401": {
+            "description": "Token inválido"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Orçamentos"]
+      }
+    },
+    "/budgets/{budget_id}": {
+      "delete": {
+        "description": "Remove um orçamento específico do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orçamento removido"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Orçamento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Orçamentos"]
+      },
+      "get": {
+        "description": "Retorna um orçamento específico do usuário com valor gasto no período.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orçamento encontrado"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Orçamento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Orçamentos"]
+      },
+      "patch": {
+        "description": "Atualiza parcialmente um orçamento do usuário autenticado.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "budget_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Orçamento atualizado"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Orçamento não encontrado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Orçamentos"]
       }
     },
     "/dashboard/overview": {
@@ -2348,19 +2340,19 @@
         "description": "Contrato canônico do dashboard financeiro do MVP1. Use esta rota para visão agregada mensal; `/transactions/dashboard` permanece apenas como compatibilidade transitória.",
         "parameters": [
           {
-            "description": "Opcional. Envie `v2` para o envelope padronizado.",
-            "example": "v2",
-            "in": "header",
-            "name": "X-API-Contract",
-            "required": false,
-            "type": "string"
-          },
-          {
             "description": "Mês de referência no formato YYYY-MM",
             "example": "2026-03",
             "in": "query",
             "name": "month",
             "required": true,
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
             "type": "string"
           }
         ],
@@ -2418,10 +2410,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -2460,10 +2449,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2502,10 +2488,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2544,10 +2527,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2570,14 +2550,12 @@
           }
         ],
         "summary": "Obter overview mensal do dashboard",
-        "tags": [
-          "Dashboard"
-        ]
+        "tags": ["Dashboard"]
       }
     },
-    "/dashboard/trends": {
+    "/dashboard/survival-index": {
       "get": {
-        "description": "Retorna a série histórica de receitas, despesas e saldo para os últimos N meses (apenas transações pagas).",
+        "description": "Calcula quantos meses o patrimônio atual sustenta o custo de vida médio. Patrimônio = soma das entradas de carteira (should_be_on_wallet=True). Custo médio = média de despesas pagas nos últimos 3 meses completos.",
         "parameters": [
           {
             "description": "Opcional. Envie `v2` para o envelope padronizado.",
@@ -2586,7 +2564,142 @@
             "name": "X-API-Contract",
             "required": false,
             "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "avg_monthly_expense": 5000,
+                    "classification": "comfortable",
+                    "period_analyzed_months": 3,
+                    "survival_months": 8.5,
+                    "total_assets": 42500
+                  },
+                  "message": "Índice de sobrevivência calculado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Índice de sobrevivência calculado",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular índice de sobrevivência",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Índice de sobrevivência financeira (burn rate)",
+        "tags": ["Dashboard"]
+      }
+    },
+    "/dashboard/trends": {
+      "get": {
+        "description": "Retorna a série histórica de receitas, despesas e saldo para os últimos N meses (apenas transações pagas).",
+        "parameters": [
           {
             "description": "Número de meses a incluir (1–24, padrão 6)",
             "example": 6,
@@ -2594,6 +2707,14 @@
             "name": "months",
             "required": false,
             "type": "integer"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {
@@ -2626,10 +2747,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -2668,10 +2786,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2710,10 +2825,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2752,10 +2864,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -2778,9 +2887,243 @@
           }
         ],
         "summary": "Tendências mensais do dashboard",
-        "tags": [
-          "Dashboard"
-        ]
+        "tags": ["Dashboard"]
+      }
+    },
+    "/dashboard/weekly-summary": {
+      "get": {
+        "description": "Retorna os totais da semana atual e da semana anterior (receita, despesa, saldo, contagem de transações pagas), o comparativo com deltas absolutos e percentuais, e uma série temporal para alimentar gráficos. Granularidade: diária quando period ≤ 31 dias, semanal caso contrário.",
+        "parameters": [
+          {
+            "description": "Data inicial para período customizado (YYYY-MM-DD)",
+            "example": "2026-03-01",
+            "in": "query",
+            "name": "start_date",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Opcional. Envie `v2` para o envelope padronizado.",
+            "example": "v2",
+            "in": "header",
+            "name": "X-API-Contract",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Preset de período da série: 1m (padrão), 3m, 6m",
+            "example": "1m",
+            "in": "query",
+            "name": "period",
+            "required": false,
+            "type": "string"
+          },
+          {
+            "description": "Data final para período customizado (YYYY-MM-DD)",
+            "example": "2026-04-19",
+            "in": "query",
+            "name": "end_date",
+            "required": false,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "comparison": {
+                      "balance_delta": 2800,
+                      "balance_delta_percent": null,
+                      "expense_delta": -300,
+                      "expense_delta_percent": -14.29,
+                      "income_delta": 2500,
+                      "income_delta_percent": null
+                    },
+                    "current_week": {
+                      "balance": 700,
+                      "end": "2026-04-20",
+                      "expense": 1800,
+                      "income": 2500,
+                      "start": "2026-04-14",
+                      "transaction_count": 8
+                    },
+                    "period": "1m",
+                    "previous_week": {
+                      "balance": -2100,
+                      "end": "2026-04-13",
+                      "expense": 2100,
+                      "income": 0,
+                      "start": "2026-04-07",
+                      "transaction_count": 5
+                    },
+                    "series": [
+                      {
+                        "balance": -200,
+                        "date": "2026-03-20",
+                        "expense": 200,
+                        "income": 0
+                      }
+                    ],
+                    "series_end": "2026-04-19",
+                    "series_start": "2026-03-20"
+                  },
+                  "message": "Resumo semanal calculado com sucesso"
+                },
+                "schema": {
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "meta": {
+                      "type": "object"
+                    }
+                  },
+                  "required": ["message", "data"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Resumo semanal calculado com sucesso",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token revogado",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Período inválido. Use 1m, 3m, 6m ou forneça start_date e end_date.",
+                  "status_code": 422
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetro inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "INTERNAL_ERROR",
+                  "message": "Erro ao calcular resumo semanal",
+                  "status_code": 500
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Erro interno",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Resumo semanal com comparativo (semana atual vs anterior)",
+        "tags": ["Dashboard"]
       }
     },
     "/entitlements": {
@@ -2800,9 +3143,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Entitlements"
-        ]
+        "tags": ["Entitlements"]
       }
     },
     "/entitlements/admin": {
@@ -2825,9 +3166,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Entitlements"
-        ]
+        "tags": ["Entitlements"]
       }
     },
     "/entitlements/admin/{entitlement_id}": {
@@ -2857,9 +3196,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Entitlements"
-        ]
+        "tags": ["Entitlements"]
       }
     },
     "/entitlements/check": {
@@ -2889,9 +3226,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Entitlements"
-        ]
+        "tags": ["Entitlements"]
       }
     },
     "/goals": {
@@ -2928,9 +3263,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Metas"
-        ]
+        "tags": ["Metas"]
       }
     },
     "/goals/{goal_id}": {
@@ -2963,9 +3296,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Metas"
-        ]
+        "tags": ["Metas"]
       },
       "get": {
         "description": "Retorna uma meta específica do usuário autenticado.",
@@ -2996,9 +3327,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Metas"
-        ]
+        "tags": ["Metas"]
       },
       "patch": {
         "description": "Atualiza parcialmente uma meta específica do usuário autenticado.",
@@ -3032,9 +3361,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Metas"
-        ]
+        "tags": ["Metas"]
       },
       "put": {
         "description": "Alias legado para atualização de metas. Use `PATCH /goals/{goal_id}` como contrato canônico para update parcial.",
@@ -3098,9 +3425,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Metas"
-        ]
+        "tags": ["Metas"]
       }
     },
     "/goals/{goal_id}/plan": {
@@ -3133,9 +3458,40 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Metas"
-        ]
+        "tags": ["Metas"]
+      }
+    },
+    "/goals/{goal_id}/projection": {
+      "get": {
+        "description": "Retorna a projeção de conclusão da meta com base na taxa de retorno do portfólio do usuário e no aporte mensal configurado. Usa juros compostos para calcular o prazo e o aporte sugerido.",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "goal_id",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Projeção calculada com sucesso"
+          },
+          "401": {
+            "description": "Token inválido"
+          },
+          "403": {
+            "description": "Sem permissão"
+          },
+          "404": {
+            "description": "Meta não encontrada"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Metas"]
       }
     },
     "/healthz": {
@@ -3147,9 +3503,7 @@
             "description": "Serviço saudável"
           }
         },
-        "tags": [
-          "Health"
-        ]
+        "tags": ["Health"]
       },
       "options": {
         "description": "Endpoint público de liveness para probes de infraestrutura.",
@@ -3159,9 +3513,7 @@
             "description": "Serviço saudável"
           }
         },
-        "tags": [
-          "Health"
-        ]
+        "tags": ["Health"]
       }
     },
     "/ops/metrics": {
@@ -3179,9 +3531,7 @@
             "description": "Export desabilitado"
           }
         },
-        "tags": [
-          "Observability"
-        ]
+        "tags": ["Observability"]
       },
       "options": {
         "description": "Exporta métricas em formato texto compatível com scrape simples.",
@@ -3197,9 +3547,7 @@
             "description": "Export desabilitado"
           }
         },
-        "tags": [
-          "Observability"
-        ]
+        "tags": ["Observability"]
       }
     },
     "/ops/observability": {
@@ -3217,9 +3565,7 @@
             "description": "Export desabilitado"
           }
         },
-        "tags": [
-          "Observability"
-        ]
+        "tags": ["Observability"]
       },
       "options": {
         "description": "Exporta snapshot JSON de métricas internas para collector externo.",
@@ -3235,9 +3581,7 @@
             "description": "Export desabilitado"
           }
         },
-        "tags": [
-          "Observability"
-        ]
+        "tags": ["Observability"]
       }
     },
     "/readiness": {
@@ -3255,9 +3599,7 @@
             "description": "Uma ou mais dependências indisponíveis"
           }
         },
-        "tags": [
-          "Health"
-        ]
+        "tags": ["Health"]
       },
       "options": {
         "description": "Readiness probe: verifica se DB e Redis estão acessíveis. Retorna 200 quando tudo está ok, 503 quando alguma dependência falhou. Protegido por bearer token (READINESS_TOKEN) quando configurado.",
@@ -3273,9 +3615,7 @@
             "description": "Uma ou mais dependências indisponíveis"
           }
         },
-        "tags": [
-          "Health"
-        ]
+        "tags": ["Health"]
       }
     },
     "/simulations": {
@@ -3321,9 +3661,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       }
     },
     "/simulations/installment-vs-cash/calculate": {
@@ -3348,9 +3686,7 @@
           }
         },
         "security": [],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       }
     },
     "/simulations/installment-vs-cash/save": {
@@ -3412,9 +3748,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       }
     },
     "/simulations/{simulation_id}": {
@@ -3444,9 +3778,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       },
       "get": {
         "description": "Retorna uma simulação específica do usuário autenticado.",
@@ -3474,9 +3806,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       }
     },
     "/simulations/{simulation_id}/goal": {
@@ -3520,9 +3850,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       }
     },
     "/simulations/{simulation_id}/planned-expense": {
@@ -3566,9 +3894,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Simulações"
-        ]
+        "tags": ["Simulações"]
       }
     },
     "/transactions": {
@@ -3641,10 +3967,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -3683,10 +4006,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -3725,10 +4045,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -3751,9 +4068,7 @@
           }
         ],
         "summary": "Listar transações",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       },
       "post": {
         "description": "Cria uma nova transação financeira.\n\nAceita receitas e despesas, com suporte a recorrência e parcelamento.",
@@ -3844,10 +4159,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -3886,10 +4198,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -3928,10 +4237,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -3970,10 +4276,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -3996,9 +4299,7 @@
           }
         ],
         "summary": "Criar transação",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/dashboard": {
@@ -4006,18 +4307,18 @@
         "description": "Compatibilidade transitória para o dashboard mensal. Prefira `GET /dashboard/overview`.",
         "parameters": [
           {
+            "description": "Mês de referência no formato YYYY-MM",
+            "example": "2026-03",
+            "in": "query",
+            "name": "month",
+            "type": "string"
+          },
+          {
             "description": "Opcional. Envie `v2` para o envelope padronizado.",
             "example": "v2",
             "in": "header",
             "name": "X-API-Contract",
             "required": false,
-            "type": "string"
-          },
-          {
-            "description": "Mês de referência no formato YYYY-MM",
-            "example": "2026-03",
-            "in": "query",
-            "name": "month",
             "type": "string"
           }
         ],
@@ -4051,10 +4352,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -4121,10 +4419,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4163,10 +4458,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4205,10 +4497,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4231,9 +4520,7 @@
           }
         ],
         "summary": "Obter dashboard mensal legado de transações",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/deleted": {
@@ -4298,10 +4585,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -4340,10 +4624,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4382,10 +4663,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4408,9 +4686,7 @@
           }
         ],
         "summary": "Listar transações deletadas",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/due-range": {
@@ -4488,10 +4764,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -4530,10 +4803,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4572,10 +4842,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4614,10 +4881,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4640,9 +4904,7 @@
           }
         ],
         "summary": "Listar vencimentos por período",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/expenses": {
@@ -4720,10 +4982,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -4790,10 +5049,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4832,10 +5088,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4874,10 +5127,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -4900,9 +5150,141 @@
           }
         ],
         "summary": "Listar despesas por período (compatibilidade)",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
+      }
+    },
+    "/transactions/export": {
+      "get": {
+        "description": "Gera um arquivo com as transações do usuário no formato solicitado.\n\n**Requer entitlement `export_pdf` (plano Premium ou Trial).**\n\nParâmetros:\n- `format`: `csv` (padrão) ou `pdf`\n- `start_date` / `end_date`: intervalo de `due_date` (YYYY-MM-DD)\n- `type`: `income` | `expense`\n- `status`: `paid` | `pending` | `cancelled` | `postponed` | `overdue`\n\nCSV: streamed via chunked transfer — sem limite de linhas.\nPDF: materializado em memória (limitado pela RAM do servidor).",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/pdf": {},
+              "text/csv": {}
+            },
+            "description": "Arquivo CSV ou PDF com as transações"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "VALIDATION_ERROR",
+                  "message": "Parâmetro 'format' inválido.",
+                  "status_code": 400
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Parâmetros inválidos",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "UNAUTHORIZED",
+                  "message": "Token ausente",
+                  "status_code": 401
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Token ausente ou inválido",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "code": "ENTITLEMENT_REQUIRED",
+                  "message": "Feature 'export_pdf' requires an active entitlement.",
+                  "status_code": 403
+                },
+                "schema": {
+                  "properties": {
+                    "code": {
+                      "type": "string"
+                    },
+                    "details": {
+                      "type": "object"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "status_code": {
+                      "type": "integer"
+                    }
+                  },
+                  "required": ["message", "code"],
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Entitlement insuficiente — plano Premium necessário",
+            "headers": {
+              "X-Request-ID": {
+                "description": "Identificador único da requisição gerado pela API.",
+                "example": "req-example-id",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "summary": "Exportar transações (CSV ou PDF)",
+        "tags": ["Transações"]
       }
     },
     "/transactions/list": {
@@ -4975,10 +5357,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -5045,10 +5424,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5087,10 +5463,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5113,9 +5486,7 @@
           }
         ],
         "summary": "Listar transações (compatibilidade /transactions/list)",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/restore/{transaction_id}": {
@@ -5186,10 +5557,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -5228,10 +5596,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5270,10 +5635,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5312,10 +5674,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5338,9 +5697,7 @@
           }
         ],
         "summary": "Restaurar transação deletada",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/summary": {
@@ -5422,10 +5779,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -5464,10 +5818,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5506,10 +5857,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5548,10 +5896,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5574,9 +5919,7 @@
           }
         ],
         "summary": "Obter resumo mensal de transações",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/{transaction_id}": {
@@ -5622,10 +5965,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -5664,10 +6004,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5706,10 +6043,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5748,10 +6082,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5790,10 +6121,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5816,9 +6144,7 @@
           }
         ],
         "summary": "Remover transação logicamente",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       },
       "get": {
         "description": "Retorna o detalhe canônico de uma transação do usuário.",
@@ -5887,10 +6213,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -5929,10 +6252,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -5971,10 +6291,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6013,10 +6330,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6055,10 +6369,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6081,9 +6392,7 @@
           }
         ],
         "summary": "Obter detalhe de transação",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       },
       "patch": {
         "description": "Atualiza parcialmente uma transação existente. Este é o contrato canônico de update do MVP1.",
@@ -6175,10 +6484,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -6217,10 +6523,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6259,10 +6562,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6301,10 +6601,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6343,10 +6640,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6385,10 +6679,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6411,9 +6702,7 @@
           }
         ],
         "summary": "Atualizar transação parcialmente",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       },
       "put": {
         "description": "Compatibilidade transitória para update parcial. Prefira `PATCH /transactions/{transaction_id}`.",
@@ -6505,10 +6794,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -6575,10 +6861,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6617,10 +6900,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6659,10 +6939,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6701,10 +6978,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6743,10 +7017,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6769,9 +7040,7 @@
           }
         ],
         "summary": "Atualizar transação (compatibilidade PUT)",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/transactions/{transaction_id}/force": {
@@ -6817,10 +7086,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -6859,10 +7125,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6901,10 +7164,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6943,10 +7203,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -6969,9 +7226,7 @@
           }
         ],
         "summary": "Remover transação permanentemente",
-        "tags": [
-          "Transações"
-        ]
+        "tags": ["Transações"]
       }
     },
     "/user/bootstrap": {
@@ -7068,10 +7323,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -7110,10 +7362,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7152,10 +7401,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7178,9 +7424,7 @@
           }
         ],
         "summary": "Obter bootstrap da home do usuário",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       }
     },
     "/user/me": {
@@ -7230,10 +7474,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -7272,10 +7513,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7314,10 +7552,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7356,10 +7591,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7382,9 +7614,7 @@
           }
         ],
         "summary": "Excluir conta do usuário (LGPD)",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       },
       "get": {
         "description": "Retorna o contexto do usuário autenticado.\n\nUso recomendado:\n- `X-API-Contract: v3` para o contrato canônico e leve\n- `/user/bootstrap` para agregado da home\n- `/transactions` para coleção paginada e filtros\n\nLegado:\n- `v1`/`v2` ainda aceitam paginação e filtros de coleção\n- respostas legadas enviam headers de deprecação e sunset",
@@ -7450,10 +7680,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -7492,10 +7719,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7518,9 +7742,48 @@
           }
         ],
         "summary": "Obter contexto do usuário autenticado",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
+      }
+    },
+    "/user/notification-preferences": {
+      "get": {
+        "description": "Lista as preferências de notificação do usuário autenticado.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Preferências retornadas com sucesso"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Usuário"]
+      },
+      "patch": {
+        "description": "Atualiza as preferências de notificação do usuário autenticado. Aceita uma lista de preferências para upsert.",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Preferências atualizadas com sucesso"
+          },
+          "400": {
+            "description": "Dados inválidos"
+          },
+          "401": {
+            "description": "Token inválido ou expirado"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "tags": ["Usuário"]
       }
     },
     "/user/profile": {
@@ -7564,10 +7827,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -7606,10 +7866,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7648,10 +7905,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7674,9 +7928,7 @@
           }
         ],
         "summary": "Obter perfil reduzido do usuário",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       },
       "put": {
         "description": "Atualiza o perfil do usuário autenticado.\n\nCampos aceitos:\n- gender: 'masculino', 'feminino', 'outro'\n- birth_date: 'YYYY-MM-DD'\n- monthly_income, net_worth, monthly_expenses, initial_investment,\n  monthly_investment: decimal\n- investment_goal_date: 'YYYY-MM-DD'\n- investor_profile: 'conservador', 'explorador', 'entusiasta'\n\nExemplo de request:\n{\n  'gender': 'masculino',\n  'birth_date': '1990-05-15',\n  'monthly_income': '5000.00',\n  'net_worth': '100000.00',\n  'monthly_expenses': '2000.00',\n  'initial_investment': '10000.00',\n  'monthly_investment': '500.00',\n  'investment_goal_date': '2025-12-31',\n  'investor_profile': 'conservador'\n}\n\nExemplo de resposta:\n{ 'message': 'Perfil atualizado com sucesso', 'data': { ...dados do usuário... } }",
@@ -7746,10 +7998,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -7788,10 +8037,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7830,10 +8076,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7872,10 +8115,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7914,10 +8154,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -7940,9 +8177,7 @@
           }
         ],
         "summary": "Atualizar perfil do usuário",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       }
     },
     "/user/profile/questionnaire": {
@@ -7998,10 +8233,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -8040,10 +8272,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -8066,9 +8295,7 @@
           }
         ],
         "summary": "Listar questionário de perfil de investidor",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       },
       "post": {
         "description": "Submete as respostas do questionário e classifica o perfil de investidor.\n\nEnvie exatamente 5 respostas, cada uma com os pontos da opção escolhida (1–3).\n\nPerfis possíveis:\n- **conservador** — score ≤ 7\n- **explorador**  — score de 8 a 11\n- **entusiasta**  — score ≥ 12\n\nO resultado é persistido no perfil do usuário autenticado.",
@@ -8087,13 +8314,7 @@
             "application/json": {
               "description": "Lista de 5 respostas, cada uma entre 1 e 3 pontos.",
               "example": {
-                "answers": [
-                  1,
-                  2,
-                  2,
-                  3,
-                  1
-                ]
+                "answers": [1, 2, 2, 3, 1]
               },
               "schema": {
                 "$ref": "#/components/schemas/app_schemas_user_schemas_QuestionnaireAnswerSchema"
@@ -8125,10 +8346,7 @@
                       "type": "object"
                     }
                   },
-                  "required": [
-                    "message",
-                    "data"
-                  ],
+                  "required": ["message", "data"],
                   "type": "object"
                 }
               }
@@ -8167,10 +8385,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -8209,10 +8424,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -8234,9 +8446,7 @@
                 "example": {
                   "code": "VALIDATION_ERROR",
                   "details": {
-                    "answers": [
-                      "Missing data for required field."
-                    ]
+                    "answers": ["Missing data for required field."]
                   },
                   "message": "Dados inválidos",
                   "status_code": 422
@@ -8256,10 +8466,7 @@
                       "type": "integer"
                     }
                   },
-                  "required": [
-                    "message",
-                    "code"
-                  ],
+                  "required": ["message", "code"],
                   "type": "object"
                 }
               }
@@ -8282,9 +8489,7 @@
           }
         ],
         "summary": "Responder questionário de perfil de investidor",
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       }
     },
     "/user/simulate-salary-increase": {
@@ -8316,9 +8521,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Usuário"
-        ]
+        "tags": ["Usuário"]
       }
     },
     "/wallet": {
@@ -8364,9 +8567,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Lista os investimentos cadastrados na carteira com paginação.",
@@ -8410,9 +8611,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "post": {
         "description": "Adiciona um novo item à carteira do usuário.\n\nVocê pode informar um valor fixo (como R$1000,00 em poupança) ou um ativo com ticker.\n\nRegras:\n- Se informar o campo 'ticker', o campo 'value' será ignorado.\n- Se não informar 'ticker', é obrigatório informar 'value'.\n- Se informar 'ticker', também é obrigatório informar 'quantity'.\n\nExemplo com valor fixo:\n{'name': 'Poupança', 'value': 1500.00, 'register_date': '2024-07-01', 'should_be_on_wallet': true}\n\nExemplo com ticker:\n{'name': 'Investimento PETR4', 'ticker': 'petr4', 'quantity': 10, 'register_date': '2024-07-01', 'should_be_on_wallet': true}\n\nResposta esperada:\n{'message': 'Ativo cadastrado com sucesso'}",
@@ -8436,9 +8635,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/valuation": {
@@ -8466,9 +8663,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna a valorização atual consolidada da carteira do usuário, com cálculo por investimento.",
@@ -8494,9 +8689,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/valuation/history": {
@@ -8504,12 +8697,6 @@
         "description": "Retorna histórico diário de evolução da carteira por período, com totais de compra/venda e valor líquido investido acumulado.",
         "parameters": [
           {
-            "description": "Data final (YYYY-MM-DD). Opcional.",
-            "in": "query",
-            "name": "end_date",
-            "required": false
-          },
-          {
             "description": "Opcional. Envie 'v2' para o contrato padronizado.",
             "in": "header",
             "name": "X-API-Contract",
@@ -8524,6 +8711,12 @@
             "required": false
           },
           {
+            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "start_date",
+            "required": false
+          },
+          {
             "deprecated": true,
             "description": "Alias legado de `end_date`.",
             "in": "query",
@@ -8531,9 +8724,9 @@
             "required": false
           },
           {
-            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "description": "Data final (YYYY-MM-DD). Opcional.",
             "in": "query",
-            "name": "start_date",
+            "name": "end_date",
             "required": false
           }
         ],
@@ -8583,20 +8776,12 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna histórico diário de evolução da carteira por período, com totais de compra/venda e valor líquido investido acumulado.",
         "parameters": [
           {
-            "description": "Data final (YYYY-MM-DD). Opcional.",
-            "in": "query",
-            "name": "end_date",
-            "required": false
-          },
-          {
             "description": "Opcional. Envie 'v2' para o contrato padronizado.",
             "in": "header",
             "name": "X-API-Contract",
@@ -8611,6 +8796,12 @@
             "required": false
           },
           {
+            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "in": "query",
+            "name": "start_date",
+            "required": false
+          },
+          {
             "deprecated": true,
             "description": "Alias legado de `end_date`.",
             "in": "query",
@@ -8618,9 +8809,9 @@
             "required": false
           },
           {
-            "description": "Data inicial (YYYY-MM-DD). Opcional.",
+            "description": "Data final (YYYY-MM-DD). Opcional.",
             "in": "query",
-            "name": "start_date",
+            "name": "end_date",
             "required": false
           }
         ],
@@ -8670,9 +8861,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}": {
@@ -8713,9 +8902,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "get": {
         "description": "Retorna o detalhe canônico de um investimento específico da carteira do usuário autenticado.",
@@ -8754,9 +8941,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico.",
@@ -8825,9 +9010,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "patch": {
         "description": "Atualiza parcialmente um investimento existente da carteira do usuário. Este é o método canônico para alterações parciais.",
@@ -8866,9 +9049,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "put": {
         "description": "Compatibilidade transitória para atualização parcial de investimento. Use `PATCH /wallet/{investment_id}` como método canônico.",
@@ -8937,9 +9118,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/history": {
@@ -8980,9 +9159,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna o histórico de alterações de um investimento, paginado e ordenado.",
@@ -9021,9 +9198,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations": {
@@ -9082,9 +9257,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Lista operações de investimento de um item da carteira com paginação.",
@@ -9141,9 +9314,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "post": {
         "description": "Registra uma operação de investimento (buy/sell) para um item da carteira.",
@@ -9185,9 +9356,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/invested-amount": {
@@ -9240,9 +9409,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna o valor investido no dia informado, considerando operações de compra e venda do investimento.",
@@ -9293,9 +9460,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/position": {
@@ -9336,9 +9501,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna posição atual e custo médio do investimento com base nas operações registradas.",
@@ -9377,9 +9540,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/summary": {
@@ -9420,9 +9581,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Resumo agregado das operações de um investimento.",
@@ -9461,9 +9620,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/operations/{operation_id}": {
@@ -9471,16 +9628,16 @@
         "description": "Remove operação de investimento.",
         "parameters": [
           {
-            "description": "ID da operação",
+            "description": "ID do investimento",
             "in": "path",
-            "name": "operation_id",
+            "name": "investment_id",
             "required": true,
             "type": "string"
           },
           {
-            "description": "ID do investimento",
+            "description": "ID da operação",
             "in": "path",
-            "name": "investment_id",
+            "name": "operation_id",
             "required": true,
             "type": "string"
           },
@@ -9511,24 +9668,22 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Atualiza operação de investimento existente.",
         "parameters": [
           {
-            "description": "ID da operação",
+            "description": "ID do investimento",
             "in": "path",
-            "name": "operation_id",
+            "name": "investment_id",
             "required": true,
             "type": "string"
           },
           {
-            "description": "ID do investimento",
+            "description": "ID da operação",
             "in": "path",
-            "name": "investment_id",
+            "name": "operation_id",
             "required": true,
             "type": "string"
           },
@@ -9562,24 +9717,22 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "put": {
         "description": "Atualiza operação de investimento existente.",
         "parameters": [
           {
-            "description": "ID da operação",
+            "description": "ID do investimento",
             "in": "path",
-            "name": "operation_id",
+            "name": "investment_id",
             "required": true,
             "type": "string"
           },
           {
-            "description": "ID do investimento",
+            "description": "ID da operação",
             "in": "path",
-            "name": "investment_id",
+            "name": "operation_id",
             "required": true,
             "type": "string"
           },
@@ -9613,9 +9766,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     },
     "/wallet/{investment_id}/valuation": {
@@ -9656,9 +9807,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       },
       "options": {
         "description": "Retorna a valorização atual de um investimento específico.",
@@ -9697,9 +9846,7 @@
             "BearerAuth": []
           }
         ],
-        "tags": [
-          "Wallet"
-        ]
+        "tags": ["Wallet"]
       }
     }
   },

--- a/shared/types/generated/openapi.ts
+++ b/shared/types/generated/openapi.ts
@@ -813,8 +813,11 @@ export interface paths {
          *     - Cada uso invalida o refresh token anterior (replay attack prevention).
          *     - O novo refresh token tem TTL de 7 dias a partir da emissão.
          *
+         *     Fontes aceitas para o refresh token (SEC-GAP-01):
+         *     - Cookie httpOnly `auraxis_refresh` (recomendado, clientes novos).
+         *     - Header `Authorization: Bearer <refresh_token>` (legado).
+         *
          *     Headers:
-         *     - `Authorization: Bearer <refresh_token>` (obrigatório)
          *     - `X-API-Contract`: opcional; `v2` padroniza o envelope.
          */
         post: {
@@ -1082,6 +1085,327 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/auth/sessions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/auth/sessions/{session_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    session_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: never;
+        };
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/budgets": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Lista todos os orçamentos ativos do usuário com valor gasto no período. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Lista de orçamentos com gasto por período */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        /** @description Cria um novo orçamento para o usuário autenticado. */
+        post: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Orçamento criado com sucesso */
+                201: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/budgets/summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Retorna total orçado vs total gasto no período atual (orçamentos ativos). */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Resumo de orçamentos vs gastos */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/budgets/{budget_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Retorna um orçamento específico do usuário com valor gasto no período. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    budget_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Orçamento encontrado */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Orçamento não encontrado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        /** @description Remove um orçamento específico do usuário autenticado. */
+        delete: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    budget_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Orçamento removido */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Orçamento não encontrado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        options?: never;
+        head?: never;
+        /** @description Atualiza parcialmente um orçamento do usuário autenticado. */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    budget_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Orçamento atualizado */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Orçamento não encontrado */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
     "/dashboard/overview": {
         parameters: {
             query?: never;
@@ -1260,6 +1584,124 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/dashboard/survival-index": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Índice de sobrevivência financeira (burn rate)
+         * @description Calcula quantos meses o patrimônio atual sustenta o custo de vida médio. Patrimônio = soma das entradas de carteira (should_be_on_wallet=True). Custo médio = média de despesas pagas nos últimos 3 meses completos.
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Índice de sobrevivência calculado */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "avg_monthly_expense": 5000,
+                         *         "classification": "comfortable",
+                         *         "period_analyzed_months": 3,
+                         *         "survival_months": 8.5,
+                         *         "total_assets": 42500
+                         *       },
+                         *       "message": "Índice de sobrevivência calculado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao calcular índice de sobrevivência",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/dashboard/trends": {
         parameters: {
             query?: never;
@@ -1393,6 +1835,196 @@ export interface paths {
                          * @example {
                          *       "code": "INTERNAL_ERROR",
                          *       "message": "Erro ao calcular tendências do dashboard",
+                         *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/dashboard/weekly-summary": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Resumo semanal com comparativo (semana atual vs anterior)
+         * @description Retorna os totais da semana atual e da semana anterior (receita, despesa, saldo, contagem de transações pagas), o comparativo com deltas absolutos e percentuais, e uma série temporal para alimentar gráficos. Granularidade: diária quando period ≤ 31 dias, semanal caso contrário.
+         */
+        get: {
+            parameters: {
+                query?: {
+                    /**
+                     * @description Data inicial para período customizado (YYYY-MM-DD)
+                     * @example 2026-03-01
+                     */
+                    start_date?: string;
+                    /**
+                     * @description Preset de período da série: 1m (padrão), 3m, 6m
+                     * @example 1m
+                     */
+                    period?: string;
+                    /**
+                     * @description Data final para período customizado (YYYY-MM-DD)
+                     * @example 2026-04-19
+                     */
+                    end_date?: string;
+                };
+                header?: {
+                    /**
+                     * @description Opcional. Envie `v2` para o envelope padronizado.
+                     * @example v2
+                     */
+                    "X-API-Contract"?: string;
+                };
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Resumo semanal calculado com sucesso */
+                200: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "data": {
+                         *         "comparison": {
+                         *           "balance_delta": 2800,
+                         *           "balance_delta_percent": null,
+                         *           "expense_delta": -300,
+                         *           "expense_delta_percent": -14.29,
+                         *           "income_delta": 2500,
+                         *           "income_delta_percent": null
+                         *         },
+                         *         "current_week": {
+                         *           "balance": 700,
+                         *           "end": "2026-04-20",
+                         *           "expense": 1800,
+                         *           "income": 2500,
+                         *           "start": "2026-04-14",
+                         *           "transaction_count": 8
+                         *         },
+                         *         "period": "1m",
+                         *         "previous_week": {
+                         *           "balance": -2100,
+                         *           "end": "2026-04-13",
+                         *           "expense": 2100,
+                         *           "income": 0,
+                         *           "start": "2026-04-07",
+                         *           "transaction_count": 5
+                         *         },
+                         *         "series": [
+                         *           {
+                         *             "balance": -200,
+                         *             "date": "2026-03-20",
+                         *             "expense": 200,
+                         *             "income": 0
+                         *           }
+                         *         ],
+                         *         "series_end": "2026-04-19",
+                         *         "series_start": "2026-03-20"
+                         *       },
+                         *       "message": "Resumo semanal calculado com sucesso"
+                         *     }
+                         */
+                        "application/json": {
+                            data: Record<string, never>;
+                            message: string;
+                            meta?: Record<string, never>;
+                        };
+                    };
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token revogado",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Parâmetro inválido */
+                422: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Período inválido. Use 1m, 3m, 6m ou forneça start_date e end_date.",
+                         *       "status_code": 422
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Erro interno */
+                500: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "INTERNAL_ERROR",
+                         *       "message": "Erro ao calcular resumo semanal",
                          *       "status_code": 500
                          *     }
                          */
@@ -1928,6 +2560,63 @@ export interface paths {
             requestBody?: never;
             responses: {
                 /** @description Planejamento calculado com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Sem permissão */
+                403: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Meta não encontrada */
+                404: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/goals/{goal_id}/projection": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Retorna a projeção de conclusão da meta com base na taxa de retorno do portfólio do usuário e no aporte mensal configurado. Usa juros compostos para calcular o prazo e o aporte sugerido. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path: {
+                    goal_id: string;
+                };
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Projeção calculada com sucesso */
                 200: {
                     headers: {
                         [name: string]: unknown;
@@ -3662,6 +4351,135 @@ export interface paths {
                          *       "code": "INTERNAL_ERROR",
                          *       "message": "Erro ao listar despesas por período",
                          *       "status_code": 500
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/transactions/export": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Exportar transações (CSV ou PDF)
+         * @description Gera um arquivo com as transações do usuário no formato solicitado.
+         *
+         *     **Requer entitlement `export_pdf` (plano Premium ou Trial).**
+         *
+         *     Parâmetros:
+         *     - `format`: `csv` (padrão) ou `pdf`
+         *     - `start_date` / `end_date`: intervalo de `due_date` (YYYY-MM-DD)
+         *     - `type`: `income` | `expense`
+         *     - `status`: `paid` | `pending` | `cancelled` | `postponed` | `overdue`
+         *
+         *     CSV: streamed via chunked transfer — sem limite de linhas.
+         *     PDF: materializado em memória (limitado pela RAM do servidor).
+         */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Arquivo CSV ou PDF com as transações */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        "application/pdf": unknown;
+                        "text/csv": unknown;
+                    };
+                };
+                /** @description Parâmetros inválidos */
+                400: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "VALIDATION_ERROR",
+                         *       "message": "Parâmetro 'format' inválido.",
+                         *       "status_code": 400
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Token ausente ou inválido */
+                401: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "UNAUTHORIZED",
+                         *       "message": "Token ausente",
+                         *       "status_code": 401
+                         *     }
+                         */
+                        "application/json": {
+                            code: string;
+                            details?: Record<string, never>;
+                            message: string;
+                            status_code?: number;
+                        };
+                    };
+                };
+                /** @description Entitlement insuficiente — plano Premium necessário */
+                403: {
+                    headers: {
+                        /**
+                         * @description Identificador único da requisição gerado pela API.
+                         * @example req-example-id
+                         */
+                        "X-Request-ID"?: string;
+                        [name: string]: unknown;
+                    };
+                    content: {
+                        /**
+                         * @example {
+                         *       "code": "ENTITLEMENT_REQUIRED",
+                         *       "message": "Feature 'export_pdf' requires an active entitlement.",
+                         *       "status_code": 403
                          *     }
                          */
                         "application/json": {
@@ -5601,6 +6419,79 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/user/notification-preferences": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Lista as preferências de notificação do usuário autenticado. */
+        get: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Preferências retornadas com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido ou expirado */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /** @description Atualiza as preferências de notificação do usuário autenticado. Aceita uma lista de preferências para upsert. */
+        patch: {
+            parameters: {
+                query?: never;
+                header?: never;
+                path?: never;
+                cookie?: never;
+            };
+            requestBody?: never;
+            responses: {
+                /** @description Preferências atualizadas com sucesso */
+                200: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Dados inválidos */
+                400: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+                /** @description Token inválido ou expirado */
+                401: {
+                    headers: {
+                        [name: string]: unknown;
+                    };
+                    content?: never;
+                };
+            };
+        };
+        trace?: never;
+    };
     "/user/profile": {
         parameters: {
             query?: never;
@@ -6447,20 +7338,20 @@ export interface paths {
         get: {
             parameters: {
                 query?: {
-                    /** @description Data final (YYYY-MM-DD). Opcional. */
-                    end_date?: string;
                     /**
                      * @deprecated
                      * @description Alias legado de `start_date`.
                      */
                     startDate?: string;
+                    /** @description Data inicial (YYYY-MM-DD). Opcional. */
+                    start_date?: string;
                     /**
                      * @deprecated
                      * @description Alias legado de `end_date`.
                      */
                     finalDate?: string;
-                    /** @description Data inicial (YYYY-MM-DD). Opcional. */
-                    start_date?: string;
+                    /** @description Data final (YYYY-MM-DD). Opcional. */
+                    end_date?: string;
                 };
                 header?: {
                     /** @description Opcional. Envie 'v2' para o contrato padronizado. */
@@ -6521,20 +7412,20 @@ export interface paths {
         options: {
             parameters: {
                 query?: {
-                    /** @description Data final (YYYY-MM-DD). Opcional. */
-                    end_date?: string;
                     /**
                      * @deprecated
                      * @description Alias legado de `start_date`.
                      */
                     startDate?: string;
+                    /** @description Data inicial (YYYY-MM-DD). Opcional. */
+                    start_date?: string;
                     /**
                      * @deprecated
                      * @description Alias legado de `end_date`.
                      */
                     finalDate?: string;
-                    /** @description Data inicial (YYYY-MM-DD). Opcional. */
-                    start_date?: string;
+                    /** @description Data final (YYYY-MM-DD). Opcional. */
+                    end_date?: string;
                 };
                 header?: {
                     /** @description Opcional. Envie 'v2' para o contrato padronizado. */
@@ -7496,10 +8387,10 @@ export interface paths {
                     "X-API-Contract"?: string;
                 };
                 path: {
-                    /** @description ID da operação */
-                    operation_id: string;
                     /** @description ID do investimento */
                     investment_id: string;
+                    /** @description ID da operação */
+                    operation_id: string;
                 };
                 cookie?: never;
             };
@@ -7552,10 +8443,10 @@ export interface paths {
                     "X-API-Contract"?: string;
                 };
                 path: {
-                    /** @description ID da operação */
-                    operation_id: string;
                     /** @description ID do investimento */
                     investment_id: string;
+                    /** @description ID da operação */
+                    operation_id: string;
                 };
                 cookie?: never;
             };
@@ -7600,10 +8491,10 @@ export interface paths {
                     "X-API-Contract"?: string;
                 };
                 path: {
-                    /** @description ID da operação */
-                    operation_id: string;
                     /** @description ID do investimento */
                     investment_id: string;
+                    /** @description ID da operação */
+                    operation_id: string;
                 };
                 cookie?: never;
             };


### PR DESCRIPTION
## Summary

Closes #345. Resincroniza `contracts/openapi.snapshot.json` ao api canônico (65 paths) e regenera os tipos TS.

## Refs

Closes #345
Plano: `auraxis-platform/.context/reports/historical/plan_quality_remediation_2026-05-01.md` fase 2.

## Changes

- `contracts/openapi.snapshot.json` — 55 → **65 paths**.
- `shared/types/generated/openapi.ts` — regenerado via `openapi-typescript` 7.13.0.
- `contracts/feature-contract-baseline.json` — atualizado.
- `contracts/known-openapi-gaps.json` — **removidas 9 stale gaps** que agora estão cobertas pelo snapshot:
  - `GET /goals/{goal_id}/projection`
  - `GET|POST /budgets`, `GET|PATCH|DELETE /budgets/{budget_id}`, `GET /budgets/summary`
  - `GET|PATCH /user/notification-preferences`

## Sequenciamento

Companion no platform: snapshot canônico em `auraxis-platform/.context/openapi/openapi.snapshot.json` foi regenerado via `bash scripts/export-openapi-snapshot.sh` (60 → 65 paths). Esse update precisa landar na platform antes deste PR ser merged, ou usar `AURAXIS_OPENAPI_LOCAL_FILE` em CI temporariamente.

## Test plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green
- [x] `npm run policy:check` — 8 governance gates verdes
- [x] `npm run contracts:check` — green (`packs=0, openapi_hash=380d938661f9`)
- [x] `npm run test:coverage` — **1640 testes / 257 suites verdes**

## Risk

Baixo. A regeneração dos tipos é determinística e o consumer audit (via `contracts:check` + typecheck) confirmou zero breakage. Stale gaps removidas eram declarações que apenas reconheciam ausência no snapshot — o código que as consome já usa os tipos manuais (mantidos como gradual migration path nesta PR).