### PR TITLE
[APP] Lint guard against react-native Image (#347)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -64,6 +64,26 @@ module.exports = defineConfig([
         "error",
         { prefer: "type-imports", fixStyle: "inline-type-imports" },
       ],
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
+            {
+              name: "react-native",
+              importNames: ["Image", "ImageBackground"],
+              message:
+                "Use AppImage from @/shared/components/app-image (wraps expo-image with cache + transition).",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
+    // The AppImage wrapper itself imports expo-image directly.
+    files: ["shared/components/app-image.tsx"],
+    rules: {
+      "no-restricted-imports": "off",
     },
   },
   {


### PR DESCRIPTION
## Summary

Closes #347.

**Audit revelou que a issue era um falso-positivo.** O app já tem `AppImage` (`shared/components/app-image.tsx`) wrapping `expo-image` com `cachePolicy: "memory-disk"` e fade transition default de 200ms. E mais importante — **zero consumers** de `<Image>` (raw, RN, ou AppImage) em todo o codebase. O número "3 ocorrências de expo-image" do relatório original eram as 3 linhas dentro do próprio `app-image.tsx`.

A app simplesmente não renderiza imagens dinâmicas ainda (icons/splash são assets nativos via `app.json`).

## Refs

Closes #347
Plano: `auraxis-platform/.context/reports/historical/plan_quality_remediation_2026-05-01.md` fase 4.

## Scope shipped

Já que a infraestrutura está pronta e a migração é vácuo, o entregável é **prevenção de regressão** via ESLint rule — para garantir que código novo não importe `Image` direto de `react-native`.

### `eslint.config.js`

```js
"no-restricted-imports": [
  "error",
  {
    paths: [
      {
        name: "react-native",
        importNames: ["Image", "ImageBackground"],
        message:
          "Use AppImage from @/shared/components/app-image (wraps expo-image with cache + transition).",
      },
    ],
  },
],
```

Plus exceção para o próprio `app-image.tsx` (que importa `expo-image` legitimamente).

## Test plan

- [x] `npm run lint` — green (existing code já não usa o import proibido)
- [x] `npm run quality-check` — 1642 testes / 258 suites verdes
- [x] `AppImage` já tem 3 testes cobrindo cachePolicy default, override, fade toggle (não adicionei mais — cobertura é adequada)

## Risk

Zero. Apenas adiciona uma regra preventiva. Lint passa porque ninguém usa `Image` de RN hoje.