### PR TITLE
[APP] Analytics — mobile useAnalytics facade

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -29,6 +29,16 @@
       "status": "enabled-dev",
       "description": "Controla o registro de push notifications nativas no app.",
       "repositories": ["auraxis-app", "auraxis-api"]
+    },
+    {
+      "key": "app.observability.analytics",
+      "owner": "platform",
+      "createdAt": "2026-05-17",
+      "removeBy": "2026-12-31",
+      "type": "release",
+      "status": "draft",
+      "description": "Controla a coleta de analytics de produto no app enquanto o provider PostHog e opt-out LGPD sao integrados.",
+      "repositories": ["auraxis-app"]
     }
   ]
 }

--- a/core/observability/analytics-runtime.ts
+++ b/core/observability/analytics-runtime.ts
@@ -1,0 +1,109 @@
+import { sanitizeTelemetryContext } from "@/core/telemetry/sanitization";
+import { isFeatureEnabled } from "@/shared/feature-flags/service";
+
+import type {
+  AnalyticsClient,
+  AnalyticsEventName,
+  AnalyticsEventPropertiesByName,
+  AnalyticsProperties,
+} from "@/core/observability/analytics-types";
+
+export const ANALYTICS_FEATURE_FLAG_KEY = "app.observability.analytics";
+
+export const ANALYTICS_EVENT_NAMES = Object.freeze([
+  "auth.login.success",
+  "auth.register.completed",
+  "auth.logout",
+  "transaction.created",
+  "transaction.deleted",
+  "transaction.restored",
+  "goal.created",
+  "goal.simulated",
+  "tool.used",
+  "subscription.checkout.opened",
+  "subscription.checkout.completed",
+  "dashboard.period.changed",
+] as const satisfies readonly AnalyticsEventName[]);
+
+interface AnalyticsRuntimeState {
+  readonly client: AnalyticsClient;
+  readonly collectionEnabled: boolean;
+}
+
+export const createNoopAnalyticsClient = (): AnalyticsClient => {
+  return {
+    capture: () => undefined,
+    identify: () => undefined,
+    reset: () => undefined,
+  };
+};
+
+const createInitialAnalyticsRuntimeState = (): AnalyticsRuntimeState => {
+  return {
+    client: createNoopAnalyticsClient(),
+    collectionEnabled: isFeatureEnabled(ANALYTICS_FEATURE_FLAG_KEY),
+  };
+};
+
+let analyticsRuntimeState = createInitialAnalyticsRuntimeState();
+
+const sanitizeAnalyticsProperties = <TProperties extends AnalyticsProperties>(
+  properties: TProperties | undefined,
+): TProperties | undefined => {
+  if (!properties) {
+    return undefined;
+  }
+
+  return sanitizeTelemetryContext(properties) as TProperties;
+};
+
+const runtimeAnalyticsClient: AnalyticsClient = {
+  capture: <TEventName extends AnalyticsEventName>(
+    eventName: TEventName,
+    properties?: AnalyticsEventPropertiesByName[TEventName],
+  ): void => {
+    if (!analyticsRuntimeState.collectionEnabled) {
+      return;
+    }
+
+    analyticsRuntimeState.client.capture(
+      eventName,
+      sanitizeAnalyticsProperties(properties),
+    );
+  },
+  identify: (distinctId: string, traits?: AnalyticsProperties): void => {
+    if (!analyticsRuntimeState.collectionEnabled) {
+      return;
+    }
+
+    analyticsRuntimeState.client.identify(
+      distinctId,
+      sanitizeAnalyticsProperties(traits),
+    );
+  },
+  reset: (): void => {
+    analyticsRuntimeState.client.reset();
+  },
+};
+
+export const getAnalyticsClient = (): AnalyticsClient => {
+  return runtimeAnalyticsClient;
+};
+
+export const setAnalyticsClient = (client: AnalyticsClient | undefined): void => {
+  analyticsRuntimeState = {
+    ...analyticsRuntimeState,
+    client: client ?? createNoopAnalyticsClient(),
+  };
+};
+
+export const setAnalyticsCollectionEnabled = (enabled: boolean): void => {
+  analyticsRuntimeState = {
+    ...analyticsRuntimeState,
+    collectionEnabled: enabled,
+  };
+};
+
+export const resetAnalyticsRuntimeForTesting = (): void => {
+  analyticsRuntimeState = createInitialAnalyticsRuntimeState();
+};

