### PR TITLE
[codex] Add channel-aware checkout gates

### DIFF
--- a/__tests__/app/installment-vs-cash-screen.test.tsx
+++ b/__tests__/app/installment-vs-cash-screen.test.tsx
@@ -5,12 +5,22 @@ import type {
   InstallmentVsCashCalculation,
   InstallmentVsCashSavedSimulation,
 } from "@/features/tools/contracts";
+import type { ReactNode } from "react";
 import type { UseMutationResult, UseQueryResult } from "@tanstack/react-query";
 import { TestProviders } from "@/shared/testing/test-providers";
 
 jest.mock("@/features/tools/hooks/use-installment-vs-cash-screen-controller", () => ({
   useInstallmentVsCashScreenController: jest.fn(),
 }));
+
+jest.mock("@/features/entitlements/components/paywall-gate", () => {
+  const ReactInner = jest.requireActual("react");
+
+  return {
+    PaywallGate: ({ children }: { readonly children: ReactNode }) =>
+      ReactInner.createElement(ReactInner.Fragment, null, children),
+  };
+});
 
 const mockedUseInstallmentVsCashScreenController = jest.mocked(
   useInstallmentVsCashScreenController,

--- a/__tests__/app/subscription-screen.test.tsx
+++ b/__tests__/app/subscription-screen.test.tsx
@@ -96,6 +96,6 @@ describe("SubscriptionScreen", () => {
     );
 
     expect(getByText("Sua assinatura")).toBeTruthy();
-    expect(getByText("Gerenciar pelo navegador")).toBeTruthy();
+    expect(getByText("Gerenciar assinatura")).toBeTruthy();
   });
 });

--- a/app/(private)/custo-estilo-de-vida.tsx
+++ b/app/(private)/custo-estilo-de-vida.tsx
@@ -1,1 +1,12 @@
-export { CostOfLifestyleScreen as default } from "@/features/tools/screens/cost-of-lifestyle-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { CostOfLifestyleScreen } from "@/features/tools/screens/cost-of-lifestyle-screen";
+
+export default function CostOfLifestyleRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <CostOfLifestyleScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/desconto-markup.tsx
+++ b/app/(private)/desconto-markup.tsx
@@ -1,1 +1,12 @@
-export { DescontoMarkupScreen as default } from "@/features/tools/screens/desconto-markup-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { DescontoMarkupScreen } from "@/features/tools/screens/desconto-markup-screen";
+
+export default function DescontoMarkupRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <DescontoMarkupScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/dividir-conta.tsx
+++ b/app/(private)/dividir-conta.tsx
@@ -1,1 +1,12 @@
-export { SplitBillScreen as default } from "@/features/tools/screens/split-bill-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { SplitBillScreen } from "@/features/tools/screens/split-bill-screen";
+
+export default function SplitBillRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <SplitBillScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/installment-vs-cash.tsx
+++ b/app/(private)/installment-vs-cash.tsx
@@ -1,1 +1,12 @@
-export { InstallmentVsCashScreen as default } from "@/features/tools/screens/installment-vs-cash-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { InstallmentVsCashScreen } from "@/features/tools/screens/installment-vs-cash-screen";
+
+export default function InstallmentVsCashRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <InstallmentVsCashScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/juros-compostos.tsx
+++ b/app/(private)/juros-compostos.tsx
@@ -1,1 +1,12 @@
-export { CompoundInterestScreen as default } from "@/features/tools/screens/compound-interest-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { CompoundInterestScreen } from "@/features/tools/screens/compound-interest-screen";
+
+export default function CompoundInterestRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <CompoundInterestScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/orcamento-50-30-20.tsx
+++ b/app/(private)/orcamento-50-30-20.tsx
@@ -1,1 +1,12 @@
-export { FiftyThirtyTwentyScreen as default } from "@/features/tools/screens/fifty-thirty-twenty-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { FiftyThirtyTwentyScreen } from "@/features/tools/screens/fifty-thirty-twenty-screen";
+
+export default function FiftyThirtyTwentyRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <FiftyThirtyTwentyScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/quitacao-dividas.tsx
+++ b/app/(private)/quitacao-dividas.tsx
@@ -1,1 +1,12 @@
-export { DebtPayoffScreen as default } from "@/features/tools/screens/debt-payoff-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { DebtPayoffScreen } from "@/features/tools/screens/debt-payoff-screen";
+
+export default function DebtPayoffRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <DebtPayoffScreen />
+    </PaywallGate>
+  );
+}

--- a/app/(private)/reserva-emergencia.tsx
+++ b/app/(private)/reserva-emergencia.tsx
@@ -1,1 +1,12 @@
-export { EmergencyFundScreen as default } from "@/features/tools/screens/emergency-fund-screen";
+import type { ReactElement } from "react";
+
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
+import { EmergencyFundScreen } from "@/features/tools/screens/emergency-fund-screen";
+
+export default function EmergencyFundRoute(): ReactElement {
+  return (
+    <PaywallGate featureKey="advanced_simulations">
+      <EmergencyFundScreen />
+    </PaywallGate>
+  );
+}

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -79,6 +79,20 @@ throw new Error("sentry-smoketest");
 `Sentry.init({ enabled: !__DEV__ })` mantém o SDK silencioso durante
 `expo start`. Só builds de preview/production reportam.
 
+## Checkout provider
+
+`EXPO_PUBLIC_CHECKOUT_PROVIDER` controla o provider de compra usado pela
+tela canonica de assinatura:
+
+| Valor | Uso |
+|---|---|
+| `hosted` | Default. Usa o checkout hospedado retornado por `/subscriptions/checkout`; recomendado para dev, preview e canais internos. |
+| `store` | Canal de App Store / Play Store. Nao abre checkout externo; enquanto StoreKit/Play Billing nao estiverem configurados, retorna erro seguro `STORE_CHECKOUT_UNCONFIGURED`. |
+
+Esse valor e publico e nao deve conter segredo. A decisao de entitlement e
+subscription continua no backend; o app apenas escolhe o provider de compra por
+canal e invalida `subscription`/`entitlements` depois do retorno.
+
 ## SSL pinning
 
 Pinning é aplicado em duas camadas:

--- a/features/entitlements/contracts.ts
+++ b/features/entitlements/contracts.ts
@@ -3,7 +3,8 @@ export type FeatureKey =
   | "advanced_simulations"
   | "export_pdf"
   | "shared_entries"
