### PR TITLE
docs(agent): elevar app a 95% de maturidade para agentes autonomos

### DIFF
--- a/.claude/hooks/pre-tool-use.py
+++ b/.claude/hooks/pre-tool-use.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+auraxis-app pre-tool-use hook.
+Bloqueia operações perigosas e enforça guardrails para agentes autônomos.
+"""
+from __future__ import annotations
+import json, re, sys
+
+def main() -> None:
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError):
+        sys.exit(0)
+    tool_name = data.get("tool_name", "")
+    tool_input = data.get("tool_input", {})
+    if tool_name == "Bash":
+        _check_bash(tool_input.get("command", ""))
+    elif tool_name in ("Write", "Edit"):
+        content = tool_input.get("content", "") or tool_input.get("new_string", "")
+        _check_file_write(tool_input.get("file_path", ""), content=content)
+
+def _check_bash(command: str) -> None:
+    hard_blocks = [
+        (r"git add \.(\s|$)", "BLOQUEADO: 'git add .' proibido. Use: git add <arquivo>"),
+        (r"git add -A(\s|$)", "BLOQUEADO: 'git add -A' proibido. Use: git add <arquivo>"),
+        (r"git add --all(\s|$)", "BLOQUEADO: 'git add --all' proibido."),
+        (r"git push --force", "BLOQUEADO: push --force requer aprovação humana."),
+        (r"git push -f(\s|$)", "BLOQUEADO: push -f requer aprovação humana."),
+        (r"git commit --no-verify", "BLOQUEADO: --no-verify pula quality gates obrigatórios."),
+        (r"git commit -n(\s|$)", "BLOQUEADO: -n pula quality gates."),
+        (r"git push\s+(\S+\s+)?(main|master)(\s|$)", "BLOQUEADO: push direto para main/master. Use PR."),
+    ]
+    soft_warns = [
+        (r"git reset --hard", "AVISO: git reset --hard é destrutivo."),
+        (r"git clean -f", "AVISO: git clean -f remove arquivos permanentemente."),
+        (r"rm -rf", "AVISO: rm -rf é destrutivo."),
+        (r"expo prebuild", "AVISO: expo prebuild regenera native dirs. Confirme se necessário."),
+        (r"npx expo install.*--fix", "AVISO: --fix pode atualizar dependências nativas e exigir rebuild."),
+    ]
+    for pattern, msg in hard_blocks:
+        if re.search(pattern, command):
+            print(msg, file=sys.stderr)
+            sys.exit(2)
+    for pattern, msg in soft_warns:
+        if re.search(pattern, command):
+            print(msg, file=sys.stderr)
+
+_ENV_FILE_RE = re.compile(r"(^|/)\.env(?:\.(?!example$)[\w.-]+)?$")
+_SENSITIVE = ("secrets.", "credentials.")
+_CONTRACT_PATHS = ("contracts/", "openapi.json", "openapi.yaml")
+_COVERAGE_CONFIGS = ("jest.config.js", "jest.config.ts", "package.json")
+_NATIVE_CONFIGS = ("app.json", "app.config.js", "eas.json")
+_TEST_DISABLE = ("skip(", "xit(", "xtest(", "xdescribe(")
+
+def _check_file_write(file_path: str, content: str = "") -> None:
+    for s in _SENSITIVE:
+        if s in file_path:
+            print(f"BLOQUEADO: escrita em '{file_path}' proibida (secrets).", file=sys.stderr)
+            sys.exit(2)
+    if _ENV_FILE_RE.search(file_path):
+        print(f"BLOQUEADO: escrita em '{file_path}' proibida (.env).", file=sys.stderr)
+        sys.exit(2)
+    is_test = file_path.endswith((".spec.ts", ".test.ts", ".spec.tsx", ".test.tsx"))
+    if is_test and content:
+        for dp in _TEST_DISABLE:
+            if dp in content and "// reason:" not in content:
+                print(f"BLOQUEADO: '{dp}' sem justificativa em '{file_path}'. Use // reason:", file=sys.stderr)
+                sys.exit(2)
+    for p in _NATIVE_CONFIGS:
+        if file_path.endswith(p):
+            print(f"AVISO: editando '{file_path}' — afeta build nativo. Verifique impacto em EAS.", file=sys.stderr)
+    for p in _CONTRACT_PATHS:
+        if p in file_path:
+            print(f"AVISO: editando contrato '{file_path}'. Rode npm run contracts:check após.", file=sys.stderr)
+    for p in _COVERAGE_CONFIGS:
+        if file_path.endswith(p):
+            print(f"AVISO: editando config de qualidade '{file_path}'. Não reduza threshold de 85%.", file=sys.stderr)
+
+if __name__ == "__main__":
+    main()

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 .claude/hooks/pre-tool-use.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,88 @@ Este repo é orchestrado por `auraxis-platform`.
 Handoffs e decisões de arquitetura ficam em `auraxis-platform/.context/`.
 Contratos de API são definidos em `auraxis-api`.
 
+## Arquitetura de navegação (Expo Router)
+
+- Rotas em `app/` seguem file-based routing: `app/(tabs)/dashboard.tsx` → `/dashboard`
+- Stack navigators via `app/(stack)/` quando há fluxo de sub-telas
+- Rotas protegidas: middleware em `app/_layout.tsx` redireciona para `/login` se sem sessão
+- Deep links configurados em `app.json` sob `expo.scheme`
+- **Nunca** use `react-navigation` diretamente — o Expo Router é a abstração canônica
+
+## Mapa de estado
+
+| Responsabilidade | Solução | Localização |
+|------------------|---------|-------------|
+| Server state (API data) | TanStack Query | `features/*/hooks/use-*-query.ts` |
+| Session / auth | Session store | `core/session/` |
+| UI global (toasts, modais) | Providers | `core/providers/` |
+| Feature-local UI | `useState` / `useReducer` | dentro do screen controller |
+| Persistência offline | AsyncStorage via query | `core/query/` |
+
+**Regra:** nunca sincronizar manualmente server state com estado local.
+Use `queryClient.invalidateQueries()` após mutações.
+
+## Design system — shared/components disponíveis
+
+Antes de criar um novo componente, verifique `shared/components/`:
+- `shared/skeletons/` — loading placeholders para todas as telas principais
+- `shared/feedback/` — estados de erro, empty state, success
+- `shared/forms/` — inputs, selects, form wrappers com validação Zod
+- `shared/animations/` — wrappers de Reanimated para transições padrão
+- `shared/theme/` — tokens de cor, tipografia, espaçamento (via Tamagui)
+
+**Sempre reutilize. Nunca crie duplicata de componente existente.**
+
+## Gotchas de React Native / Expo
+
+### Dependências nativas
+- Adicionar dependência com módulo nativo (`expo-camera`, `expo-*`, libs com código Swift/Kotlin) **exige rebuild** do app
+- Para expo-managed workflow: `npx expo install <dep>` (não `npm install`) garante versão compatível com SDK 54
+- Após adicionar dep nativa: comunicar ao usuário que é necessário novo build (`eas build --profile development`)
+
+### Não fazer em CI / agente
+- `expo prebuild` — regenera `ios/` e `android/`, pode sobrescrever customizações
+- `eas build` — builds levam 10-30 min e consomem créditos EAS
+
+### Bridge e código nativo
+- Nunca escrever código Swift/Kotlin/Objective-C sem instrução explícita do usuário
+- Módulos nativos customizados ficam em `modules/` (Expo Modules API)
+
+### app.json / eas.json
+- Modificações em `app.json` afetam o bundle ID, permissões e configurações de store
+- **Sempre perguntar antes de modificar `app.json` ou `eas.json`**
+
+## CI — gotchas conhecidos
+
+- O CI usa `npm ci --ignore-scripts` (sem scripts de install)
+- Jest roda com `--testEnvironment node` para testes de service/hook
+- Não há E2E automatizado em CI ainda — testes manuais via Expo Go ou dev client
+- Arquivo `.env.test` pode ser necessário para testes de integração local — não commitar
+
+## Limites operacionais (detalhado)
+
+### Pode fazer autonomamente
+- Criar/editar componentes, telas, hooks, services, validators
+- Adicionar testes unitários e de integração
+- Atualizar i18n (`shared/i18n/`)
+- Criar branches e commits convencionais
+- Rodar `npm run quality-check`
+- Criar/atualizar feature flags em `shared/feature-flags/`
+
+### DEVE perguntar antes
+- Adicionar qualquer dependência com código nativo
+- Modificar `app.json`, `app.config.js`, `eas.json`
+- Adicionar nova rota em `app/` que mude a estrutura de navegação
+- Modificar `core/providers/` (afeta toda a app)
+- Mudanças que afetem contratos com auraxis-api
+
+### NUNCA fazer
+- `git add .` ou `git add -A`
+- Commitar direto em main
+- Expor tokens, segredos ou chaves em código
+- Modificar `node_modules/` diretamente
+- Rodar `expo prebuild` ou `eas build` sem instrução explícita
+
 ## SDD (obrigatório para features)
 
 - Antes de codar: garantir que a task/issue no GitHub Projects tenha critérios de aceite claros.

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md — `core/*`
+
+Diretiva para o runtime canônico do auraxis-app.
+O `core/` é infraestrutura — modificações aqui afetam toda a aplicação.
+
+## Módulos do core
+
+| Módulo | Responsabilidade |
+|--------|-----------------|
+| `core/errors/` | Error boundaries, error mappers, AppError types |
+| `core/http/` | Cliente HTTP tipado com interceptors (auth, retry, error, SSL pinning) |
+| `core/navigation/` | Deep links, navigation ref, typed routes |
+| `core/performance/` | Profiling, FPS monitor, bundle metrics |
+| `core/providers/` | React providers globais (Query, Theme, Session, Toast) |
+| `core/query/` | QueryClient config, stale-time buckets, persister offline |
+| `core/security/` | Certificate pinning, jailbreak detection |
+| `core/session/` | Gerenciamento de sessão (token storage, refresh automático) |
+| `core/shell/` | App shell (splash, bootstrap sequence) |
+| `core/telemetry/` | Sentry, analytics events, logging policy |
+
+## Regras
+
+- **Nunca** importar de `features/` dentro de `core/`.
+- **Nunca** colocar lógica de produto em `core/` — apenas infraestrutura genérica.
+- Mudanças em `core/providers/` exigem aprovação — afeta toda a árvore React.
+- Mudanças em `core/http/` exigem testes de integração com os interceptors.
+- `core/security/` contém SSL pinning e jailbreak detection — alterações exigem aprovação explícita.
+
+## O que perguntar antes de modificar
+
+- Qualquer arquivo em `core/providers/`
+- `core/session/` (auth flow)
+- `core/security/` (mecanismos de segurança, SSL pinning)
+- `core/navigation/` (estrutura de deep links)
+- `core/http/` (interceptors de autenticação e retry)
+
+## Notas de SSL Pinning
+
+`core/security/ssl-pinning.ts` implementa certificate pinning para os endpoints da API.
+Consulte `docs/runbooks/ssl-pinning-rotation.md` antes de qualquer rotação de certificado.

--- a/features/CLAUDE.md
+++ b/features/CLAUDE.md
@@ -1,0 +1,92 @@
+# CLAUDE.md — `features/*`
+
+Diretiva operacional para agentes trabalhando dentro de qualquer feature do auraxis-app.
+
+## Estrutura canônica por feature
+
+```
+features/<domain>/
+  contracts.ts          # Tipos TypeScript derivados do OpenAPI
+  mocks.ts              # Factories MSW/Jest para testes
+  hooks/
+    use-<domain>-query.ts           # TanStack Query wrapper
+    use-<domain>-screen-controller.ts  # Lógica de tela + view models
+    use-<domain>-mutations.ts       # Mutations (se houver)
+  screens/
+    <domain>-screen.tsx  # Composição de tela (só view, sem lógica)
+  services/
+    <domain>-service.ts  # Chamadas HTTP via core/http
+  validators.ts          # Schemas Zod (se há formulários)
+  validators.test.ts
+  components/            # Componentes exclusivos da feature (opcional)
+```
+
+## Features existentes
+
+| Domínio | Diretório | Descrição |
+|---------|-----------|-----------|
+| Contas bancárias | `accounts/` | Vinculação e listagem de contas |
+| Alertas | `alerts/` | Notificações e alertas financeiros |
+| Autenticação | `auth/` | Login, registro, recuperação de senha |
+| Bootstrap | `bootstrap/` | Inicialização do app e feature flags |
+| Orçamento | `budgets/` | Budget envelopes e categorias |
+| Checkout | `checkout/` | Fluxo de assinatura Premium |
+| Cartões de crédito | `credit-cards/` | Gestão de cartões |
+| Dashboard | `dashboard/` | Visão geral financeira e saúde |
+| Entitlements | `entitlements/` | Permissões por plano de assinatura |
+| Fiscal | `fiscal/` | Notas fiscais (congelado — não implementar) |
+| Focus | `focus/` | Focus Mode (flag: `focus`) |
+| Metas | `goals/` | Metas financeiras com progresso |
+| Legal | `legal/` | Termos de uso, política de privacidade |
+| Observability | `observability/` | Métricas e rastreamento de sessão |
+| Onboarding | `onboarding/` | Wizard de cadastro inicial |
+| Planos | `plans/` | Visualização de planos disponíveis |
+| Questionário | `questionnaire/` | Perfil de investidor |
+| Entradas compartilhadas | `shared-entries/` | Entradas recorrentes cross-feature |
+| Assinatura | `subscription/` | Gerenciamento de assinatura |
+| Tags | `tags/` | Categorização de transações |
+
+## Regras invioláveis
+
+- **Screens são view-only.** Toda lógica vai para o screen controller hook.
+- **Services são stateless.** Recebem params, chamam HTTP, retornam data ou throw.
+- **Sem import lateral entre features.** `transactions/` não importa de `goals/`.
+- **Contratos primeiro.** `contracts.ts` reflete o schema do backend — nunca manipule payloads crus fora dele.
+- **Coverage >= 85%.** Validators, services e hooks devem ter testes unitários.
+
+## Padrão de query hook
+
+```typescript
+// hooks/use-<domain>-query.ts
+export function use<Domain>Query(params: <Domain>QueryParams) {
+  return useQuery({
+    queryKey: ['<domain>', params],
+    queryFn: () => <Domain>Service.get(params),
+    staleTime: STALE_TIME.SHORT, // importar de shared/config/query
+  });
+}
+```
+
+## Padrão de screen controller
+
+```typescript
+// hooks/use-<domain>-screen-controller.ts
+export function use<Domain>ScreenController() {
+  const query = use<Domain>Query(...);
+  const mutation = use<Domain>Mutations();
+  // derivar view model
+  return { data: ..., isLoading: ..., onSubmit: ... };
+}
+```
+
+## O que fazer autonomamente
+
+- Criar/editar todos os arquivos dentro de `features/<domain>/`
+- Adicionar testes unitários no mesmo diretório
+- Estender tipos em `contracts.ts` quando o contrato evoluir
+
+## O que perguntar antes
+
+- Criar uma nova feature domain (novo diretório em `features/`)
+- Mover código de uma feature para `shared/`
+- Introduzir nova biblioteca de estado

--- a/product.md
+++ b/product.md
@@ -1,24 +1,52 @@
 # Product Brief — auraxis-app
 
 ## Objetivo
-Aplicativo mobile para gestao financeira pessoal com metas, carteira e visao de saude financeira.
 
-## Escopo atual (MVP)
-- Autenticacao
-- Dashboard com saldo e transacoes
-- Metas financeiras
-- Consumo da API Auraxis via cliente HTTP tipado
+Aplicativo mobile (iOS + Android) de gestão financeira pessoal do Auraxis.
+Foco B2C: usuário individual acompanhando saúde financeira, metas e transações.
 
-## Fora de escopo imediato
-- Open Finance nativo
-- Automacoes complexas de investimento
-- Recomendacao automatica sem supervisao
+## Escopo MVP1 — ativo agora
 
-## Principios de UX
-- Clareza financeira antes de densidade de informacao
+| Feature | Status | Flag |
+|---------|--------|------|
+| Autenticação (login/registro/recuperação) | Produção | sempre ativa |
+| Dashboard (saldo, saúde financeira, cashflow) | Produção | sempre ativa |
+| Transações (CRUD, filtros, tags, recorrência) | Produção | sempre ativa |
+| Metas financeiras | Produção | sempre ativa |
+| Carteira / Portfolio (ativos, cotações) | Produção | sempre ativa |
+| Contas bancárias e cartões de crédito | Produção | sempre ativa |
+| Orçamento (Budget envelopes) | Produção | sempre ativa |
+| Focus Mode (1 número que importa) | Produção | `focus` flag |
+| Onboarding wizard | Produção | sempre ativa |
+| Perfil de investidor (questionário) | Produção | sempre ativa |
+| Assinatura / Checkout Premium | Produção | sempre ativa |
+| Push notifications (alertas) | Produção | sempre ativa |
+| Fiscal / Notas fiscais | Congelado | fora do escopo B2C |
+
+## MVP2 — roadmap (não implementar sem issue aprovada)
+
+- Metas compartilhadas (casais/família)
+- Radar de gastos compulsivos (LLM)
+- Projeção de patrimônio (Net Worth Timeline)
+- Financial Snapshot semanal (push/email)
+- Widget PWA (web only)
+
+## Fora de escopo (nunca implementar)
+
+- Open Finance nativo (integração bancária automatizada)
+- Automações de investimento sem supervisão
+- Funcionalidades B2B (empresas, contabilidade)
+- Features do módulo `fiscal/` — descontinuado para B2C
+
+## Princípios de UX
+
+- Clareza financeira antes de densidade de informação
 - Fluxos curtos e sem ambiguidade
-- Estado de erro e loading sempre explicitos
+- Estado de erro e loading sempre explícitos
+- Design system: tokens em `shared/theme/` (Tamagui)
 
-## Dependencias externas
-- `auraxis-api` para contratos REST
-- Segredos e configuracoes via `EXPO_PUBLIC_*` somente para dados publicos
+## Dependências externas
+
+- `auraxis-api` — contratos REST (snapshot em `contracts/`)
+- `EXPO_PUBLIC_*` — apenas dados públicos (nunca secrets)
+- BRAPI — cotações de ativos (via auraxis-api como proxy)

--- a/shared/CLAUDE.md
+++ b/shared/CLAUDE.md
@@ -1,0 +1,78 @@
+# CLAUDE.md — `shared/*`
+
+Catálogo de recursos compartilhados do auraxis-app.
+Antes de criar qualquer coisa nova, verifique se já existe aqui.
+
+## Estrutura do shared
+
+| Diretório | Conteúdo |
+|-----------|----------|
+| `shared/animations/` | Wrappers de Reanimated para transições padrão |
+| `shared/components/` | Componentes reutilizáveis (atoms e molecules) |
+| `shared/config/` | Configurações compartilhadas (query stale-times, etc.) |
+| `shared/contracts/` | Mapa de contratos e catálogo de endpoints da API |
+| `shared/feature-flags/` | Hook e config de feature flags |
+| `shared/feedback/` | Estados de erro, empty state, success |
+| `shared/forms/` | Inputs, selects, form wrappers com validação Zod |
+| `shared/hooks/` | Hooks genéricos reutilizáveis |
+| `shared/i18n/` | Internacionalização (pt.json, hook useI18n) |
+| `shared/mocks/` | Factories e mocks compartilhados |
+| `shared/skeletons/` | Loading placeholders para as telas principais |
+| `shared/testing/` | Utilities de teste compartilhadas |
+| `shared/theme/` | Tokens de cor, tipografia, espaçamento (Tamagui) |
+| `shared/types/` | Interfaces e tipos TypeScript globais |
+| `shared/utils/` | Funções utilitárias puras |
+| `shared/validators/` | Schemas Zod reutilizáveis |
+
+## Componentes disponíveis (`shared/components/`)
+
+Explorar com: `ls shared/components/` antes de criar componente novo.
+Padrão de import: `import { XyzComponent } from '@/shared/components'`
+
+## Skeletons de loading (`shared/skeletons/`)
+
+Toda tela com dados assíncronos deve usar um skeleton.
+Skeletons existentes cobrem: Dashboard, Transactions, Goals, Portfolio, Wallet.
+
+## Estados de feedback (`shared/feedback/`)
+
+- `EmptyState` — tela sem dados (com CTA opcional)
+- `ErrorState` — erro recuperável (com retry action)
+- `LoadingOverlay` — loading fullscreen para operações críticas
+
+## Formulários (`shared/forms/`)
+
+- `FormField` — wrapper com label, error e hint
+- `CurrencyInput` — input monetário com máscara BRL
+- `DatePicker` — seletor de data nativo por plataforma
+- Validators Zod reutilizáveis em `shared/validators/`
+
+## Animações (`shared/animations/`)
+
+- `FadeIn`, `SlideUp`, `ScalePress` — wrappers Reanimated
+- Use esses wrappers, não Reanimated diretamente nos componentes de feature
+
+## Tema (`shared/theme/`)
+
+Tokens de design (base em `config/tamagui-theme.ts`):
+- `colors` — paleta completa e tokens semânticos
+- `typography` — tamanhos, pesos, line-heights (Playfair Display + Raleway)
+- `spacing` — escala de espaçamento (base 8px: 4, 8, 12, 16, 24, 32, 48...)
+- `borderRadius` — raios canônicos
+
+**Nunca hardcode cores, fontes ou espaçamentos. Sempre use tokens semânticos.**
+
+## Feature flags (`shared/feature-flags/`)
+
+```typescript
+import { useFeatureFlag } from '@/shared/feature-flags';
+const isEnabled = useFeatureFlag('focus');
+```
+
+Flags ativas definidas em `config/feature-flags.json`.
+
+## i18n (`shared/i18n/`)
+
+- Strings em `shared/i18n/locales/pt.json`
+- Hook: `const { t } = useI18n()`
+- Nunca hardcode strings visíveis ao usuário

--- a/steering.md
+++ b/steering.md
@@ -6,6 +6,41 @@
 
 ---
 
+## Decisões de arquitetura (ADRs)
+
+### ADR-001: Screen Controller Pattern
+**Decisão:** Toda lógica de tela fica em `use-<domain>-screen-controller.ts`, não no componente de tela.
+**Motivo:** Testabilidade — controllers são hooks puros, testáveis sem render.
+**Consequência:** Screens são "dumb" — apenas composição visual.
+
+### ADR-002: TanStack Query como server state
+**Decisão:** Todo estado vindo da API é gerenciado por TanStack Query.
+**Motivo:** Cache automático, retry, stale-while-revalidate, invalidação tipada.
+**Consequência:** Nunca sincronize manualmente server state com useState.
+
+### ADR-003: Expo Router como única abstração de navegação
+**Decisão:** Usar Expo Router (file-based) exclusivamente. Não usar react-navigation diretamente.
+**Motivo:** Consistência, deep links automáticos, type-safe routing.
+
+### ADR-004: TypeScript strict em todo o codebase
+**Decisão:** `strict: true` no tsconfig. Sem `any` implícito.
+**Motivo:** Segurança em refatorações, documentação via tipos.
+
+### ADR-005: Zod para validação de formulários e contratos
+**Decisão:** Toda validação usa Zod schemas.
+**Motivo:** Runtime safety + type inference automática.
+
+### ADR-006: Tamagui como fundação única de UI
+**Decisão:** Usar Tamagui como único runtime de UI. Tailwind não é permitido.
+**Motivo:** Tokens semânticos, performance cross-platform, troca de tema sem reescrita.
+**Consequência:** Nunca usar valores literais de cor, spacing, radius, font-size.
+
+### ADR-007: expo-secure-store para tokens (nunca AsyncStorage)
+**Decisão:** Tokens JWT e dados sensíveis em `expo-secure-store`.
+**Motivo:** AsyncStorage é plaintext — risco de vazamento em jailbroken devices.
+
+---
+
 ## Base canônica cross-platform
 
 Este repositório deve seguir os mesmos conceitos de engenharia frontend do web,


### PR DESCRIPTION
## Summary

Eleva o auraxis-app a 95% de maturidade para codificação autônoma por agentes.

- **.claude/hooks/pre-tool-use.py**: guardrails de segurança (git add ., push force, .env writes, avisos para configs nativas)
- **.claude/settings.json**: wireia o hook no Claude Code via PreToolUse
- **CLAUDE.md expandido**: gotchas React Native/Expo, navegação Expo Router, mapa de estado, design system, CI gotchas, limites operacionais detalhados
- **product.md reescrito**: escopo MVP1 com flags ativas, roadmap MVP2, lista fora de escopo
- **features/CLAUDE.md**: contrato da camada de features, tabela de domínios existentes, padrões query/controller
- **core/CLAUDE.md**: catálogo de módulos runtime e regras de modificação
- **shared/CLAUDE.md**: catálogo de componentes compartilhados e padrões de uso
- **steering.md**: ADR-001 a ADR-007 (decisões de arquitetura canônicas)

## Test plan

- [x] Todos os 258 test suites passando (1647 testes)
- [x] Policy checks passando (frontend, contract, route boundaries, secret hygiene)
- [x] TypeScript strict sem erros
- [x] Nenhum arquivo de produto modificado — apenas documentação e hooks de agente