--- a/core/observability/analytics-types.ts
+++ b/core/observability/analytics-types.ts
@@ -1,0 +1,88 @@
+export type AnalyticsPropertyPrimitive =
+  | string
+  | number
+  | boolean
+  | null
+  | undefined;
+
+export type AnalyticsPropertyValue =
+  | AnalyticsPropertyPrimitive
+  | readonly AnalyticsPropertyValue[]
+  | {
+      readonly [key: string]: AnalyticsPropertyValue;
+    };
+
+export type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
+
+export interface AuthLoginSuccessAnalyticsProperties
+  extends AnalyticsProperties {
+  readonly method?: "password" | "biometric" | "magic-link" | "unknown";
+  readonly emailConfirmed?: boolean;
+}
+
+export interface AuthRegisterCompletedAnalyticsProperties
+  extends AnalyticsProperties {
+  readonly emailConfirmed?: boolean;
+  readonly locale?: string;
+}
+
+export interface AuthLogoutAnalyticsProperties extends AnalyticsProperties {
+  readonly reason?: "manual" | "session_expired" | "auth_failure" | "unknown";
+}
+
+export interface TransactionAnalyticsProperties extends AnalyticsProperties {
+  readonly transactionType?: "income" | "expense" | "transfer" | "unknown";
+  readonly source?: string;
+}
+
+export interface GoalCreatedAnalyticsProperties extends AnalyticsProperties {
+  readonly goalType?: string;
+  readonly targetAmountBucket?: string;
+}
+
+export interface GoalSimulatedAnalyticsProperties extends AnalyticsProperties {
+  readonly horizonMonths?: number;
+  readonly contributionBucket?: string;
+}
+
+export interface ToolUsedAnalyticsProperties extends AnalyticsProperties {
+  readonly slug: string;
+}
+
+export interface SubscriptionCheckoutAnalyticsProperties
+  extends AnalyticsProperties {
+  readonly provider?: "hosted" | "store" | "unknown";
+  readonly planId?: string;
+  readonly status?: "opened" | "completed" | "cancelled" | "unknown";
+}
+
+export interface DashboardPeriodChangedAnalyticsProperties
+  extends AnalyticsProperties {
+  readonly period: string;
+}
+
+export interface AnalyticsEventPropertiesByName {
+  readonly "auth.login.success": AuthLoginSuccessAnalyticsProperties;
+  readonly "auth.register.completed": AuthRegisterCompletedAnalyticsProperties;
+  readonly "auth.logout": AuthLogoutAnalyticsProperties;
+  readonly "transaction.created": TransactionAnalyticsProperties;
+  readonly "transaction.deleted": TransactionAnalyticsProperties;
+  readonly "transaction.restored": TransactionAnalyticsProperties;
+  readonly "goal.created": GoalCreatedAnalyticsProperties;
+  readonly "goal.simulated": GoalSimulatedAnalyticsProperties;
+  readonly "tool.used": ToolUsedAnalyticsProperties;
+  readonly "subscription.checkout.opened": SubscriptionCheckoutAnalyticsProperties;
+  readonly "subscription.checkout.completed": SubscriptionCheckoutAnalyticsProperties;
+  readonly "dashboard.period.changed": DashboardPeriodChangedAnalyticsProperties;
+}
+
+export type AnalyticsEventName = keyof AnalyticsEventPropertiesByName;
+
+export interface AnalyticsClient {
+  capture: <TEventName extends AnalyticsEventName>(
+    eventName: TEventName,
+    properties?: AnalyticsEventPropertiesByName[TEventName],
+  ) => void;
+  identify: (distinctId: string, traits?: AnalyticsProperties) => void;
+  reset: () => void;
+}