-  | "wallet_read";
+  | "wallet_read"
+  | "focus_mode";
 
 export interface EntitlementCheckQuery {
   readonly featureKey: FeatureKey;

--- a/features/focus/screens/focus-screen.test.tsx
+++ b/features/focus/screens/focus-screen.test.tsx
@@ -1,0 +1,93 @@
+import { render } from "@testing-library/react-native";
+import type { ReactNode } from "react";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { FocusScreen } from "@/features/focus/screens/focus-screen";
+import { useFocusScreenController } from "@/features/focus/hooks/use-focus-screen-controller";
+
+jest.mock("@/features/focus/hooks/use-focus-screen-controller", () => ({
+  useFocusScreenController: jest.fn(),
+}));
+
+jest.mock("@/features/entitlements/components/paywall-gate", () => {
+  const ReactInner = jest.requireActual("react");
+  const ReactNative = jest.requireActual("react-native");
+
+  return {
+    PaywallGate: ({
+      featureKey,
+      children,
+    }: {
+      readonly featureKey: string;
+      readonly children: ReactNode;
+    }) =>
+      ReactInner.createElement(
+        ReactNative.View,
+        { testID: `paywall-${featureKey}` },
+        children,
+      ),
+  };
+});
+
+const mockedUseController = jest.mocked(useFocusScreenController);
+
+const buildController = (
+  overrides: Partial<ReturnType<typeof useFocusScreenController>> = {},
+) =>
+  ({
+    overviewQuery: {
+      data: null,
+      isLoading: false,
+      isFetching: false,
+      isSuccess: true,
+      isError: false,
+      isPending: false,
+      refetch: jest.fn(),
+    },
+    trendsQuery: {
+      data: null,
+      isLoading: false,
+      isFetching: false,
+      isSuccess: true,
+      isError: false,
+      isPending: false,
+      refetch: jest.fn(),
+    },
+    metricIds: ["freeBalanceAfterFixed"],
+    selectedMetricId: "freeBalanceAfterFixed",
+    metric: {
+      id: "freeBalanceAfterFixed",
+      label: "Saldo livre",
+      caption: "Depois dos fixos",
+      value: 1250,
+      unit: "currency",
+      trend: null,
+      unavailable: false,
+    },
+    handleSelectMetric: jest.fn(),
+    ...overrides,
+  }) as never;
+
+const renderWithProviders = (
+  controller: ReturnType<typeof buildController>,
+): ReturnType<typeof render> => {
+  mockedUseController.mockReturnValue(controller);
+  return render(
+    <AppProviders>
+      <FocusScreen />
+    </AppProviders>,
+  );
+};
+
+describe("FocusScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("protege a tela com entitlement focus_mode", () => {
+    const { getByTestId, getByText } = renderWithProviders(buildController());
+
+    expect(getByTestId("paywall-focus_mode")).toBeTruthy();
+    expect(getByText("O numero que importa")).toBeTruthy();
+  });
+});

--- a/features/focus/screens/focus-screen.tsx
+++ b/features/focus/screens/focus-screen.tsx
@@ -7,6 +7,7 @@ import {
   useFocusScreenController,
   type FocusScreenController,
 } from "@/features/focus/hooks/use-focus-screen-controller";
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
@@ -40,10 +41,12 @@ const formatTrend = (metric: FocusMetric): string | null => {
 export function FocusScreen(): ReactElement {
   const controller = useFocusScreenController();
   return (
-    <AppScreen>
-      <SelectorCard controller={controller} />
-      <MetricCard metric={controller.metric} />
-    </AppScreen>
+    <PaywallGate featureKey="focus_mode">
+      <AppScreen>
+        <SelectorCard controller={controller} />
+        <MetricCard metric={controller.metric} />
+      </AppScreen>
+    </PaywallGate>
   );
 }
 

--- a/features/shared-entries/screens/shared-entries-screen.test.tsx
+++ b/features/shared-entries/screens/shared-entries-screen.test.tsx
@@ -1,0 +1,92 @@
+import { render } from "@testing-library/react-native";
+import type { ReactNode } from "react";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { SharedEntriesScreen } from "@/features/shared-entries/screens/shared-entries-screen";
+import { useSharedEntriesScreenController } from "@/features/shared-entries/hooks/use-shared-entries-screen-controller";
+
+jest.mock(
+  "@/features/shared-entries/hooks/use-shared-entries-screen-controller",
+  () => ({
+    useSharedEntriesScreenController: jest.fn(),
+  }),
+);
+
+jest.mock("@/features/entitlements/components/paywall-gate", () => {
+  const ReactInner = jest.requireActual("react");
+  const ReactNative = jest.requireActual("react-native");
+
+  return {
+    PaywallGate: ({
+      featureKey,
+      children,
+    }: {
+      readonly featureKey: string;
+      readonly children: ReactNode;
+    }) =>
+      ReactInner.createElement(
+        ReactNative.View,
+        { testID: `paywall-${featureKey}` },
+        children,
+      ),
+  };
+});
+
+const mockedUseController = jest.mocked(useSharedEntriesScreenController);
+
+const buildQuery = () =>
+  ({
+    data: null,
+    isLoading: false,
+    isFetching: false,
+    isSuccess: true,
+    isError: false,
+    isPending: false,
+    refetch: jest.fn(),
+  }) as never;
+
+const buildController = (
+  overrides: Partial<ReturnType<typeof useSharedEntriesScreenController>> = {},
+) =>
+  ({
+    invitationsQuery: buildQuery(),
+    byMeQuery: buildQuery(),
+    withMeQuery: buildQuery(),
+    pendingInvitations: [],
+    byMeEntries: [],
+    withMeEntries: [],
+    selectedTab: "invitations",
+    setSelectedTab: jest.fn(),
+    pendingInvitationIds: new Set<string>(),
+    pendingEntryIds: new Set<string>(),
+    lastError: null,
+    handleAccept: jest.fn().mockResolvedValue(undefined),
+    handleReject: jest.fn().mockResolvedValue(undefined),
+    handleRevoke: jest.fn().mockResolvedValue(undefined),
+    dismissError: jest.fn(),
+    ...overrides,
+  }) as never;
+
+const renderWithProviders = (
+  controller: ReturnType<typeof buildController>,
+): ReturnType<typeof render> => {
+  mockedUseController.mockReturnValue(controller);
+  return render(
+    <AppProviders>
+      <SharedEntriesScreen />
+    </AppProviders>,
+  );
+};
+
+describe("SharedEntriesScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("protege a tela com entitlement shared_entries", () => {
+    const { getByTestId, getByText } = renderWithProviders(buildController());
+
+    expect(getByTestId("paywall-shared_entries")).toBeTruthy();
+    expect(getByText("Convites")).toBeTruthy();
+  });
+});

