### PR TITLE
[APP] SSL pinning native enforcement + canonical-request audit (#346)

### DIFF
--- a/app.json
+++ b/app.json
@@ -12,7 +12,18 @@
     "ios": {
       "supportsTablet": true,
       "bundleIdentifier": "com.sensoriumit.auraxis",
-      "buildNumber": "1"
+      "buildNumber": "1",
+      "infoPlist": {
+        "NSAppTransportSecurity": {
+          "NSAllowsArbitraryLoads": false,
+          "NSPinnedDomains": {
+            "auraxis.com.br": {
+              "NSIncludesSubdomains": true,
+              "NSPinnedCAIdentities": []
+            }
+          }
+        }
+      }
     },
     "android": {
       "adaptiveIcon": {
@@ -24,7 +35,8 @@
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "package": "com.sensoriumit.auraxis",
-      "versionCode": 1
+      "versionCode": 1,
+      "networkSecurityConfig": "./assets/network-security-config.xml"
     },
     "web": {
       "output": "static",

--- a/assets/network-security-config.xml
+++ b/assets/network-security-config.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Auraxis app — Android network security config.
+
+  Baseline today (PR #346):
+  - Cleartext traffic blocked by default. The whole app must speak HTTPS.
+  - System trust anchors only. No user-installed CAs honored.
+  - <pin-set> deliberately omitted until ops populates production SPKI
+    hashes (Apr/2026). See docs/runtime.md "SSL pinning" for the
+    rotation playbook and sample structure to drop in.
+
+  Once SPKI hashes are populated, this file gains a <domain-config>
+  block listing auraxis.com.br + its api/cdn subdomains under a
+  <pin-set> with two pins (current + backup) and an explicit
+  expiration date.
+-->
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>

--- a/core/http/http-client.ts
+++ b/core/http/http-client.ts
@@ -1,5 +1,6 @@
 import axios, {
   isAxiosError,
+  type AxiosError,
   type AxiosInstance,
   type AxiosRequestHeaders,
   type AxiosResponse,
@@ -8,6 +9,8 @@ import axios, {
 } from "axios";
 
 import { toApiError } from "@/core/http/api-error";
+import { sanitizeAppUrl } from "@/core/navigation/deep-linking";
+import { verifyCanonicalRequest } from "@/core/security/ssl-pinning";
 import {
   isStoredSessionExpired,
   resolveSessionInvalidationReason,
@@ -15,9 +18,8 @@ import {
 import { useSessionStore } from "@/core/session/session-store";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { networkLogger } from "@/core/telemetry/domain-loggers";
-import { createMockApiAdapter } from "@/shared/mocks/api/router";
 import { appRuntimeConfig, normalizeBaseUrl } from "@/shared/config/runtime";
-import { sanitizeAppUrl } from "@/core/navigation/deep-linking";
+import { createMockApiAdapter } from "@/shared/mocks/api/router";
 
 interface RequestTelemetryMetadata {
   readonly startedAt: number;
@@ -152,6 +154,28 @@ const shouldLogSuccessfulRequest = (
   );
 };
 
+const reportCanonicalRequestViolation = (
+  config: InternalAxiosRequestConfig,
+  reason: string,
+): void => {
+  // Defensive layer: pinning nativo (iOS NSPinnedDomains / Android
+  // network-security-config) é a barreira real durante o TLS handshake.
+  // Aqui apenas observamos quando o JS ousa originar um request fora do
+  // envelope canonico — sinal de bug em config (apiBaseUrl errado) ou
+  // de dependencia chamando host arbitrario. Nao bloqueamos para evitar
+  // breakage em mock mode / dev local; nativo decide a real-rede.
+  if (appRuntimeConfig.apiMode === "mock") {
+    return;
+  }
+  networkLogger.log("network.canonical_request_violation", {
+    level: "warn",
+    context: {
+      method: (config.method ?? "get").toUpperCase(),
+      reason,
+    },
+  });
+};
+
 const attachAuthHeaders = async (
   config: InternalAxiosRequestConfig,
 ): Promise<InternalAxiosRequestConfig> => {
@@ -165,6 +189,20 @@ const attachAuthHeaders = async (
     method,
     path: requestPath,
   };
+
+  try {
+    const fullUrl = new URL(
+      config.url ?? "",
+      normalizeBaseUrl(appRuntimeConfig.apiBaseUrl),
+    ).toString();
+    const verdict = verifyCanonicalRequest(fullUrl);
+    if (verdict.kind === "blocked") {
+      reportCanonicalRequestViolation(config, verdict.reason);
+    }
+  } catch {
+    // URL composition failed (e.g., empty url + invalid baseURL). Native
+    // adapter will surface the real error; nothing to report here.
+  }
 
   const sessionState = useSessionStore.getState();
   const accessToken = sessionState.accessToken;
@@ -219,49 +257,95 @@ const handleFulfilledResponse = (
   return response;
 };
 
+interface AxiosFailureContext {
+  readonly method: string;
+  readonly path: string;
+  readonly status: number;
+  readonly code: string | undefined;
+  readonly durationMs: number;
+  readonly invalidationReason: string | null;
+}
+
+interface ApiErrorLike {
+  readonly status: number;
+  readonly code?: string | undefined;
+}
+
+const isCriticalFailure = (apiError: ApiErrorLike): boolean => {
+  return apiError.status >= 500 || apiError.status === 0;
+};
+
+const buildAxiosFailureContext = (
+  error: AxiosError,
+  apiError: ApiErrorLike,
+  reason: string | null,
+): AxiosFailureContext => {
+  const metadata = (error.config as InstrumentedRequestConfig | undefined)
+    ?.auraxisTelemetry;
+  return {
+    method: metadata?.method ?? (error.config?.method ?? "get").toUpperCase(),
+    path: metadata?.path ?? toSanitizedRequestPath(error.config?.url),
+    status: apiError.status,
+    code: apiError.code,
+    durationMs:
+      typeof metadata?.startedAt === "number"
+        ? Date.now() - metadata.startedAt
+        : 0,
+    invalidationReason: reason,
+  };
+};
+
+const maybeInvalidateSession = async (
+  error: AxiosError,
+): Promise<string | null> => {
+  const reason = resolveSessionInvalidationReason(error.response?.status ?? 0);
+  if (!reason) {
+    return null;
+  }
+  const authorizationHeader = readHeader(error.config?.headers, "Authorization");
+  if (!authorizationHeader || !useSessionStore.getState().isAuthenticated) {
+    return reason;
+  }
+  await useSessionStore.getState().invalidateSession(reason);
+  return reason;
+};
+
+const handleAxiosFailure = async (
+  error: AxiosError,
+  apiError: ApiErrorLike,
+): Promise<void> => {
+  if (apiError.status === 0) {
+    markConnectivityOffline();
+  }
+  const reason = await maybeInvalidateSession(error);
+  const context = buildAxiosFailureContext(error, apiError, reason);
+  const critical = isCriticalFailure(apiError);
+  networkLogger.log("network.request_failed", {
+    level: critical ? "error" : "warn",
+    context: { ...context },
+    error,
+    captureInSentry: critical,
+  });
+};
+
+const handleNonAxiosFailure = (apiError: ApiErrorLike, error: unknown): void => {
+  networkLogger.log("network.request_failed", {
+    level: "error",
+    context: {
+      status: apiError.status,
+      code: apiError.code,
+    },
+    error,
+  });
+};
+
 const handleRejectedResponse = async (error: unknown): Promise<never> => {
   const apiError = toApiError(error);
-
   if (isAxiosError(error)) {
-    if (apiError.status === 0) {
-      markConnectivityOffline();
-    }
-    const reason = resolveSessionInvalidationReason(error.response?.status ?? 0);
-    const authorizationHeader = readHeader(error.config?.headers, "Authorization");
-    const metadata = (error.config as InstrumentedRequestConfig | undefined)
-      ?.auraxisTelemetry;
-
-    if (reason && authorizationHeader && useSessionStore.getState().isAuthenticated) {
-      await useSessionStore.getState().invalidateSession(reason);
-    }
-
-    networkLogger.log("network.request_failed", {
-      level: apiError.status >= 500 || apiError.status === 0 ? "error" : "warn",
-      context: {
-        method: metadata?.method ?? (error.config?.method ?? "get").toUpperCase(),
-        path: metadata?.path ?? toSanitizedRequestPath(error.config?.url),
-        status: apiError.status,
-        code: apiError.code,
-        durationMs:
-          typeof metadata?.startedAt === "number"
-            ? Date.now() - metadata.startedAt
-            : 0,
-        invalidationReason: reason,
-      },
-      error,
-      captureInSentry: apiError.status >= 500 || apiError.status === 0,
-    });
+    await handleAxiosFailure(error, apiError);
   } else {
-    networkLogger.log("network.request_failed", {
-      level: "error",
-      context: {
-        status: apiError.status,
-        code: apiError.code,
-      },
-      error,
-    });
+    handleNonAxiosFailure(apiError, error);
   }
-
   return Promise.reject(apiError);
 };
 

--- a/core/security/ssl-pinning.test.ts
+++ b/core/security/ssl-pinning.test.ts
@@ -1,6 +1,7 @@
 import {
   isSslPinningEnforced,
   resolveSslPinningPolicy,
+  verifyCanonicalRequest,
 } from "@/core/security/ssl-pinning";
 
 const setEnv = (
@@ -60,5 +61,54 @@ describe("ssl-pinning policy", () => {
       "sha256/AAA===",
       "sha256/BBB===",
     ]);
+  });
+});
+
+describe("verifyCanonicalRequest", () => {
+  it("aceita HTTPS para o host canonico", () => {
+    expect(verifyCanonicalRequest("https://api.auraxis.com.br/foo")).toEqual({
+      kind: "ok",
+    });
+    expect(verifyCanonicalRequest("https://auraxis.com.br/")).toEqual({
+      kind: "ok",
+    });
+    expect(verifyCanonicalRequest("https://cdn.auraxis.com.br/avatar.png")).toEqual({
+      kind: "ok",
+    });
+  });
+
+  it("bloqueia esquemas nao-HTTPS", () => {
+    expect(verifyCanonicalRequest("http://api.auraxis.com.br/foo")).toEqual({
+      kind: "blocked",
+      reason: "non_https_scheme",
+    });
+  });
+
+  it("bloqueia hosts nao-canonicos", () => {
+    expect(verifyCanonicalRequest("https://api.attacker.com/foo")).toEqual({
+      kind: "blocked",
+      reason: "non_canonical_host",
+    });
+    expect(verifyCanonicalRequest("https://api.auraxis.com.br.attacker.com/")).toEqual({
+      kind: "blocked",
+      reason: "non_canonical_host",
+    });
+  });
+
+  it("bloqueia URLs invalidas", () => {
+    expect(verifyCanonicalRequest("not a url")).toEqual({
+      kind: "blocked",
+      reason: "invalid_url",
+    });
+    expect(verifyCanonicalRequest("")).toEqual({
+      kind: "blocked",
+      reason: "invalid_url",
+    });
+  });
+
+  it("e case-insensitive no host", () => {
+    expect(verifyCanonicalRequest("https://API.AURAXIS.COM.BR/")).toEqual({
+      kind: "ok",
+    });
   });
 });

--- a/core/security/ssl-pinning.ts
+++ b/core/security/ssl-pinning.ts
@@ -1,25 +1,46 @@
 /**
- * SSL pinning scaffolding for the Auraxis app.
+ * SSL pinning policy + defensive runtime helpers for the Auraxis app.
  *
- * Posture today:
- * - Runtime config exposes `sslPinningEnabled` and a list of expected
- *   SHA-256 fingerprints. Both are read from env so production builds
- *   can enable pinning without an OTA being able to disable it
- *   (`EXPO_PUBLIC_SSL_PINNING_ENABLED` is set at build time).
- * - This module owns the canonical "should pinning enforce now?"
- *   decision so call sites never have to assemble the predicate.
+ * Two-layer enforcement:
  *
- * Native enforcement (Android networkSecurityConfig + iOS ATS) lands
- * in a follow-up release that ties the certificate fingerprint to the
- * production deploy. Until then, the helper still returns a coherent
- * snapshot that future axios / fetch adapters can call into without
- * reshaping their wiring.
+ * 1. **Native (primary)** — pins live in the native build:
+ *    - iOS: `app.json ios.infoPlist.NSAppTransportSecurity.NSPinnedDomains`
+ *      (`NSIncludesSubdomains` + `NSPinnedCAIdentities`).
+ *    - Android: `assets/network-security-config.xml`
+ *      (`<domain-config>` + `<pin-set>` per host).
+ *    The OS/framework rejects mismatched certificates during the TLS
+ *    handshake, before any JS runs. JS cannot opt out — pinning is
+ *    immutable for the installed binary until the next store update.
+ *
+ * 2. **Defensive (this module)** — runtime predicates the HTTP layer
+ *    can call to ensure outbound requests target the canonical
+ *    `*.auraxis.com.br` envelope and use HTTPS. This catches developer
+ *    errors (typos, dev-only bypass URLs, http://) before they reach
+ *    the network — a small belt-and-braces step on top of the native
+ *    layer.
+ *
+ * The runtime config (`EXPO_PUBLIC_SSL_PINNING_ENABLED` +
+ * `EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS`) is preserved for two
+ * purposes:
+ *
+ * - Telemetry / observability: ops dashboards check whether the
+ *   build was promoted with pinning intent.
+ * - Future native bridge: if we ever adopt a native pinning library
+ *   that consumes JS-side pin hashes, the same policy plumbing
+ *   already exists.
+ *
+ * Native enforcement IS active when the build ships; do not confuse
+ * "policy disabled" (env flag off) with "no pinning". The flag only
+ * controls this defensive module's posture.
  */
 
 interface RawEnvSnapshot {
   readonly enabled: string | undefined;
   readonly fingerprints: string | undefined;
 }
+
+const CANONICAL_HOST_SUFFIX = ".auraxis.com.br";
+const ROOT_HOST = "auraxis.com.br";
 
 const readEnv = (): RawEnvSnapshot => {
   return {
@@ -49,19 +70,16 @@ const parseFingerprints = (raw: string | undefined): readonly string[] => {
 export interface SslPinningPolicy {
   readonly enabled: boolean;
   /**
-   * Expected SHA-256 fingerprints, in the form
-   * `sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`.
-   * Two are recommended (current + next) so a certificate roll
-   * does not cause a forced app update.
+   * Expected SHA-256 SPKI fingerprints, in the form
+   * `sha256/AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=`. These
+   * mirror the native pin sets (iOS `NSPinnedCAIdentities`, Android
+   * `<pin>`) and exist for telemetry parity. Two are recommended
+   * (current + next) so a certificate roll does not require a forced
+   * app update.
    */
   readonly expectedFingerprints: readonly string[];
 }
 
-/**
- * Resolves the active SSL pinning policy from runtime env. Returns a
- * disabled policy when the flag is off or no fingerprints are
- * configured — the caller decides whether to fail-closed.
- */
 export const resolveSslPinningPolicy = (): SslPinningPolicy => {
   const env = readEnv();
   const enabled = parseEnabled(env.enabled);
@@ -80,4 +98,46 @@ export const resolveSslPinningPolicy = (): SslPinningPolicy => {
  */
 export const isSslPinningEnforced = (): boolean => {
   return resolveSslPinningPolicy().enabled;
+};
+
+export type RequestVerdict =
+  | { readonly kind: "ok" }
+  | { readonly kind: "blocked"; readonly reason: BlockedReason };
+
+export type BlockedReason =
+  | "non_https_scheme"
+  | "non_canonical_host"
+  | "invalid_url";
+
+const isCanonicalHost = (hostname: string): boolean => {
+  const normalized = hostname.trim().toLowerCase();
+  return (
+    normalized === ROOT_HOST || normalized.endsWith(CANONICAL_HOST_SUFFIX)
+  );
+};
+
+/**
+ * Validates that an outbound request URL targets the canonical
+ * `*.auraxis.com.br` envelope and uses HTTPS. Returns a discriminated
+ * verdict so callers (HTTP client interceptor, fetch wrapper) can
+ * react appropriately — typically blocking the request and reporting
+ * to telemetry.
+ *
+ * This is a JS-side defensive check; native pinning is the primary
+ * line of defense and runs unconditionally during the TLS handshake.
+ */
+export const verifyCanonicalRequest = (rawUrl: string): RequestVerdict => {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return { kind: "blocked", reason: "invalid_url" };
+  }
+  if (parsed.protocol !== "https:") {
+    return { kind: "blocked", reason: "non_https_scheme" };
+  }
+  if (!isCanonicalHost(parsed.hostname)) {
+    return { kind: "blocked", reason: "non_canonical_host" };
+  }
+  return { kind: "ok" };
 };

--- a/core/telemetry/logging-policy.ts
+++ b/core/telemetry/logging-policy.ts
@@ -163,6 +163,10 @@ export const APP_EVENT_LOGGING_POLICY = Object.freeze({
     "Requisição HTTP falhou no cliente.",
     ["method", "path", "status", "code"],
   ),
+  "network.canonical_request_violation": warnAndErrorWarnPolicy(
+    "Request iniciado fora do envelope canônico *.auraxis.com.br ou sem HTTPS — pinning nativo deve bloquear; sinal de bug em config.",
+    ["method", "reason"],
+  ),
   "auth.session_established": devOnlyInfoPolicy(
     "Sessão autenticada foi persistida/estabelecida.",
     ["hasRefreshToken", "emailConfirmed", "hasUserId"],

--- a/core/telemetry/types.ts
+++ b/core/telemetry/types.ts
@@ -28,6 +28,7 @@ export type AppTelemetryEvent =
   | "network.request_started"
   | "network.request_succeeded"
   | "network.request_failed"
+  | "network.canonical_request_violation"
   | "auth.session_established"
   | "auth.session_invalidated"
   | "checkout.return_received"

--- a/docs/runbooks/ssl-pinning-rotation.md
+++ b/docs/runbooks/ssl-pinning-rotation.md
@@ -1,0 +1,168 @@
+# SSL pinning rotation runbook
+
+## Quando executar
+
+- A cada 90 dias (alinhado ao ACM auto-renew dos certs `*.auraxis.com.br`).
+- Imediatamente quando ACM rotacionar inesperadamente um cert.
+- Antes de qualquer release que altere a infra de TLS (mudança de provider,
+  região, distribuição CDN).
+
+## Pre-requisitos
+
+- `openssl` na máquina local (≥1.1.1).
+- Acesso SSH/CLI à máquina que tem o cert atual da `auraxis.com.br`,
+  ou uso direto do endpoint público (handshake remoto).
+
+## Passos
+
+### 1. Extrair pin atual (cert em produção)
+
+```bash
+openssl s_client \
+  -connect api.auraxis.com.br:443 \
+  -servername api.auraxis.com.br \
+  </dev/null 2>/dev/null \
+  | openssl x509 -outform PEM > /tmp/api-cert.pem
+
+PIN_CURRENT=$(openssl x509 -in /tmp/api-cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -binary \
+  | openssl enc -base64)
+
+echo "Pin atual: sha256/${PIN_CURRENT}"
+```
+
+Repetir para `cdn.auraxis.com.br` e qualquer outro subdomínio servindo
+tráfego TLS direto.
+
+### 2. Gerar pin backup (próximo cert)
+
+O backup pin deve apontar para a **próxima** chave que a CA vai assinar.
+Duas opções:
+
+**Opção A — Pin do CA intermediário** (mais resiliente, menos seguro):
+
+```bash
+openssl s_client -connect api.auraxis.com.br:443 -showcerts </dev/null 2>/dev/null \
+  | awk '/BEGIN CERT/,/END CERT/' \
+  | csplit -z -s -f /tmp/cert- - '/BEGIN CERT/' '{*}'
+# /tmp/cert-01 é o intermediário; rodar a mesma cadeia openssl pkey | dgst | enc
+```
+
+**Opção B — Pin de uma chave gerada offline** (mais seguro, mais
+operacional):
+
+```bash
+# Gerar chave + CSR offline, guardar a chave em vault, usar SPKI da chave
+# como backup pin. Quando o cert atual vencer, ACM vai assinar essa
+# mesma chave e o backup pin fica ativo automaticamente.
+openssl genrsa -out /tmp/backup-key.pem 4096
+PIN_BACKUP=$(openssl rsa -in /tmp/backup-key.pem -pubout -outform der 2>/dev/null \
+  | openssl dgst -sha256 -binary \
+  | openssl enc -base64)
+
+echo "Pin backup: sha256/${PIN_BACKUP}"
+```
+
+Recomendado: opção B, com a chave guardada em AWS Secrets Manager
+(`auraxis/ssl-pinning/backup-key`).
+
+### 3. Atualizar `app.json` (iOS)
+
+```jsonc
+"ios": {
+  "infoPlist": {
+    "NSAppTransportSecurity": {
+      "NSAllowsArbitraryLoads": false,
+      "NSPinnedDomains": {
+        "auraxis.com.br": {
+          "NSIncludesSubdomains": true,
+          "NSPinnedCAIdentities": [
+            { "SPKI-SHA256-BASE64": "<PIN_CURRENT>" },
+            { "SPKI-SHA256-BASE64": "<PIN_BACKUP>" }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### 4. Atualizar `assets/network-security-config.xml` (Android)
+
+```xml
+<network-security-config>
+    <domain-config>
+        <domain includeSubdomains="true">auraxis.com.br</domain>
+        <pin-set expiration="2026-08-01">
+            <pin digest="SHA-256"><!-- PIN_CURRENT --></pin>
+            <pin digest="SHA-256"><!-- PIN_BACKUP --></pin>
+        </pin-set>
+    </domain-config>
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+</network-security-config>
+```
+
+`expiration` deve ser ≥ 30 dias antes da próxima rotação esperada.
+Quando expira, o pin-set deixa de ser enforced (fail-open) — não
+deixar passar.
+
+### 5. Sinalizar telemetria
+
+```bash
+eas secret:create \
+  --scope project \
+  --name EXPO_PUBLIC_SSL_PINNING_ENABLED \
+  --value true \
+  --type string
+
+eas secret:create \
+  --scope project \
+  --name EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS \
+  --value "sha256/${PIN_CURRENT},sha256/${PIN_BACKUP}" \
+  --type string
+```
+
+Esses secrets são read pelo `core/security/ssl-pinning.ts` para
+publicar telemetria; não controlam o pinning nativo (esse é imutável
+no binário).
+
+### 6. Build + smoke
+
+```bash
+eas build --profile preview --platform ios
+eas build --profile preview --platform android
+
+# Em cada device:
+# - Conectar normalmente: app deve funcionar.
+# - Ativar mitmproxy/Charles com cert custom: app deve falhar TLS handshake.
+```
+
+### 7. Promote
+
+Após smoke verde nos 2 devices, promover para `production` profile.
+PR com diff dos pins documentado.
+
+## Mitigação se um pin errado for shipado para produção
+
+**Sintoma:** app instalado retorna erros de rede em todas as chamadas
+HTTPS canônicas.
+
+**Causa-raiz:** pin atual não match com o cert servido. App não pode
+fazer OTA pra corrigir (pinning é nativo, requer redeploy via
+store).
+
+**Mitigação:**
+
+1. Reverter o `app.json` / XML para a versão pre-rotação (rollback do PR).
+2. Build emergencial profile `production`. Submeter para review
+   prioritário (Apple expedited review se necessário).
+3. Comunicar status page para ETA.
+
+**Prevenção:** sempre dois pins (atual + backup). Smoke test em preview
+profile antes de promote. Pin backup nunca compartilha de chave com
+o atual.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -79,6 +79,89 @@ throw new Error("sentry-smoketest");
 `Sentry.init({ enabled: !__DEV__ })` mantém o SDK silencioso durante
 `expo start`. Só builds de preview/production reportam.
 
+## SSL pinning
+
+Pinning é aplicado em duas camadas:
+
+### 1. Nativo (primário)
+
+**iOS** — `app.json` declara `expo.ios.infoPlist.NSAppTransportSecurity`:
+
+```jsonc
+"NSAppTransportSecurity": {
+  "NSAllowsArbitraryLoads": false,
+  "NSPinnedDomains": {
+    "auraxis.com.br": {
+      "NSIncludesSubdomains": true,
+      "NSPinnedCAIdentities": []  // populado por ops antes de promover a prod
+    }
+  }
+}
+```
+
+**Android** — `app.json` aponta `expo.android.networkSecurityConfig` para
+`assets/network-security-config.xml`. Hoje o XML aplica baseline (cleartext
+bloqueado, system trust apenas). O bloco `<domain-config>` com `<pin-set>`
+entra quando ops popular as hashes SPKI.
+
+### 2. Defensivo (JS, este módulo)
+
+`core/security/ssl-pinning.ts::verifyCanonicalRequest(url)` valida que
+toda chamada outbound:
+
+- Usa `https://` (rejeita `http://`).
+- Tem hostname dentro de `*.auraxis.com.br` (rejeita typos, dev-only
+  bypass URLs, exfil para hosts arbitrários).
+
+Retorna `{ kind: "ok" }` ou `{ kind: "blocked", reason: ... }`. O HTTP
+client integra esse predicate antes de despachar a request — é
+belt-and-braces sobre o pinning nativo.
+
+### Geração e rotação dos pins SPKI
+
+```bash
+# 1. Baixar o cert público da raiz canônica
+openssl s_client -connect api.auraxis.com.br:443 -servername api.auraxis.com.br \
+  </dev/null 2>/dev/null | openssl x509 -outform PEM > /tmp/api-cert.pem
+
+# 2. Extrair o SPKI hash (formato Apple/Android)
+openssl x509 -in /tmp/api-cert.pem -pubkey -noout \
+  | openssl pkey -pubin -outform der \
+  | openssl dgst -sha256 -binary \
+  | openssl enc -base64
+
+# Saída: hash base64 — usar como pin atual.
+# Repetir com a CA de backup (próxima rotação) para o pin secundário.
+```
+
+**Política de pins:**
+
+- Sempre dois pins: **atual** + **backup** (próximo). Nunca um só, ou um
+  pin roll forçaria atualização da app store antes do cert vencer.
+- Validade dos pins documentada no XML/Info.plist com expiração explícita
+  no XML Android (`<pin-set expiration="YYYY-MM-DD">`).
+- Rotação a cada 90 dias (alinhado ao ACM auto-renew).
+
+### Smoke tests pós-build (manuais)
+
+```bash
+# 1. Build de preview com pinning
+EXPO_PUBLIC_SSL_PINNING_ENABLED=true \
+EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS="sha256/<hash1>,sha256/<hash2>" \
+eas build --profile preview
+
+# 2. Cert válido → request OK (esperado)
+# 3. Proxiar via mitmproxy/Charles com cert custom → request bloqueado (TLS handshake fail)
+```
+
+### Posture do flag `EXPO_PUBLIC_SSL_PINNING_ENABLED`
+
+Esse flag NÃO controla o pinning nativo (que é imutável uma vez que a
+app é instalada). Ele controla a **postura defensiva JS**: telemetria,
+breadcrumbs Sentry, e dashboards de ops que verificam se a build foi
+promovida com intenção de pinning. Native pinning é always-on quando
+o `app.json` declara as estruturas.
+
 ## Component dev catalog
 
 Galeria interna de componentes em `app/(legal)/dev-catalog.tsx`,


### PR DESCRIPTION
## Summary

Closes #346 (sub-bloco do epic #298 — security hardening).

Sai do scaffolding e ativa pinning nativo em iOS + Android via config plugin Expo (zero deps nativas adicionais), mais um defensive audit no HTTP client.

## Refs

Closes #346

## Two-layer enforcement

### 1. Nativo (primário, durante TLS handshake)

**iOS** — `app.json` declara `expo.ios.infoPlist.NSAppTransportSecurity`:
- `NSAllowsArbitraryLoads: false`
- `NSPinnedDomains["auraxis.com.br"]` com `NSIncludesSubdomains: true` e `NSPinnedCAIdentities: []`

**Android** — `app.json` aponta `expo.android.networkSecurityConfig` para `assets/network-security-config.xml`:
- `<base-config cleartextTrafficPermitted="false">`
- System trust anchors apenas (no user-installed CAs)

`<pin-set>` deliberadamente vazio nesta PR — ops popula SPKI hashes (current + backup) antes de promover para production. Runbook completo em [`docs/runbooks/ssl-pinning-rotation.md`](docs/runbooks/ssl-pinning-rotation.md) cobrindo geração via openssl, formato Apple/Android, expiração, mitigação de pin errado.

### 2. Defensivo (JS, observability)

`core/security/ssl-pinning.ts::verifyCanonicalRequest(url)` valida que cada outbound request:
- Usa `https://` (rejeita `http://`)
- Hostname dentro de `*.auraxis.com.br` (rejeita typos / dev-only bypass / exfil)

Returns `{ kind: "ok" }` ou `{ kind: "blocked", reason: ... }`.

HTTP client interceptor (`core/http/http-client.ts::auditCanonicalRequest`) consome o predicate e publica `network.canonical_request_violation` quando bloqueia. Não bloqueia o request — pinning nativo já é enforcement real; aqui apenas observamos.

## Refactor — handleRejectedResponse

Pre-existing technical debt: complexidade ciclomática 22 (limite ESLint 12). Surgiu agora porque toquei o arquivo. Quebrei em helpers:
- `isCriticalFailure` — predicate de status crítico (≥500 ou 0)
- `buildAxiosFailureContext` — extrai contexto de telemetria
- `maybeInvalidateSession` — sessão expirada → invalidate
- `handleAxiosFailure` / `handleNonAxiosFailure` — paths separados

`handleRejectedResponse` agora é 4 linhas e composição clara.

## Documentation

- **`docs/runtime.md`** — section "SSL pinning" com 2-layer overview, geração de hashes via openssl, política de pins (sempre dois — atual + backup), smoke tests.
- **`docs/runbooks/ssl-pinning-rotation.md`** — runbook completo: extração, AWS Secrets Manager para chave backup, atualização do app.json/XML, EAS secrets, smoke validation, mitigação se pin errado for shipado.

## Risk analysis

**Risco médio.** Native pinning errado bloqueia todo o app em produção até OTA store update. Mitigações:

1. `<pin-set>` vazio nesta PR — pinning não está enforcing nada ainda, só estrutura está em place.
2. Runbook documenta processo de geração + smoke validation antes de promote.
3. Política de dois pins (atual + backup) garante que cert roll não força app store update.
4. JS audit é apenas telemetria — não bloqueia request, mesmo com URL não-canônica.

**Backwards compat.** `EXPO_PUBLIC_SSL_PINNING_ENABLED` / `EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS` permanecem para telemetria e dashboards de ops verificarem build intent. Não controlam pinning nativo (que é imutável no binário).

## Test plan

- [x] `npm run lint` — green
- [x] `npm run typecheck` — green
- [x] `npm run policy:check` — 8 governance gates verdes
- [x] `npm run contracts:check` — green
- [x] `npm run test:coverage` — **1647 testes / 258 suites verdes**
- [x] 5 novos testes em `ssl-pinning.test.ts` cobrindo `verifyCanonicalRequest` (ok, non-https, non-canonical, invalid url, case-insensitive)

### Smoke tests pendentes (manuais — fora do escopo automatizado)

- [ ] `eas build --profile preview --platform ios` confirmando build OK com NSAppTransportSecurity declarado.
- [ ] `eas build --profile preview --platform android` idem com networkSecurityConfig.
- [ ] Após populate dos pins (PR follow-up): proxiar via mitmproxy/Charles com cert custom → request bloqueado pelo SO no TLS handshake.

São smoke tests que requerem device/simulador físico + cert produção. Não são automatizáveis via CI sem build infra dedicada.