--- a/core/observability/use-analytics.test.tsx
+++ b/core/observability/use-analytics.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook } from "@testing-library/react-native";
+
+import {
+  ANALYTICS_EVENT_NAMES,
+  resetAnalyticsRuntimeForTesting,
+  setAnalyticsClient,
+  setAnalyticsCollectionEnabled,
+} from "@/core/observability/analytics-runtime";
+import { useAnalytics } from "@/core/observability/use-analytics";
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+
+const makeAnalyticsClient = (): jest.Mocked<AnalyticsClient> => {
+  return {
+    capture: jest.fn(),
+    identify: jest.fn(),
+    reset: jest.fn(),
+  };
+};
+
+describe("useAnalytics", () => {
+  beforeEach(() => {
+    resetAnalyticsRuntimeForTesting();
+  });
+
+  it("expoe um cliente noop seguro quando nenhum provider esta configurado", () => {
+    const { result } = renderHook(() => useAnalytics());
+
+    expect(() => {
+      result.current.capture("auth.login.success", {
+        method: "password",
+      });
+      result.current.identify("user-123");
+      result.current.reset();
+    }).not.toThrow();
+  });
+
+  it("mantem catalogo tipado para os eventos-chave do epic de observabilidade", () => {
+    expect(ANALYTICS_EVENT_NAMES).toEqual([
+      "auth.login.success",
+      "auth.register.completed",
+      "auth.logout",
+      "transaction.created",
+      "transaction.deleted",
+      "transaction.restored",
+      "goal.created",
+      "goal.simulated",
+      "tool.used",
+      "subscription.checkout.opened",
+      "subscription.checkout.completed",
+      "dashboard.period.changed",
+    ]);
+  });
+
+  it("encaminha eventos e traits sanitizados quando a coleta esta habilitada", () => {
+    const analyticsClient = makeAnalyticsClient();
+    setAnalyticsClient(analyticsClient);
+    setAnalyticsCollectionEnabled(true);
+
+    const { result } = renderHook(() => useAnalytics());
+
+    result.current.capture("auth.login.success", {
+      method: "password",
+      email: "person@example.com",
+      nested: {
+        apiKey: "secret-key",
+      },
+    });
+    result.current.identify("user-123", {
+      plan: "premium",
+      email: "person@example.com",
+    });
+    result.current.reset();
+
+    expect(analyticsClient.capture).toHaveBeenCalledWith(
+      "auth.login.success",
+      {
+        method: "password",
+        email: "<redacted>",
+        nested: {
+          apiKey: "<redacted>",
+        },
+      },
+    );
+    expect(analyticsClient.identify).toHaveBeenCalledWith("user-123", {
+      plan: "premium",
+      email: "<redacted>",
+    });
+    expect(analyticsClient.reset).toHaveBeenCalledTimes(1);
+  });
+
+  it("bloqueia capture e identify quando a coleta esta desabilitada", () => {
+    const analyticsClient = makeAnalyticsClient();
+    setAnalyticsClient(analyticsClient);
+    setAnalyticsCollectionEnabled(false);
+
+    const { result } = renderHook(() => useAnalytics());
+
+    result.current.capture("tool.used", {
+      slug: "salary-raise-calculator",
+    });
+    result.current.identify("user-123", {
+      plan: "premium",
+    });
+    result.current.reset();
+
+    expect(analyticsClient.capture).not.toHaveBeenCalled();
+    expect(analyticsClient.identify).not.toHaveBeenCalled();
+    expect(analyticsClient.reset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/core/observability/use-analytics.ts
+++ b/core/observability/use-analytics.ts
@@ -1,0 +1,7 @@
+import { getAnalyticsClient } from "@/core/observability/analytics-runtime";
+
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+
+export const useAnalytics = (): AnalyticsClient => {
+  return getAnalyticsClient();
+};


### PR DESCRIPTION
## Summary

- Adds a typed mobile analytics event catalog for the product events listed in #305.
- Adds a safe no-op analytics runtime and `useAnalytics()` hook under `core/observability`.
- Gates collection behind `app.observability.analytics` in `draft` state and sanitizes event properties/traits before forwarding to future providers.

## Screenshots

Not applicable. This PR is infrastructure-only and does not change visual screens.

## Validation

- `npm test -- core/observability/use-analytics.test.tsx --runInBand`
- `npm run flags:check`
- `npm run typecheck`
- `npm run lint`
- `npm run quality-check`
- `git push -u origin feat/408-analytics-facade` pre-push checks

Part of #305.
Closes #408