--- a/features/shared-entries/screens/shared-entries-screen.tsx
+++ b/features/shared-entries/screens/shared-entries-screen.tsx
@@ -4,6 +4,7 @@ import { Paragraph, XStack, YStack } from "tamagui";
 
 import { SharedEntryCard } from "@/features/shared-entries/components/shared-entry-card";
 import { SharedInvitationCard } from "@/features/shared-entries/components/shared-invitation-card";
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
 import {
   useSharedEntriesScreenController,
   type SharedEntriesScreenController,
@@ -32,27 +33,29 @@ export function SharedEntriesScreen(): ReactElement {
   const controller = useSharedEntriesScreenController();
 
   return (
-    <AppScreen>
-      <TabSelector controller={controller} />
-      {controller.lastError ? (
-        <AppErrorNotice
-          error={controller.lastError}
-          fallbackTitle="Algo deu errado"
-          fallbackDescription="Tente novamente em instantes."
-          secondaryActionLabel="Fechar"
-          onSecondaryAction={controller.dismissError}
-        />
-      ) : null}
-      {controller.selectedTab === "invitations" ? (
-        <InvitationsTab controller={controller} />
-      ) : null}
-      {controller.selectedTab === "byMe" ? (
-        <ByMeTab controller={controller} />
-      ) : null}
-      {controller.selectedTab === "withMe" ? (
-        <WithMeTab controller={controller} />
-      ) : null}
-    </AppScreen>
+    <PaywallGate featureKey="shared_entries">
+      <AppScreen>
+        <TabSelector controller={controller} />
+        {controller.lastError ? (
+          <AppErrorNotice
+            error={controller.lastError}
+            fallbackTitle="Algo deu errado"
+            fallbackDescription="Tente novamente em instantes."
+            secondaryActionLabel="Fechar"
+            onSecondaryAction={controller.dismissError}
+          />
+        ) : null}
+        {controller.selectedTab === "invitations" ? (
+          <InvitationsTab controller={controller} />
+        ) : null}
+        {controller.selectedTab === "byMe" ? (
+          <ByMeTab controller={controller} />
+        ) : null}
+        {controller.selectedTab === "withMe" ? (
+          <WithMeTab controller={controller} />
+        ) : null}
+      </AppScreen>
+    </PaywallGate>
   );
 }
 

--- a/features/subscription/hooks/use-checkout-flow.test.tsx
+++ b/features/subscription/hooks/use-checkout-flow.test.tsx
@@ -6,6 +6,7 @@ import { ApiError } from "@/core/http/api-error";
 import type { CheckoutSession } from "@/features/subscription/contracts";
 import { useCheckoutFlow } from "@/features/subscription/hooks/use-checkout-flow";
 import { useCreateCheckoutMutation } from "@/features/subscription/hooks/use-subscription-mutations";
+import type { CheckoutProvider } from "@/features/subscription/services/checkout-provider-service";
 
 jest.mock("@/features/subscription/hooks/use-subscription-mutations", () => ({
   useCreateCheckoutMutation: jest.fn(),
@@ -32,26 +33,33 @@ const wrapper = (client: QueryClient) => {
   return Provider;
 };
 
-describe("useCheckoutFlow", () => {
-  let mutateAsync: jest.Mock;
-  let reset: jest.Mock;
-  let openCheckout: jest.Mock;
-  let client: QueryClient;
+type CheckoutFlowTestState = {
+  readonly mutateAsync: jest.Mock;
+  readonly reset: jest.Mock;
+  readonly openCheckout: jest.Mock;
+  readonly client: QueryClient;
+};
 
-  beforeEach(() => {
-    mutateAsync = jest.fn().mockResolvedValue(buildSession());
-    reset = jest.fn();
-    openCheckout = jest.fn().mockResolvedValue({ type: "success", returnUrl: "x://" });
-    mockedUseCreate.mockReturnValue({
+const setupCheckoutFlowTest = (): CheckoutFlowTestState => {
+  jest.clearAllMocks();
+  const mutateAsync = jest.fn().mockResolvedValue(buildSession());
+  const reset = jest.fn();
+  const openCheckout = jest
+    .fn()
+    .mockResolvedValue({ type: "success", returnUrl: "x://" });
+  mockedUseCreate.mockReturnValue({
       mutateAsync,
       reset,
       isPending: false,
       error: null,
     } as never);
-    client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  });
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return { mutateAsync, reset, openCheckout, client };
+};
 
+describe("useCheckoutFlow", () => {
   it("invalida subscription e entitlements em sucesso e retorna completed", async () => {
+    const { client, mutateAsync, openCheckout } = setupCheckoutFlowTest();
     const invalidateSpy = jest.spyOn(client, "invalidateQueries");
     const { result } = renderHook(
       () =>
@@ -79,6 +87,7 @@ describe("useCheckoutFlow", () => {
   });
 
   it("nao invalida estado quando o usuario cancelou", async () => {
+    const { client, openCheckout } = setupCheckoutFlowTest();
     openCheckout.mockResolvedValueOnce({ type: "cancel", returnUrl: "x://" });
     const invalidateSpy = jest.spyOn(client, "invalidateQueries");
 
@@ -101,6 +110,7 @@ describe("useCheckoutFlow", () => {
   });
 
   it("captura erro quando createCheckout falha e nao abre browser", async () => {
+    const { client, mutateAsync, openCheckout } = setupCheckoutFlowTest();
     mutateAsync.mockRejectedValueOnce(
       new ApiError({ message: "checkout offline", status: 503 }),
     );
@@ -124,7 +134,46 @@ describe("useCheckoutFlow", () => {
     expect(result.current.lastError).toBeInstanceOf(ApiError);
   });
 
+  it("usa provider store sem criar checkout hospedado nem abrir browser externo", async () => {
+    const { client, mutateAsync, openCheckout } = setupCheckoutFlowTest();
+    const storeError = new ApiError({
+      message: "Compras pela loja ainda nao configuradas.",
+      status: 503,
+      code: "STORE_CHECKOUT_UNCONFIGURED",
+    });
+    const storeProvider: CheckoutProvider = {
+      kind: "store",
+      requiresCheckoutSession: false,
+      openCheckout: jest.fn().mockRejectedValue(storeError),
+      dismissCheckout: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const { result } = renderHook(
+      () =>
+        useCheckoutFlow({
+          checkoutProvider: storeProvider,
+        }),
+      { wrapper: wrapper(client) },
+    );
+
+    const outcomeRef: { current: { outcome: string } | null } = { current: null };
+    await act(async () => {
+      outcomeRef.current = await result.current.start({ planSlug: "premium-monthly" });
+    });
+    const outcome = outcomeRef.current;
+
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(openCheckout).not.toHaveBeenCalled();
+    expect(storeProvider.openCheckout).toHaveBeenCalledWith({
+      command: { planSlug: "premium-monthly" },
+      session: null,
+    });
+    expect(outcome?.outcome).toBe("unavailable");
+    expect(result.current.lastError).toBe(storeError);
+  });
+
   it("registra erro quando o session nao tem checkoutUrl", async () => {
+    const { client, mutateAsync, openCheckout } = setupCheckoutFlowTest();
     mutateAsync.mockResolvedValueOnce(buildSession({ checkoutUrl: null }));
 
     const { result } = renderHook(
@@ -147,6 +196,7 @@ describe("useCheckoutFlow", () => {
   });
 
   it("resetError limpa lastError e a mutation", async () => {
+    const { client, mutateAsync, openCheckout, reset } = setupCheckoutFlowTest();
     mutateAsync.mockRejectedValueOnce(new ApiError({ message: "x", status: 500 }));
     const { result } = renderHook(
       () =>

--- a/features/subscription/hooks/use-checkout-flow.ts
+++ b/features/subscription/hooks/use-checkout-flow.ts
@@ -9,9 +9,16 @@ import type {
 } from "@/features/subscription/contracts";
 import { useCreateCheckoutMutation } from "@/features/subscription/hooks/use-subscription-mutations";
 import {
-  hostedCheckoutService,
+  type hostedCheckoutService,
   type HostedCheckoutResultType,
 } from "@/features/subscription/services/hosted-checkout-service";
+import {
+  checkoutProviderResolver,
+  createHostedCheckoutProvider,
+  type CheckoutProvider,
+  type CheckoutProviderInput,
+  type CheckoutProviderResolver,
+} from "@/features/subscription/services/checkout-provider-service";
 
 export type CheckoutOutcome =
   | "completed"
@@ -53,12 +60,14 @@ const RESULT_OUTCOME: Record<HostedCheckoutResultType, CheckoutOutcome> = {
 export function useCheckoutFlow(
   dependencies: {
     readonly checkoutService?: typeof hostedCheckoutService;
+    readonly checkoutProvider?: CheckoutProvider;
+    readonly checkoutProviderResolver?: CheckoutProviderResolver;
   } = {},
 ): CheckoutFlowController {
   const queryClient = useQueryClient();
   const createCheckout = useCreateCheckoutMutation();
   const [lastError, setLastError] = useState<unknown | null>(null);
-  const checkoutService = dependencies.checkoutService ?? hostedCheckoutService;
+  const checkoutProvider = resolveCheckoutProvider(dependencies);
 
   const invalidateBillingState = (): void => {
     void queryClient.invalidateQueries({ queryKey: queryKeys.subscription.root });
@@ -70,18 +79,25 @@ export function useCheckoutFlow(
   ): Promise<CheckoutFlowResult> => {
     setLastError(null);
 
-    const session = await safeCreateCheckout(command, createCheckout, setLastError);
-    if (!session) {
-      return { outcome: "unavailable", session: null };
-    }
-    if (!session.checkoutUrl) {
-      setLastError(
-        new ApiError({ message: "Checkout indisponivel no momento.", status: 503 }),
-      );
-      return { outcome: "unavailable", session };
+    let session: CheckoutSession | null = null;
+    if (checkoutProvider.requiresCheckoutSession) {
+      session = await safeCreateCheckout(command, createCheckout, setLastError);
+      if (!session) {
+        return { outcome: "unavailable", session: null };
+      }
+      if (!session.checkoutUrl) {
+        setLastError(
+          new ApiError({ message: "Checkout indisponivel no momento.", status: 503 }),
+        );
+        return { outcome: "unavailable", session };
+      }
     }
 
-    const outcome = await safeOpenCheckout(session, checkoutService, setLastError);
+    const outcome = await safeOpenCheckout(
+      { command, session },
+      checkoutProvider,
+      setLastError,
+    );
     if (!outcome) {
       return { outcome: "unavailable", session };
     }
@@ -104,6 +120,25 @@ export function useCheckoutFlow(
   };
 }
 
+const resolveCheckoutProvider = (
+  dependencies: {
+    readonly checkoutService?: typeof hostedCheckoutService;
+    readonly checkoutProvider?: CheckoutProvider;
+    readonly checkoutProviderResolver?: CheckoutProviderResolver;
+  },
+): CheckoutProvider => {
+  if (dependencies.checkoutProvider) {
+    return dependencies.checkoutProvider;
+  }
+
+  if (dependencies.checkoutService) {
+    return createHostedCheckoutProvider(dependencies.checkoutService);
+  }
+
+  return (dependencies.checkoutProviderResolver ?? checkoutProviderResolver)
+    .resolveProvider();
+};
+
 const safeCreateCheckout = async (
   command: CreateCheckoutCommand,
   createCheckout: ReturnType<typeof useCreateCheckoutMutation>,
@@ -118,12 +153,12 @@ const safeCreateCheckout = async (
 };
 
 const safeOpenCheckout = async (
-  session: CheckoutSession,
-  checkoutService: typeof hostedCheckoutService,
+  input: CheckoutProviderInput,
+  checkoutProvider: CheckoutProvider,
   onError: (error: unknown) => void,
 ): Promise<CheckoutOutcome | null> => {
   try {
-    const result = await checkoutService.openCheckout(session);
+    const result = await checkoutProvider.openCheckout(input);
     return RESULT_OUTCOME[result.type] ?? "dismissed";
   } catch (error) {
     onError(error);

--- a/features/subscription/screens/subscription-screen.tsx
+++ b/features/subscription/screens/subscription-screen.tsx
@@ -27,9 +27,9 @@ const SUCCESS_NOTICE: Record<string, { title: string; description: string }> = {
       "Recebemos a confirmacao do pagamento. Pode levar alguns segundos para a UI atualizar.",
   },
   opened: {
-    title: "Checkout aberto no navegador",
+    title: "Checkout aberto",
     description:
-      "Conclua o pagamento na janela do navegador e volte ao app para ver o estado atualizado.",
+      "Conclua o pagamento e volte ao app para ver o estado atualizado.",
   },
 };
 
@@ -131,7 +131,7 @@ function SubscriptionDetails({
         }}
         testID="manage-subscription-button"
       >
-        Gerenciar pelo navegador
+        Gerenciar assinatura
       </AppButton>
     </YStack>
   );
@@ -149,8 +149,8 @@ function TrialCallout({ controller }: ControllerProps): ReactElement | null {
     >
       <YStack gap="$3">
         <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
-          Sem cobranca no trial. Cancele a qualquer momento pelo Gerenciar pelo
-          navegador.
+          Sem cobranca no trial. Cancele a qualquer momento em Gerenciar
+          assinatura.
         </Paragraph>
         {controller.trialError ? (
           <AppErrorNotice
@@ -263,7 +263,7 @@ function PlansCard({ controller }: ControllerProps): ReactElement {
             ))}
             {controller.isStartingCheckout ? (
               <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
-                Abrindo checkout no navegador...
+                Abrindo checkout...
               </Paragraph>
             ) : null}
           </YStack>
@@ -272,4 +272,3 @@ function PlansCard({ controller }: ControllerProps): ReactElement {
     </AppSurfaceCard>
   );
 }
-

--- a/features/subscription/services/checkout-provider-service.test.ts
+++ b/features/subscription/services/checkout-provider-service.test.ts
@@ -1,0 +1,91 @@
+import { type ApiError } from "@/core/http/api-error";
+import type { CheckoutSession } from "@/features/subscription/contracts";
+import {
+  createCheckoutProviderResolver,
+  createHostedCheckoutProvider,
+  createStoreCheckoutProvider,
+  normalizeCheckoutProviderChannel,
+  type CheckoutProvider,
+} from "@/features/subscription/services/checkout-provider-service";
+
+const buildSession = (
+  overrides: Partial<CheckoutSession> = {},
+): CheckoutSession => ({
+  planSlug: "premium-monthly",
+  planCode: "premium",
+  billingCycle: "monthly",
+  checkoutUrl: "https://checkout.example.com/session",
+  provider: "asaas",
+  ...overrides,
+});
+
+const buildProvider = (
+  overrides: Partial<CheckoutProvider> = {},
+): CheckoutProvider => ({
+  kind: "hosted",
+  requiresCheckoutSession: true,
+  openCheckout: jest.fn().mockResolvedValue({ type: "opened", returnUrl: "x://" }),
+  dismissCheckout: jest.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+describe("checkout provider service", () => {
+  it("normaliza o canal de checkout para hosted por padrão", () => {
+    expect(normalizeCheckoutProviderChannel(undefined)).toBe("hosted");
+    expect(normalizeCheckoutProviderChannel("")).toBe("hosted");
+    expect(normalizeCheckoutProviderChannel("hosted")).toBe("hosted");
+    expect(normalizeCheckoutProviderChannel("store")).toBe("store");
+    expect(normalizeCheckoutProviderChannel("app-store")).toBe("store");
+    expect(normalizeCheckoutProviderChannel("play-store")).toBe("store");
+  });
+
+  it("resolve provider hosted e delega para o serviço hospedado", async () => {
+    const openCheckout = jest
+      .fn()
+      .mockResolvedValue({ type: "success", returnUrl: "auraxisapp://assinatura" });
+    const hosted = createHostedCheckoutProvider({
+      openCheckout,
+      dismissCheckout: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const result = await hosted.openCheckout({
+      command: { planSlug: "premium-monthly" },
+      session: buildSession(),
+    });
+
+    expect(hosted.kind).toBe("hosted");
+    expect(hosted.requiresCheckoutSession).toBe(true);
+    expect(openCheckout).toHaveBeenCalledWith(buildSession());
+    expect(result.type).toBe("success");
+  });
+
+  it("resolve provider store sem depender de checkout URL hospedada", () => {
+    const hostedProvider = buildProvider({ kind: "hosted" });
+    const storeProvider = buildProvider({
+      kind: "store",
+      requiresCheckoutSession: false,
+    });
+    const resolver = createCheckoutProviderResolver({
+      getChannel: () => "store",
+      hostedProvider,
+      storeProvider,
+    });
+
+    expect(resolver.resolveProvider()).toBe(storeProvider);
+  });
+
+  it("provider store falha de forma segura enquanto StoreKit/Play Billing nao estao configurados", async () => {
+    const store = createStoreCheckoutProvider();
+
+    await expect(
+      store.openCheckout({
+        command: { planSlug: "premium-monthly" },
+        session: null,
+      }),
+    ).rejects.toMatchObject({
+      name: "ApiError",
+      code: "STORE_CHECKOUT_UNCONFIGURED",
+      status: 503,
+    } satisfies Partial<ApiError>);
+  });
+});

--- a/features/subscription/services/checkout-provider-service.ts
+++ b/features/subscription/services/checkout-provider-service.ts
@@ -1,0 +1,94 @@
+import { ApiError } from "@/core/http/api-error";
+import { appRuntimeConfig } from "@/shared/config/runtime";
+import type {
+  CheckoutSession,
+  CreateCheckoutCommand,
+} from "@/features/subscription/contracts";
+import {
+  hostedCheckoutService,
+  type HostedCheckoutResult,
+} from "@/features/subscription/services/hosted-checkout-service";
+import {
+  normalizeCheckoutProviderChannel,
+  type CheckoutProviderChannel,
+} from "@/shared/config/checkout-provider-channel";
+
+export type CheckoutProviderKind = CheckoutProviderChannel;
+
+export interface CheckoutProviderInput {
+  readonly command: CreateCheckoutCommand;
+  readonly session: CheckoutSession | null;
+}
+
+export interface CheckoutProvider {
+  readonly kind: CheckoutProviderKind;
+  readonly requiresCheckoutSession: boolean;
+  readonly openCheckout: (
+    input: CheckoutProviderInput,
+  ) => Promise<HostedCheckoutResult>;
+  readonly dismissCheckout: () => Promise<void>;
+}
+
+export interface CheckoutProviderResolver {
+  readonly resolveProvider: () => CheckoutProvider;
+}
+
+interface HostedCheckoutService {
+  readonly openCheckout: (
+    checkoutSession: CheckoutSession,
+  ) => Promise<HostedCheckoutResult>;
+  readonly dismissCheckout: () => Promise<void>;
+}
+
+interface CheckoutProviderResolverDependencies {
+  readonly getChannel: () => CheckoutProviderChannel;
+  readonly hostedProvider: CheckoutProvider;
+  readonly storeProvider: CheckoutProvider;
+}
+
+export { normalizeCheckoutProviderChannel };
+
+export const createHostedCheckoutProvider = (
+  service: HostedCheckoutService = hostedCheckoutService,
+): CheckoutProvider => ({
+  kind: "hosted",
+  requiresCheckoutSession: true,
+  openCheckout: async ({ session }): Promise<HostedCheckoutResult> => {
+    if (!session) {
+      throw new Error("Hosted checkout provider requires a checkout session.");
+    }
+
+    return service.openCheckout(session);
+  },
+  dismissCheckout: service.dismissCheckout,
+});
+
+export const createStoreCheckoutProvider = (): CheckoutProvider => ({
+  kind: "store",
+  requiresCheckoutSession: false,
+  openCheckout: async (): Promise<HostedCheckoutResult> => {
+    throw new ApiError({
+      message:
+        "Compras pela loja ainda nao estao configuradas para este build.",
+      status: 503,
+      code: "STORE_CHECKOUT_UNCONFIGURED",
+    });
+  },
+  dismissCheckout: async (): Promise<void> => undefined,
+});
+
+export const createCheckoutProviderResolver = ({
+  getChannel,
+  hostedProvider,
+  storeProvider,
+}: CheckoutProviderResolverDependencies): CheckoutProviderResolver => ({
+  resolveProvider: (): CheckoutProvider => {
+    return getChannel() === "store" ? storeProvider : hostedProvider;
+  },
+});
+
+export const checkoutProviderResolver = createCheckoutProviderResolver({
+  getChannel: () => appRuntimeConfig.checkoutProviderChannel,
+  hostedProvider: createHostedCheckoutProvider(),
+  storeProvider: createStoreCheckoutProvider(),
+});

--- a/features/tools/screens/simulations-history-screen.test.tsx
+++ b/features/tools/screens/simulations-history-screen.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render } from "@testing-library/react-native";
+import type { ReactNode } from "react";
 
 import { AppProviders } from "@/core/providers/app-providers";
 import type { SimulationRecord } from "@/features/tools/contracts";
@@ -11,6 +12,26 @@ jest.mock(
     useSimulationsHistoryScreenController: jest.fn(),
   }),
 );
+
+jest.mock("@/features/entitlements/components/paywall-gate", () => {
+  const ReactInner = jest.requireActual("react");
+  const ReactNative = jest.requireActual("react-native");
+
+  return {
+    PaywallGate: ({
+      featureKey,
+      children,
+    }: {
+      readonly featureKey: string;
+      readonly children: ReactNode;
+    }) =>
+      ReactInner.createElement(
+        ReactNative.View,
+        { testID: `paywall-${featureKey}` },
+        children,
+      ),
+  };
+});
 
 const mockedUseController = jest.mocked(useSimulationsHistoryScreenController);
 
@@ -68,6 +89,11 @@ describe("SimulationsHistoryScreen", () => {
     const { getByText, getByTestId } = renderWithProviders(buildController());
     expect(getByText("Voltar")).toBeTruthy();
     expect(getByTestId("simulations-refresh")).toBeTruthy();
+  });
+
+  it("protege o historico com entitlement advanced_simulations", () => {
+    const { getByTestId } = renderWithProviders(buildController());
+    expect(getByTestId("paywall-advanced_simulations")).toBeTruthy();
   });
 
   it("encaminha refresh para o controller", () => {

--- a/features/tools/screens/simulations-history-screen.tsx
+++ b/features/tools/screens/simulations-history-screen.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 import { Paragraph, XStack, YStack } from "tamagui";
 
 import type { SimulationRecord } from "@/features/tools/contracts";
+import { PaywallGate } from "@/features/entitlements/components/paywall-gate";
 import {
   useSimulationsHistoryScreenController,
   type SimulationsHistoryScreenController,
@@ -44,10 +45,12 @@ const formatDate = (iso: string): string => {
 export function SimulationsHistoryScreen(): ReactElement {
   const controller = useSimulationsHistoryScreenController();
   return (
-    <AppScreen>
-      <HeaderCard controller={controller} />
-      <HistoryBody controller={controller} />
-    </AppScreen>
+    <PaywallGate featureKey="advanced_simulations">
+      <AppScreen>
+        <HeaderCard controller={controller} />
+        <HistoryBody controller={controller} />
+      </AppScreen>
+    </PaywallGate>
   );
 }
 

--- a/features/tools/services/tools-catalog.test.ts
+++ b/features/tools/services/tools-catalog.test.ts
@@ -67,4 +67,24 @@ describe("tools catalog", () => {
     expect(ids.has("salary-simulator")).toBe(true);
     expect(ids.has("goal-simulator")).toBe(true);
   });
+
+  it("marca como premium as ferramentas avançadas equivalentes ao web", () => {
+    const catalog = getCanonicalToolsCatalog();
+    const premiumIds = new Set([
+      "installment-vs-cash",
+      "compound-interest",
+      "emergency-fund",
+      "fifty-thirty-twenty",
+      "debt-payoff",
+      "split-bill",
+      "cost-of-lifestyle",
+      "desconto-markup",
+    ]);
+
+    for (const tool of catalog.tools) {
+      if (premiumIds.has(tool.id)) {
+        expect(tool.requiresPremium).toBe(true);
+      }
+    }
+  });
 });

--- a/features/tools/services/tools-catalog.ts
+++ b/features/tools/services/tools-catalog.ts
@@ -47,9 +47,17 @@ const FUNCTIONAL_ROUTES: ReadonlyMap<string, string> = new Map([
   ["desconto-markup", "/desconto-markup"],
 ]);
 
-// No tool is premium-gated yet. Premium gating returns when the first
-// paywalled tool ships — the contract's optional `requiresPremium`
-// field stays open for it.
+const PREMIUM_TOOL_IDS = new Set([
+  "installment-vs-cash",
+  "compound-interest",
+  "emergency-fund",
+  "fifty-thirty-twenty",
+  "debt-payoff",
+  "split-bill",
+  "cost-of-lifestyle",
+  "desconto-markup",
+]);
+
 const buildTool = (
   category: ToolCategory,
   seed: ToolSeed,
@@ -63,6 +71,7 @@ const buildTool = (
     description,
     category,
     enabled: route !== undefined,
+    ...(PREMIUM_TOOL_IDS.has(id) && { requiresPremium: true }),
     ...(route !== undefined && { route }),
   };
 };

--- a/shared/config/checkout-provider-channel.ts
+++ b/shared/config/checkout-provider-channel.ts
@@ -1,0 +1,10 @@
+export type CheckoutProviderChannel = "hosted" | "store";
+
+const STORE_ALIASES = new Set(["store", "app-store", "play-store", "iap"]);
+
+export const normalizeCheckoutProviderChannel = (
+  rawValue: string | null | undefined,
+): CheckoutProviderChannel => {
+  const normalised = rawValue?.trim().toLowerCase() ?? "";
+  return STORE_ALIASES.has(normalised) ? "store" : "hosted";
+};

--- a/shared/config/runtime.ts
+++ b/shared/config/runtime.ts
@@ -1,5 +1,10 @@
 import Constants from "expo-constants";
 
+import {
+  normalizeCheckoutProviderChannel,
+  type CheckoutProviderChannel,
+} from "@/shared/config/checkout-provider-channel";
+
 export type ApiMode = "live" | "mock";
 
 export interface AppRuntimeConfig {
@@ -12,6 +17,7 @@ export interface AppRuntimeConfig {
   readonly sessionExpiryLeewayMs: number;
   readonly appScheme: string;
   readonly checkoutReturnPath: string;
+  readonly checkoutProviderChannel: CheckoutProviderChannel;
   readonly observabilityExportEnabled: boolean;
   readonly observabilityExportPublicKey: string | null;
   readonly mockLatencyMs: number;
@@ -42,6 +48,7 @@ type RuntimeEnvKey =
   | "EXPO_PUBLIC_SESSION_EXPIRY_LEEWAY_MS"
   | "EXPO_PUBLIC_APP_SCHEME"
   | "EXPO_PUBLIC_CHECKOUT_RETURN_PATH"
+  | "EXPO_PUBLIC_CHECKOUT_PROVIDER"
   | "EXPO_PUBLIC_OBSERVABILITY_EXPORT_ENABLED"
   | "EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY"
   | "EXPO_PUBLIC_API_MOCK_LATENCY_MS"
@@ -59,6 +66,7 @@ const RUNTIME_ENV_READERS: Readonly<Record<RuntimeEnvKey, () => string | undefin
   EXPO_PUBLIC_SESSION_EXPIRY_LEEWAY_MS: () => process.env.EXPO_PUBLIC_SESSION_EXPIRY_LEEWAY_MS,
   EXPO_PUBLIC_APP_SCHEME: () => process.env.EXPO_PUBLIC_APP_SCHEME,
   EXPO_PUBLIC_CHECKOUT_RETURN_PATH: () => process.env.EXPO_PUBLIC_CHECKOUT_RETURN_PATH,
+  EXPO_PUBLIC_CHECKOUT_PROVIDER: () => process.env.EXPO_PUBLIC_CHECKOUT_PROVIDER,
   EXPO_PUBLIC_OBSERVABILITY_EXPORT_ENABLED: () =>
     process.env.EXPO_PUBLIC_OBSERVABILITY_EXPORT_ENABLED,
   EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY: () => process.env.EXPO_PUBLIC_OBSERVABILITY_EXPORT_KEY,
@@ -189,6 +197,9 @@ export const appRuntimeConfig: AppRuntimeConfig = Object.freeze({
     "EXPO_PUBLIC_CHECKOUT_RETURN_PATH",
     "checkoutReturnPath",
     DEFAULT_CHECKOUT_RETURN_PATH,
+  ),
+  checkoutProviderChannel: normalizeCheckoutProviderChannel(
+    readString("EXPO_PUBLIC_CHECKOUT_PROVIDER", "checkoutProvider", "hosted"),
   ),
   observabilityExportEnabled: readBoolean(
     "EXPO_PUBLIC_OBSERVABILITY_EXPORT_ENABLED",

--- a/shared/mocks/api/router.ts
+++ b/shared/mocks/api/router.ts
@@ -444,6 +444,7 @@ const handleEntitlementRoutes: MockRouteHandler = (context) => {
     "export_pdf",
     "shared_entries",
     "wallet_read",
+    "focus_mode",
   ]);
 
   return ok({

--- a/shared/types/generated/graphql.ts
+++ b/shared/types/generated/graphql.ts
@@ -361,6 +361,37 @@ export type DeleteWalletEntryMutation = {
   ok: Scalars['Boolean']['output'];
 };
 
+export type FiscalDocumentListType = {
+  __typename?: 'FiscalDocumentListType';
+  fiscalDocuments: Array<FiscalDocumentType>;
+  total: Scalars['Int']['output'];
+};
+
+export type FiscalDocumentPayload = {
+  __typename?: 'FiscalDocumentPayload';
+  data?: Maybe<FiscalDocumentType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+export type FiscalDocumentType = {
+  __typename?: 'FiscalDocumentType';
+  counterparty: Scalars['String']['output'];
+  createdAt: Scalars['String']['output'];
+  currency: Scalars['String']['output'];
+  description?: Maybe<Scalars['String']['output']>;
+  externalId: Scalars['String']['output'];
+  grossAmount: Scalars['DecimalScalar']['output'];
+  id: Scalars['ID']['output'];
+  issuedAt: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
 export type GoalListPayloadType = {
   __typename?: 'GoalListPayloadType';
   items: Array<Maybe<GoalTypeObject>>;
@@ -614,6 +645,8 @@ export type Mutation = {
   addTicker?: Maybe<AddTickerPayload>;
   /** @deprecated ADR-0002: use POST /wallet */
   addWalletEntry?: Maybe<AddWalletEntryMutation>;
+  /** @deprecated ADR-0002: use DELETE /fiscal/receivables/{id} */
+  cancelReceivable?: Maybe<ReceivablePayload>;
   /** @deprecated ADR-0004: use POST /subscription/cancel */
   cancelSubscription?: Maybe<CancelSubscriptionMutation>;
   /**
@@ -632,10 +665,14 @@ export type Mutation = {
   createBudget?: Maybe<CreateBudgetMutation>;
   /** @deprecated ADR-0004: use POST /subscription/checkout */
   createCheckoutSession?: Maybe<CreateCheckoutSessionMutation>;
+  /** @deprecated ADR-0002: use POST /fiscal/fiscal-documents */
+  createFiscalDocument?: Maybe<FiscalDocumentPayload>;
   /** @deprecated ADR-0002: use POST /goals */
   createGoal?: Maybe<CreateGoalMutation>;
   createGoalFromInstallmentVsCashSimulation?: Maybe<CreateGoalFromInstallmentVsCashSimulationMutation>;
   createPlannedExpenseFromInstallmentVsCashSimulation?: Maybe<CreatePlannedExpenseFromInstallmentVsCashSimulationMutation>;
+  /** @deprecated ADR-0002: use POST /fiscal/receivables */
+  createReceivable?: Maybe<ReceivablePayload>;
   createTag?: Maybe<TagPayload>;
   /** @deprecated ADR-0002: use POST /transactions */
   createTransaction?: Maybe<CreateTransactionMutation>;
@@ -655,6 +692,8 @@ export type Mutation = {
   forgotPassword?: Maybe<AuthPayloadType>;
   login?: Maybe<AuthPayloadType>;
   logout?: Maybe<LogoutMutation>;
+  /** @deprecated ADR-0002: use PATCH /fiscal/receivables/{id}/receive */
+  markReceivableReceived?: Maybe<ReceivablePayload>;
   /**
    * Parse a bank statement text and return a deduplication preview.
    *
@@ -719,6 +758,11 @@ export type MutationAddWalletEntryArgs = {
 };
 
 
+export type MutationCancelReceivableArgs = {
+  entryId: Scalars['UUID']['input'];
+};
+
+
 export type MutationConfirmBankImportArgs = {
   bankName: Scalars['String']['input'];
   mode: Scalars['String']['input'];
@@ -754,6 +798,15 @@ export type MutationCreateBudgetArgs = {
 export type MutationCreateCheckoutSessionArgs = {
   billingCycle?: InputMaybe<BillingCycle>;
   planSlug: Scalars['String']['input'];
+};
+
+
+export type MutationCreateFiscalDocumentArgs = {
+  amount: Scalars['String']['input'];
+  counterpartName?: InputMaybe<Scalars['String']['input']>;
+  externalId?: InputMaybe<Scalars['String']['input']>;
+  issuedAt: Scalars['String']['input'];
+  type: Scalars['String']['input'];
 };
 
 
@@ -795,6 +848,14 @@ export type MutationCreatePlannedExpenseFromInstallmentVsCashSimulationArgs = {
   tagId?: InputMaybe<Scalars['UUID']['input']>;
   title: Scalars['String']['input'];
   upfrontDueDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type MutationCreateReceivableArgs = {
+  amount: Scalars['String']['input'];
+  category?: InputMaybe<Scalars['String']['input']>;
+  description: Scalars['String']['input'];
+  expectedDate: Scalars['String']['input'];
 };
 
 
@@ -875,6 +936,13 @@ export type MutationForgotPasswordArgs = {
 export type MutationLoginArgs = {
   email: Scalars['String']['input'];
   password: Scalars['String']['input'];
+};
+
+
+export type MutationMarkReceivableReceivedArgs = {
+  entryId: Scalars['UUID']['input'];
+  receivedAmount?: InputMaybe<Scalars['String']['input']>;
+  receivedDate: Scalars['String']['input'];
 };
 
 
@@ -1146,6 +1214,7 @@ export type Query = {
   budgetSummary?: Maybe<BudgetSummaryType>;
   budgets?: Maybe<BudgetListPayloadType>;
   dashboardOverview?: Maybe<TransactionDashboardPayloadType>;
+  fiscalDocuments?: Maybe<FiscalDocumentListType>;
   goal?: Maybe<GoalTypeObject>;
   goalPlan?: Maybe<GoalPlanType>;
   goals?: Maybe<GoalListPayloadType>;
@@ -1160,6 +1229,8 @@ export type Query = {
   notificationPreferences?: Maybe<NotificationPreferencesType>;
   portfolioValuation?: Maybe<PortfolioValuationPayloadType>;
   portfolioValuationHistory?: Maybe<PortfolioHistoryPayloadType>;
+  receivables?: Maybe<ReceivableListType>;
+  receivablesSummary?: Maybe<ReceivableSummaryType>;
   simulation?: Maybe<SimulationType>;
   simulations: SimulationListPayloadType;
   tag?: Maybe<TagType>;
@@ -1195,6 +1266,11 @@ export type QueryBudgetArgs = {
 
 export type QueryDashboardOverviewArgs = {
   month: Scalars['String']['input'];
+};
+
+
+export type QueryFiscalDocumentsArgs = {
+  type?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1261,6 +1337,11 @@ export type QueryInvestmentValuationArgs = {
 export type QueryPortfolioValuationHistoryArgs = {
   finalDate?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+
+export type QueryReceivablesArgs = {
+  status?: InputMaybe<Scalars['String']['input']>;
 };
 
 
@@ -1346,6 +1427,52 @@ export type QueryWeeklySummaryArgs = {
   endDate?: InputMaybe<Scalars['String']['input']>;
   period?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
+};
+
+/**
+ * IMPORTANT: expected_net_amount is advisory-only. Clients MUST display
+ * the ``disclaimer`` field alongside any monetary value derived from it.
+ */
+export type ReceivableEntryType = {
+  __typename?: 'ReceivableEntryType';
+  createdAt: Scalars['String']['output'];
+  disclaimer: Scalars['String']['output'];
+  expectedNetAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  fiscalDocumentId: Scalars['ID']['output'];
+  id: Scalars['ID']['output'];
+  outstandingAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  receivedAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  receivedAt?: Maybe<Scalars['String']['output']>;
+  reconciliationStatus: Scalars['String']['output'];
+};
+
+export type ReceivableListType = {
+  __typename?: 'ReceivableListType';
+  receivables: Array<ReceivableEntryType>;
+  total: Scalars['Int']['output'];
+};
+
+export type ReceivablePayload = {
+  __typename?: 'ReceivablePayload';
+  data?: Maybe<ReceivableEntryType>;
+  /** Field-level validation errors (empty on success). */
+  errors: Array<ValidationError>;
+  /** Human-readable status message. */
+  message: Scalars['String']['output'];
+  /** True when the mutation completed without errors. */
+  ok: Scalars['Boolean']['output'];
+};
+
+/**
+ * IMPORTANT: all monetary values are advisory-only estimates.
+ * Always display the ``disclaimer`` field.
+ */
+export type ReceivableSummaryType = {
+  __typename?: 'ReceivableSummaryType';
+  disclaimer: Scalars['String']['output'];
+  expectedTotal: Scalars['String']['output'];
+  pendingTotal: Scalars['String']['output'];
+  receivedTotal: Scalars['String']['output'];
 };
 
 /** Revoke all active sessions — global logout (#1028). */


### PR DESCRIPTION
## Summary
- Adds channel-aware checkout provider selection for `hosted` and `store` app builds.
- Keeps hosted checkout available for dev/preview/internal while store builds avoid external checkout and fail safely until StoreKit/Play Billing are configured.
- Aligns app premium gates with web entitlements for focus mode, shared entries, and advanced simulations, including protected advanced tool routes.
- Documents the runtime checkout provider setting and commits generated GraphQL types required by `codegen:check`.

## Validation
- `npm run quality-check`
- pre-commit lint-staged checks
- pre-push policy/contracts/typecheck/test coverage

Closes #396