### PR TITLE
[codex] Add weekly insight dashboard card

### DIFF
--- a/__tests__/app/dashboard-screen.test.tsx
+++ b/__tests__/app/dashboard-screen.test.tsx
@@ -2,8 +2,10 @@ import { render } from "@testing-library/react-native";
 import type { UseQueryResult } from "@tanstack/react-query";
 
 import DashboardScreen from "@/app/(private)/dashboard";
+import type { ApiError } from "@/core/http/api-error";
 import type { DashboardOverview, DashboardTrends } from "@/features/dashboard/contracts";
 import { useDashboardScreenController } from "@/features/dashboard/hooks/use-dashboard-screen-controller";
+import type { UserInsight } from "@/features/insights/contracts";
 import { TestProviders } from "@/shared/testing/test-providers";
 
 jest.mock("@/features/dashboard/hooks/use-dashboard-screen-controller", () => ({
@@ -13,8 +15,8 @@ jest.mock("@/features/dashboard/hooks/use-dashboard-screen-controller", () => ({
 const mockedUseDashboardScreenController = jest.mocked(useDashboardScreenController);
 
 const buildQuery = <TData,>(
-  overrides: Partial<UseQueryResult<TData, Error>>,
-): UseQueryResult<TData, Error> =>
+  overrides: Partial<UseQueryResult<TData, ApiError>>,
+): UseQueryResult<TData, ApiError> =>
   ({
     data: undefined,
     error: null,
@@ -42,7 +44,18 @@ const buildQuery = <TData,>(
     isEnabled: true,
     promise: Promise.resolve(undefined),
     ...overrides,
-  }) as UseQueryResult<TData, Error>;
+  }) as UseQueryResult<TData, ApiError>;
+
+const insightData: UserInsight = {
+  id: "ins-1",
+  content: "Voce reduziu gastos variaveis sem cortar lazer.",
+  keyMetric: "Voce economizou R$ 320 nesta semana",
+  periodStart: "2026-05-04T00:00:00.000Z",
+  periodEnd: "2026-05-10T23:59:59.000Z",
+  status: "delivered",
+  generatedAt: "2026-05-11T09:00:00.000Z",
+  readAt: null,
+};
 
 describe("DashboardScreen", () => {
   afterEach(() => {
@@ -108,6 +121,14 @@ describe("DashboardScreen", () => {
         delta: null,
         percent: null,
       },
+      weeklyInsight: {
+        insight: insightData,
+        isLoading: false,
+        isNew: true,
+        fetchLatest: jest.fn(),
+        markAsRead: jest.fn(),
+        query: buildQuery({ data: insightData }),
+      },
       greetingName: "Italo",
       setSelectedMonth: jest.fn(),
     });
@@ -119,6 +140,9 @@ describe("DashboardScreen", () => {
     );
 
     expect(getByText(/Saldo geral/u)).toBeTruthy();
+    expect(getByText("Insight da semana")).toBeTruthy();
+    expect(getByText("NOVO")).toBeTruthy();
+    expect(getByText("Voce economizou R$ 320 nesta semana")).toBeTruthy();
     expect(getByText("abril de 2026")).toBeTruthy();
     expect(getByText(/Receitas:/u)).toBeTruthy();
   });

--- a/__tests__/app/private-layout.test.tsx
+++ b/__tests__/app/private-layout.test.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from "react";
+
+import { render } from "@testing-library/react-native";
+
+import PrivateLayout from "@/app/(private)/_layout";
+import { usePrivateRouteGuard } from "@/core/navigation/use-route-guards";
+import { useWeeklyInsight } from "@/features/insights/hooks/use-weekly-insight-query";
+
+const mockTabsScreens: {
+  name: string;
+  options?: Record<string, unknown>;
+}[] = [];
+
+jest.mock("expo-router", () => {
+  function MockTabs({ children }: { readonly children: ReactNode }): ReactNode {
+    return children;
+  }
+
+  function MockTabsScreen(props: {
+    readonly name: string;
+    readonly options?: Record<string, unknown>;
+  }): null {
+    mockTabsScreens.push({ name: props.name, options: props.options });
+    return null;
+  }
+
+  function MockRedirect(): null {
+    return null;
+  }
+
+  const Tabs = Object.assign(MockTabs, { Screen: MockTabsScreen });
+
+  return {
+    Redirect: MockRedirect,
+    Tabs,
+  };
+});
+
+jest.mock("@expo/vector-icons", () => ({
+  MaterialCommunityIcons: () => null,
+}));
+
+jest.mock("@/core/navigation/use-route-guards", () => ({
+  usePrivateRouteGuard: jest.fn(),
+}));
+
+jest.mock("@/features/entitlements/hooks/use-entitlements-foreground-refresh", () => ({
+  useEntitlementsForegroundRefresh: jest.fn(),
+}));
+
+jest.mock("@/features/insights/hooks/use-weekly-insight-query", () => ({
+  useWeeklyInsight: jest.fn(),
+}));
+
+const mockedUsePrivateRouteGuard = jest.mocked(usePrivateRouteGuard);
+const mockedUseWeeklyInsight = jest.mocked(useWeeklyInsight);
+
+const buildInsightState = (isNew: boolean): ReturnType<typeof useWeeklyInsight> =>
+  ({
+    insight: null,
+    isLoading: false,
+    isNew,
+    fetchLatest: jest.fn(),
+    markAsRead: jest.fn(),
+    query: {},
+  }) as unknown as ReturnType<typeof useWeeklyInsight>;
+
+describe("PrivateLayout", () => {
+  beforeEach(() => {
+    mockTabsScreens.length = 0;
+    mockedUsePrivateRouteGuard.mockReturnValue({ ready: true, redirectTo: null });
+    mockedUseWeeklyInsight.mockReturnValue(buildInsightState(false));
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("exibe badge no tab do dashboard quando existe insight novo", () => {
+    mockedUseWeeklyInsight.mockReturnValue(buildInsightState(true));
+
+    render(<PrivateLayout />);
+
+    const dashboardScreen = mockTabsScreens.find((screen) => screen.name === "dashboard");
+    expect(dashboardScreen?.options?.tabBarBadge).toBe("1");
+  });
+
+  it("omite badge no tab do dashboard quando o insight ja foi lido", () => {
+    mockedUseWeeklyInsight.mockReturnValue(buildInsightState(false));
+
+    render(<PrivateLayout />);
+
+    const dashboardScreen = mockTabsScreens.find((screen) => screen.name === "dashboard");
+    expect(dashboardScreen?.options?.tabBarBadge).toBeUndefined();
+  });
+});

--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -8,6 +8,7 @@ import { AppErrorBoundary } from "@/core/errors/app-error-boundary";
 import { privateTabDefinitions } from "@/core/navigation/routes";
 import { usePrivateRouteGuard } from "@/core/navigation/use-route-guards";
 import { useEntitlementsForegroundRefresh } from "@/features/entitlements/hooks/use-entitlements-foreground-refresh";
+import { useWeeklyInsight } from "@/features/insights/hooks/use-weekly-insight-query";
 
 const HIDDEN_TAB_NAMES: readonly string[] = [
   "installment-vs-cash",
@@ -32,6 +33,7 @@ const HIDDEN_TAB_NAMES: readonly string[] = [
 
 function PrivateLayoutContent(): ReactElement | null {
   const { ready, redirectTo } = usePrivateRouteGuard();
+  const weeklyInsight = useWeeklyInsight({ enabled: ready && !redirectTo });
   useEntitlementsForegroundRefresh();
 
   if (!ready) {
@@ -56,6 +58,8 @@ function PrivateLayoutContent(): ReactElement | null {
             name={tab.name}
             options={{
               title: tab.title,
+              tabBarBadge:
+                tab.name === "dashboard" && weeklyInsight.isNew ? "1" : undefined,
               tabBarIcon: ({ color, size }) => {
                 return (
                   <MaterialCommunityIcons name={tab.icon} color={color} size={size} />

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -16,7 +16,7 @@
       "createdAt": "2026-05-16",
       "removeBy": "2026-12-31",
       "type": "release",
-      "status": "active",
+      "status": "enabled-prod",
       "description": "Controla a exibição do insight semanal personalizado no dashboard do app.",
       "repositories": ["auraxis-app", "auraxis-api"]
     }

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -9,6 +9,16 @@
       "status": "draft",
       "description": "Controla a exibição da calculadora de pedir aumento na aba Ferramentas.",
       "repositories": ["auraxis-app", "auraxis-api", "auraxis-web"]
+    },
+    {
+      "key": "app.insights.weekly",
+      "owner": "platform",
+      "createdAt": "2026-05-16",
+      "removeBy": "2026-12-31",
+      "type": "release",
+      "status": "active",
+      "description": "Controla a exibição do insight semanal personalizado no dashboard do app.",
+      "repositories": ["auraxis-app", "auraxis-api"]
     }
   ]
 }

--- a/contracts/known-openapi-gaps.json
+++ b/contracts/known-openapi-gaps.json
@@ -38,6 +38,8 @@
     "GET /credit-cards",
     "POST /credit-cards",
     "PUT /credit-cards/{credit_card_id}",
-    "DELETE /credit-cards/{credit_card_id}"
+    "DELETE /credit-cards/{credit_card_id}",
+    "GET /v1/insights/latest",
+    "POST /v1/insights/{insight_id}/read"
   ]
 }

--- a/core/query/query-keys.ts
+++ b/core/query/query-keys.ts
@@ -7,6 +7,10 @@ export const queryKeys = {
     root: ["dashboard"] as const,
     overview: () => ["dashboard", "overview"] as const,
   },
+  insights: {
+    root: ["insights"] as const,
+    latest: () => ["insights", "latest"] as const,
+  },
   transactions: {
     root: ["transactions"] as const,
     list: () => ["transactions", "list"] as const,

--- a/features/dashboard/hooks/use-dashboard-screen-controller.ts
+++ b/features/dashboard/hooks/use-dashboard-screen-controller.ts
@@ -13,6 +13,10 @@ import {
   savingsRateCalculator,
   type SavingsRateAssessment,
 } from "@/features/dashboard/services/savings-rate-calculator";
+import {
+  useWeeklyInsight,
+  type WeeklyInsightState,
+} from "@/features/insights/hooks/use-weekly-insight-query";
 
 export interface DashboardMonthOption {
   readonly value: string;
@@ -35,6 +39,7 @@ export interface DashboardScreenController {
   readonly currentBalance: number;
   readonly savingsRate: SavingsRateAssessment | null;
   readonly comparison: PeriodComparison;
+  readonly weeklyInsight: WeeklyInsightState;
   readonly greetingName: string;
   readonly setSelectedMonth: (month: string) => void;
 }
@@ -69,6 +74,7 @@ export function useDashboardScreenController(): DashboardScreenController {
   const [selectedMonth, setSelectedMonth] = useState(getCurrentMonth);
   const overviewQuery = useDashboardOverviewQuery({ month: selectedMonth });
   const trendsQuery = useDashboardTrendsQuery(6);
+  const weeklyInsight = useWeeklyInsight();
 
   const monthOptions = useMemo<DashboardMonthOption[]>(() => {
     return (
@@ -125,6 +131,7 @@ export function useDashboardScreenController(): DashboardScreenController {
     currentBalance: overviewQuery.data?.totals.balance ?? 0,
     savingsRate,
     comparison,
+    weeklyInsight,
     greetingName: firstName(userName),
     setSelectedMonth,
   };

--- a/features/dashboard/screens/dashboard-screen.tsx
+++ b/features/dashboard/screens/dashboard-screen.tsx
@@ -15,6 +15,7 @@ import {
   useDashboardScreenController,
   type DashboardScreenController,
 } from "@/features/dashboard/hooks/use-dashboard-screen-controller";
+import { WeeklyInsightCard } from "@/features/insights/components/weekly-insight-card";
 import { useUserProfileQuery } from "@/features/user-profile/hooks/use-user-profile-query";
 import type {
   SavingsRateAssessment,
@@ -53,6 +54,7 @@ export function DashboardScreen(): ReactElement {
   return (
     <AppScreen>
       <BalanceCard controller={controller} />
+      <DashboardWeeklyInsightCard controller={controller} />
       {controller.monthSnapshot ? (
         <DashboardComparisonCard
           title="Saldo"
@@ -165,6 +167,17 @@ function BalanceCard({ controller }: ControllerProps): ReactElement {
         )}
       </AppQueryState>
     </AppSurfaceCard>
+  );
+}
+
+function DashboardWeeklyInsightCard({ controller }: ControllerProps): ReactElement {
+  return (
+    <WeeklyInsightCard
+      insight={controller.weeklyInsight.insight}
+      isLoading={controller.weeklyInsight.isLoading}
+      isNew={controller.weeklyInsight.isNew}
+      onMarkAsRead={controller.weeklyInsight.markAsRead}
+    />
   );
 }
 

--- a/features/insights/components/weekly-insight-card.test.tsx
+++ b/features/insights/components/weekly-insight-card.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { UserInsight } from "@/features/insights/contracts";
+import { WeeklyInsightCard } from "@/features/insights/components/weekly-insight-card";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+const insightFixture: UserInsight = {
+  id: "ins-1",
+  content: "Voce reduziu gastos variaveis sem cortar lazer.",
+  keyMetric: "Voce economizou R$ 320 nesta semana",
+  periodStart: "2026-05-04T00:00:00.000Z",
+  periodEnd: "2026-05-10T23:59:59.000Z",
+  status: "delivered",
+  generatedAt: "2026-05-11T09:00:00.000Z",
+  readAt: null,
+};
+
+describe("WeeklyInsightCard", () => {
+  it("renderiza loading em altura fixa", () => {
+    const { getByTestId } = render(
+      <TestProviders>
+        <WeeklyInsightCard
+          insight={null}
+          isLoading
+          isNew={false}
+          onMarkAsRead={jest.fn()}
+        />
+      </TestProviders>,
+    );
+
+    expect(getByTestId("weekly-insight-loading")).toBeTruthy();
+  });
+
+  it("renderiza placeholder quando nao ha insight", () => {
+    const { getByText } = render(
+      <TestProviders>
+        <WeeklyInsightCard
+          insight={null}
+          isLoading={false}
+          isNew={false}
+          onMarkAsRead={jest.fn()}
+        />
+      </TestProviders>,
+    );
+
+    expect(getByText("Seu insight semanal esta sendo preparado")).toBeTruthy();
+  });
+
+  it("destaca insight novo e marca como lido ao expandir", () => {
+    const markAsRead = jest.fn();
+    const { getByText, queryByText } = render(
+      <TestProviders>
+        <WeeklyInsightCard
+          insight={insightFixture}
+          isLoading={false}
+          isNew
+          onMarkAsRead={markAsRead}
+        />
+      </TestProviders>,
+    );
+
+    expect(getByText("NOVO")).toBeTruthy();
+    expect(getByText("Voce economizou R$ 320 nesta semana")).toBeTruthy();
+    expect(queryByText("Voce reduziu gastos variaveis sem cortar lazer.")).toBeNull();
+
+    fireEvent.press(getByText("Ver mais"));
+
+    expect(markAsRead).toHaveBeenCalledWith("ins-1");
+    expect(getByText("Voce reduziu gastos variaveis sem cortar lazer.")).toBeTruthy();
+  });
+});

--- a/features/insights/components/weekly-insight-card.tsx
+++ b/features/insights/components/weekly-insight-card.tsx
@@ -1,0 +1,81 @@
+import { useState, type ReactElement } from "react";
+import { ActivityIndicator } from "react-native";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import type { UserInsight } from "@/features/insights/contracts";
+import { AppBadge } from "@/shared/components/app-badge";
+import { AppButton } from "@/shared/components/app-button";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+
+export interface WeeklyInsightCardProps {
+  readonly insight: UserInsight | null;
+  readonly isLoading: boolean;
+  readonly isNew: boolean;
+  readonly onMarkAsRead: (insightId: string) => void | Promise<void>;
+}
+
+export function WeeklyInsightCard({
+  insight,
+  isLoading,
+  isNew,
+  onMarkAsRead,
+}: WeeklyInsightCardProps): ReactElement {
+  const [expanded, setExpanded] = useState(false);
+
+  const handleToggle = (): void => {
+    if (!insight) {
+      return;
+    }
+    const nextExpanded = !expanded;
+    setExpanded(nextExpanded);
+    if (nextExpanded && isNew) {
+      void onMarkAsRead(insight.id);
+    }
+  };
+
+  return (
+    <AppSurfaceCard
+      title="Insight da semana"
+      description="Uma leitura personalizada sobre seus movimentos recentes."
+    >
+      {isLoading ? (
+        <YStack
+          minHeight={104}
+          alignItems="center"
+          justifyContent="center"
+          testID="weekly-insight-loading"
+        >
+          <ActivityIndicator />
+        </YStack>
+      ) : null}
+
+      {!isLoading && !insight ? (
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$4">
+          Seu insight semanal esta sendo preparado
+        </Paragraph>
+      ) : null}
+
+      {!isLoading && insight ? (
+        <YStack gap="$3">
+          <XStack alignItems="center" gap="$2" flexWrap="wrap">
+            {isNew ? <AppBadge tone="primary">NOVO</AppBadge> : null}
+            <Paragraph color="$secondary" fontFamily="$heading" fontSize="$6">
+              {insight.keyMetric}
+            </Paragraph>
+          </XStack>
+
+          {expanded ? (
+            <Paragraph color="$color" fontFamily="$body" fontSize="$4">
+              {insight.content}
+            </Paragraph>
+          ) : null}
+
+          <AppButton tone="secondary" onPress={handleToggle}>
+            {expanded ? "Ver menos" : "Ver mais"}
+          </AppButton>
+        </YStack>
+      ) : null}
+    </AppSurfaceCard>
+  );
+}

--- a/features/insights/contracts.ts
+++ b/features/insights/contracts.ts
@@ -1,0 +1,16 @@
+export type InsightStatus = "pending" | "delivered" | "read";
+
+export interface UserInsight {
+  readonly id: string;
+  readonly content: string;
+  readonly keyMetric: string;
+  readonly periodStart: string;
+  readonly periodEnd: string;
+  readonly status: InsightStatus;
+  readonly generatedAt: string;
+  readonly readAt: string | null;
+}
+
+export interface LatestInsightResponse {
+  readonly insight: UserInsight | null;
+}

--- a/features/insights/hooks/use-weekly-insight-query.test.tsx
+++ b/features/insights/hooks/use-weekly-insight-query.test.tsx
@@ -1,0 +1,90 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import type { UserInsight } from "@/features/insights/contracts";
+import { useWeeklyInsight } from "@/features/insights/hooks/use-weekly-insight-query";
+import { insightService } from "@/features/insights/services/insight-service";
+import { createTestQueryClient } from "@/shared/testing/test-query-client";
+import { createTestHookWrapper } from "@/shared/testing/test-providers";
+
+jest.mock("@/features/insights/services/insight-service", () => ({
+  insightService: {
+    getLatest: jest.fn(),
+    markAsRead: jest.fn(),
+  },
+}));
+
+const mockedInsightService = jest.mocked(insightService);
+
+const insightFixture: UserInsight = {
+  id: "ins-1",
+  content: "Voce reduziu gastos variaveis sem cortar lazer.",
+  keyMetric: "Voce economizou R$ 320 nesta semana",
+  periodStart: "2026-05-04T00:00:00.000Z",
+  periodEnd: "2026-05-10T23:59:59.000Z",
+  status: "delivered",
+  generatedAt: "2026-05-11T09:00:00.000Z",
+  readAt: null,
+};
+
+describe("useWeeklyInsight", () => {
+  beforeEach(() => {
+    mockedInsightService.getLatest.mockResolvedValue(insightFixture);
+    mockedInsightService.markAsRead.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("carrega o insight semanal e expõe isNew quando ainda nao foi lido", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestHookWrapper({ queryClient });
+
+    const { result } = renderHook(() => useWeeklyInsight(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.insight).toEqual(insightFixture);
+    expect(result.current.isNew).toBe(true);
+    expect(mockedInsightService.getLatest).toHaveBeenCalledTimes(1);
+  });
+
+  it("expõe insight null e isNew false quando nao ha insight disponivel", async () => {
+    mockedInsightService.getLatest.mockResolvedValueOnce(null);
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestHookWrapper({ queryClient });
+
+    const { result } = renderHook(() => useWeeklyInsight(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.insight).toBeNull();
+    expect(result.current.isNew).toBe(false);
+  });
+
+  it("marca como lido com atualizacao otimista no cache", async () => {
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestHookWrapper({ queryClient });
+
+    const { result } = renderHook(() => useWeeklyInsight(), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.insight?.id).toBe("ins-1");
+    });
+
+    await act(async () => {
+      await result.current.markAsRead("ins-1");
+    });
+
+    expect(mockedInsightService.markAsRead).toHaveBeenCalledWith("ins-1");
+    await waitFor(() => {
+      expect(result.current.insight?.status).toBe("read");
+    });
+    expect(result.current.insight?.readAt).toEqual(expect.any(String));
+    expect(result.current.isNew).toBe(false);
+  });
+});

--- a/features/insights/hooks/use-weekly-insight-query.ts
+++ b/features/insights/hooks/use-weekly-insight-query.ts
@@ -1,0 +1,75 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { createApiQuery } from "@/core/query/create-api-query";
+import { queryKeys } from "@/core/query/query-keys";
+import type { UserInsight } from "@/features/insights/contracts";
+import { insightService } from "@/features/insights/services/insight-service";
+
+const markInsightRead = (insight: UserInsight, readAt: string): UserInsight => ({
+  ...insight,
+  status: "read",
+  readAt,
+});
+
+export interface WeeklyInsightState {
+  readonly insight: UserInsight | null;
+  readonly isLoading: boolean;
+  readonly isNew: boolean;
+  readonly fetchLatest: () => Promise<unknown>;
+  readonly markAsRead: (insightId: string) => Promise<void>;
+  readonly query: ReturnType<typeof createApiQuery<UserInsight | null>>;
+}
+
+export const useWeeklyInsight = (
+  options: { readonly enabled?: boolean } = {},
+): WeeklyInsightState => {
+  const enabled = options.enabled ?? true;
+  const queryClient = useQueryClient();
+  const query = createApiQuery<UserInsight | null>(
+    queryKeys.insights.latest(),
+    () => insightService.getLatest(),
+    { enabled },
+  );
+  const mutation = useMutation<
+    void,
+    Error,
+    string,
+    { readonly previous: UserInsight | null | undefined }
+  >({
+    mutationFn: (insightId) => insightService.markAsRead(insightId),
+    onMutate: async (insightId) => {
+      await queryClient.cancelQueries({ queryKey: queryKeys.insights.latest() });
+      const previous = queryClient.getQueryData<UserInsight | null>(
+        queryKeys.insights.latest(),
+      );
+      const readAt = new Date().toISOString();
+      if (previous?.id === insightId) {
+        queryClient.setQueryData<UserInsight | null>(
+          queryKeys.insights.latest(),
+          markInsightRead(previous, readAt),
+        );
+      }
+      return { previous };
+    },
+    onError: (_error, _insightId, context) => {
+      const previous = context?.previous;
+      if (previous !== undefined) {
+        queryClient.setQueryData<UserInsight | null>(
+          queryKeys.insights.latest(),
+          previous,
+        );
+      }
+    },
+  });
+
+  return {
+    insight: query.data ?? null,
+    isLoading: query.isPending || query.isLoading,
+    isNew: Boolean(query.data && query.data.status !== "read"),
+    fetchLatest: query.refetch,
+    markAsRead: async (insightId: string): Promise<void> => {
+      await mutation.mutateAsync(insightId);
+    },
+    query,
+  };
+};

--- a/features/insights/mocks.ts
+++ b/features/insights/mocks.ts
@@ -1,0 +1,13 @@
+import type { UserInsight } from "@/features/insights/contracts";
+
+export const weeklyInsightFixture: UserInsight = {
+  id: "insight-weekly-1",
+  content:
+    "Voce manteve as despesas essenciais sob controle e abriu espaco para investir mais sem cortar tudo que gosta.",
+  keyMetric: "Voce economizou R$ 320 nesta semana",
+  periodStart: "2026-05-04T00:00:00.000Z",
+  periodEnd: "2026-05-10T23:59:59.000Z",
+  status: "delivered",
+  generatedAt: "2026-05-11T09:00:00.000Z",
+  readAt: null,
+};

--- a/features/insights/services/insight-service.test.ts
+++ b/features/insights/services/insight-service.test.ts
@@ -1,0 +1,71 @@
+import type { AxiosInstance } from "axios";
+
+import { ApiError } from "@/core/http/api-error";
+import { createInsightService } from "@/features/insights/services/insight-service";
+
+const createClient = (): jest.Mocked<Pick<AxiosInstance, "get" | "post">> => ({
+  get: jest.fn(),
+  post: jest.fn(),
+});
+
+describe("insightService", () => {
+  it("carrega o insight semanal mais recente mapeando snake_case", async () => {
+    const client = createClient();
+    client.get.mockResolvedValue({
+      data: {
+        data: {
+          insight: {
+            id: "ins-1",
+            content: "Voce reduziu gastos variaveis sem cortar lazer.",
+            key_metric: "Voce economizou R$ 320 nesta semana",
+            period_start: "2026-05-04T00:00:00.000Z",
+            period_end: "2026-05-10T23:59:59.000Z",
+            status: "delivered",
+            generated_at: "2026-05-11T09:00:00.000Z",
+            read_at: null,
+          },
+        },
+      },
+    });
+
+    const service = createInsightService(client as unknown as AxiosInstance);
+    const result = await service.getLatest();
+
+    expect(client.get).toHaveBeenCalledWith("/v1/insights/latest");
+    expect(result).toEqual({
+      id: "ins-1",
+      content: "Voce reduziu gastos variaveis sem cortar lazer.",
+      keyMetric: "Voce economizou R$ 320 nesta semana",
+      periodStart: "2026-05-04T00:00:00.000Z",
+      periodEnd: "2026-05-10T23:59:59.000Z",
+      status: "delivered",
+      generatedAt: "2026-05-11T09:00:00.000Z",
+      readAt: null,
+    });
+  });
+
+  it("retorna null quando a API responde 404 para insight ausente", async () => {
+    const client = createClient();
+    client.get.mockRejectedValue(
+      new ApiError({
+        message: "Insight nao encontrado",
+        status: 404,
+        code: "NOT_FOUND",
+      }),
+    );
+
+    const service = createInsightService(client as unknown as AxiosInstance);
+
+    await expect(service.getLatest()).resolves.toBeNull();
+  });
+
+  it("marca o insight como lido no endpoint canonico", async () => {
+    const client = createClient();
+    client.post.mockResolvedValue({ data: { data: {} } });
+
+    const service = createInsightService(client as unknown as AxiosInstance);
+    await service.markAsRead("ins-1");
+
+    expect(client.post).toHaveBeenCalledWith("/v1/insights/ins-1/read");
+  });
+});

--- a/features/insights/services/insight-service.ts
+++ b/features/insights/services/insight-service.ts
@@ -1,0 +1,64 @@
+import type { AxiosInstance } from "axios";
+
+import { ApiError } from "@/core/http/api-error";
+import { unwrapEnvelopeData } from "@/core/http/contracts";
+import { httpClient } from "@/core/http/http-client";
+import type { UserInsight } from "@/features/insights/contracts";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
+import { resolveApiContractPath } from "@/shared/contracts/resolve-api-contract-path";
+
+interface UserInsightPayload {
+  readonly id: string;
+  readonly content: string;
+  readonly key_metric: string;
+  readonly period_start: string;
+  readonly period_end: string;
+  readonly status: UserInsight["status"];
+  readonly generated_at: string;
+  readonly read_at: string | null;
+}
+
+const mapInsight = (payload: UserInsightPayload): UserInsight => {
+  return {
+    id: payload.id,
+    content: payload.content,
+    keyMetric: payload.key_metric,
+    periodStart: payload.period_start,
+    periodEnd: payload.period_end,
+    status: payload.status,
+    generatedAt: payload.generated_at,
+    readAt: payload.read_at,
+  };
+};
+
+const isNotFoundError = (error: unknown): boolean => {
+  return error instanceof ApiError && error.status === 404;
+};
+
+export const createInsightService = (client: AxiosInstance) => {
+  return {
+    getLatest: async (): Promise<UserInsight | null> => {
+      try {
+        const response = await client.get(apiContractMap.insightsLatest.path);
+        const payload = unwrapEnvelopeData<{
+          readonly insight?: UserInsightPayload | null;
+        }>(response.data);
+        return payload.insight ? mapInsight(payload.insight) : null;
+      } catch (error) {
+        if (isNotFoundError(error)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+    markAsRead: async (insightId: string): Promise<void> => {
+      await client.post(
+        resolveApiContractPath(apiContractMap.insightsMarkRead.path, {
+          insight_id: insightId,
+        }),
+      );
+    },
+  };
+};
+
+export const insightService = createInsightService(httpClient);

--- a/shared/contracts/api-contract-map.ts
+++ b/shared/contracts/api-contract-map.ts
@@ -75,6 +75,7 @@ import type {
   ReceivableRecord,
   RevenueSummary,
 } from "@/features/fiscal/contracts";
+import type { LatestInsightResponse } from "@/features/insights/contracts";
 import type {
   QuestionnaireCollection,
   QuestionnaireResult,
@@ -345,6 +346,26 @@ export const apiContractMap = {
   >({
     method: "GET",
     path: "/dashboard/trends",
+    authRequired: true,
+  }),
+  insightsLatest: defineApiContract<
+    "GET",
+    "/v1/insights/latest",
+    never,
+    LatestInsightResponse
+  >({
+    method: "GET",
+    path: "/v1/insights/latest",
+    authRequired: true,
+  }),
+  insightsMarkRead: defineApiContract<
+    "POST",
+    "/v1/insights/{insight_id}/read",
+    never,
+    void
+  >({
+    method: "POST",
+    path: "/v1/insights/{insight_id}/read",
     authRequired: true,
   }),
   transactionsList: defineApiContract<

--- a/shared/contracts/api-endpoint-catalog.ts
+++ b/shared/contracts/api-endpoint-catalog.ts
@@ -25,6 +25,10 @@ export const apiEndpointCatalog = {
     "GET /dashboard/overview",
     "GET /dashboard/trends",
   ],
+  insights: [
+    "GET /v1/insights/latest",
+    "POST /v1/insights/{insight_id}/read",
+  ],
   goals: [
     "GET /goals",
     "POST /goals",

--- a/shared/feature-flags/service.test.ts
+++ b/shared/feature-flags/service.test.ts
@@ -71,6 +71,13 @@ describe("feature flag service - local fallback", () => {
     expect(isFeatureEnabled("app.tools.salary-raise-calculator")).toBe(false);
   });
 
+  it("considera status enabled-prod habilitado no fallback local", () => {
+    const localFlag = getLocalFlag("app.insights.weekly");
+
+    expect(localFlag?.status).toBe("enabled-prod");
+    expect(isFeatureEnabled("app.insights.weekly")).toBe(true);
+  });
+
   it("respeita decisao explicita do provider externo", () => {
     expect(isFeatureEnabled("app.tools.salary-raise-calculator", true)).toBe(true);
     expect(isFeatureEnabled("app.tools.salary-raise-calculator", false)).toBe(false);

--- a/shared/feature-flags/service.ts
+++ b/shared/feature-flags/service.ts
@@ -3,7 +3,12 @@ import featureFlagsCatalogJson from "@/config/feature-flags.json";
 import type { FeatureFlagCatalog, FeatureFlagDefinition } from "@/shared/feature-flags/types";
 
 const featureFlagsCatalog: FeatureFlagCatalog = featureFlagsCatalogJson as FeatureFlagCatalog;
-const enabledStatuses = new Set<string>(["active", "released", "enabled"]);
+const enabledStatuses = new Set<string>([
+  "enabled-dev",
+  "enabled-staging",
+  "enabled-prod",
+  "cleanup-pending",
+]);
 const overridePrefix = "EXPO_PUBLIC_FLAG_";
 const defaultUnleashAppName = "auraxis-app";
 const defaultUnleashEnvironment = "development";

--- a/shared/mocks/api/router.ts
+++ b/shared/mocks/api/router.ts
@@ -11,6 +11,7 @@ import {
   dashboardOverviewFixture,
   dashboardTrendsFixture,
 } from "@/features/dashboard/mocks";
+import { weeklyInsightFixture } from "@/features/insights/mocks";
 import { goalListFixture } from "@/features/goals/mocks";
 import {
   observabilitySnapshotFixture,
@@ -321,6 +322,21 @@ const serializeDashboardOverview = (): Record<string, unknown> => {
   };
 };
 
+const serializeWeeklyInsight = (): Record<string, unknown> => {
+  return {
+    insight: {
+      id: weeklyInsightFixture.id,
+      content: weeklyInsightFixture.content,
+      key_metric: weeklyInsightFixture.keyMetric,
+      period_start: weeklyInsightFixture.periodStart,
+      period_end: weeklyInsightFixture.periodEnd,
+      status: weeklyInsightFixture.status,
+      generated_at: weeklyInsightFixture.generatedAt,
+      read_at: weeklyInsightFixture.readAt,
+    },
+  };
+};
+
 const serializeWalletCollection = (): Record<string, unknown> => {
   return {
     items: walletCollectionFixture.items.map((item) => ({
@@ -500,6 +516,22 @@ const handleDashboardRoutes: MockRouteHandler = (context) => {
   return null;
 };
 
+const handleInsightRoutes: MockRouteHandler = (context) => {
+  if (context.method === "GET" && context.pathname === "/v1/insights/latest") {
+    return ok(serializeWeeklyInsight());
+  }
+
+  if (
+    context.method === "POST" &&
+    context.pathname.startsWith("/v1/insights/") &&
+    context.pathname.endsWith("/read")
+  ) {
+    return ok({});
+  }
+
+  return null;
+};
+
 const handleWalletRoute: MockRouteHandler = (context) => {
   if (context.method !== "GET" || context.pathname !== "/wallet") {
     return null;
@@ -587,6 +619,7 @@ const routeHandlers: MockRouteHandler[] = [
   handleEntitlementRoutes,
   handleSubscriptionRoutes,
   handleDashboardRoutes,
+  handleInsightRoutes,
   handleWalletRoute,
   handleGoalRoute,
   handleAlertRoutes,


### PR DESCRIPTION
## Summary
- Adds the weekly insight API service, React Query hook, contracts, fixtures, and mock API routes.
- Renders the weekly insight card on the dashboard with loading, empty, new badge, key metric highlight, expandable content, and optimistic mark-as-read.
- Adds the dashboard tab badge for unread insights and tests the card, hook, service, dashboard integration, and private layout badge.

## Validation
- npm run quality-check
- pre-commit lint-staged checks
- pre-push policy/contracts/typecheck/test coverage

## Notes
- Refs #369.
- The push notification acceptance criterion remains blocked: the app does not currently have expo-notifications installed/configured or an existing notification response listener to extend.