### PR TITLE
[APP] Analytics — auth event instrumentation

### DIFF
--- a/features/auth/hooks/use-auth-mutations.test.ts
+++ b/features/auth/hooks/use-auth-mutations.test.ts
@@ -1,11 +1,26 @@
-import { useLogoutMutation } from "@/features/auth/hooks/use-auth-mutations";
+import {
+  useLoginMutation,
+  useLogoutMutation,
+  useRegisterMutation,
+} from "@/features/auth/hooks/use-auth-mutations";
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+import type { AuthSession } from "@/features/auth/contracts";
 import { authService } from "@/features/auth/services/auth-service";
 import { useSessionStore } from "@/core/session/session-store";
 
 const mockCreateApiMutation = jest.fn();
+const mockAnalyticsClient: jest.Mocked<AnalyticsClient> = {
+  capture: jest.fn(),
+  identify: jest.fn(),
+  reset: jest.fn(),
+};
 
 jest.mock("@/core/query/create-api-mutation", () => ({
   createApiMutation: (...args: readonly unknown[]) => mockCreateApiMutation(...args),
+}));
+
+jest.mock("@/core/observability/use-analytics", () => ({
+  useAnalytics: () => mockAnalyticsClient,
 }));
 
 jest.mock("@/core/session/session-store", () => ({
@@ -14,7 +29,9 @@ jest.mock("@/core/session/session-store", () => ({
 
 jest.mock("@/features/auth/services/auth-service", () => ({
   authService: {
+    login: jest.fn(),
     logout: jest.fn(),
+    register: jest.fn(),
   },
 }));
 
@@ -29,6 +46,89 @@ describe("useAuthMutations", () => {
         mutationFn,
         ...(options ?? {}),
       }),
+    );
+  });
+
+  it("identifica usuario e captura login sem enviar email bruto", async () => {
+    const signIn = jest.fn().mockResolvedValue(undefined);
+    mockedUseSessionStore.mockReturnValue(signIn as never);
+    const session: AuthSession = {
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      user: {
+        id: "user-123",
+        name: "Person",
+        email: "person@example.com",
+        emailConfirmed: true,
+      },
+    };
+
+    const mutation = useLoginMutation() as unknown as {
+      onSuccess: (session: AuthSession) => Promise<void>;
+    };
+
+    await mutation.onSuccess(session);
+
+    expect(signIn).toHaveBeenCalledWith({
+      accessToken: "access-token",
+      refreshToken: "refresh-token",
+      user: {
+        id: "user-123",
+        name: "Person",
+        email: "person@example.com",
+        emailConfirmed: true,
+      },
+    });
+    expect(mockAnalyticsClient.identify).toHaveBeenCalledWith("user-123", {
+      emailConfirmed: true,
+    });
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
+      "auth.login.success",
+      {
+        method: "password",
+        emailConfirmed: true,
+      },
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      "person@example.com",
+    );
+    expect(JSON.stringify(mockAnalyticsClient.identify.mock.calls)).not.toContain(
+      "person@example.com",
+    );
+  });
+
+  it("captura cadastro concluido sem enviar email bruto", async () => {
+    const mutation = useRegisterMutation() as unknown as {
+      onSuccess: (
+        data: unknown,
+        variables: {
+          readonly name: string;
+          readonly email: string;
+          readonly password: string;
+        },
+      ) => void;
+    };
+
+    mutation.onSuccess(
+      { accepted: true, message: "ok" },
+      {
+        name: "Person",
+        email: "person@example.com",
+        password: "secret-password",
+      },
+    );
+
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
+      "auth.register.completed",
+      {
+        emailConfirmed: false,
+      },
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      "person@example.com",
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      "secret-password",
     );
   });
 
@@ -53,6 +153,13 @@ describe("useAuthMutations", () => {
 
     await mutation.onSettled(undefined, new Error("fail"), undefined, undefined);
 
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith("auth.logout", {
+      reason: "manual",
+    });
+    expect(mockAnalyticsClient.reset).toHaveBeenCalledTimes(1);
+    expect(
+      mockAnalyticsClient.capture.mock.invocationCallOrder[0],
+    ).toBeLessThan(mockAnalyticsClient.reset.mock.invocationCallOrder[0] ?? 0);
     expect(signOut).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/auth/hooks/use-auth-mutations.ts
+++ b/features/auth/hooks/use-auth-mutations.ts
@@ -1,4 +1,5 @@
 import { createApiMutation } from "@/core/query/create-api-mutation";
+import { useAnalytics } from "@/core/observability/use-analytics";
 import { useSessionStore } from "@/core/session/session-store";
 import type {
   AuthActionResult,
@@ -12,6 +13,7 @@ import type {
 import { authService } from "@/features/auth/services/auth-service";
 
 export const useLoginMutation = () => {
+  const analytics = useAnalytics();
   const signIn = useSessionStore((state) => state.signIn);
 
   return createApiMutation<AuthSession, LoginCommand>(authService.login, {
@@ -26,23 +28,44 @@ export const useLoginMutation = () => {
           emailConfirmed: session.user.emailConfirmed,
         },
       });
+      analytics.identify(session.user.id, {
+        emailConfirmed: session.user.emailConfirmed,
+      });
+      analytics.capture("auth.login.success", {
+        method: "password",
+        emailConfirmed: session.user.emailConfirmed,
+      });
     },
   });
 };
 
 export const useLogoutMutation = () => {
+  const analytics = useAnalytics();
   const signOut = useSessionStore((state) => state.signOut);
 
   return createApiMutation<void, void>(() => authService.logout(), {
     onSettled: async () => {
+      analytics.capture("auth.logout", {
+        reason: "manual",
+      });
+      analytics.reset();
       await signOut();
     },
   });
 };
 
 export const useRegisterMutation = () => {
+  const analytics = useAnalytics();
+
   return createApiMutation<AuthActionResult, RegisterCommand>(
     authService.register,
+    {
+      onSuccess: () => {
+        analytics.capture("auth.register.completed", {
+          emailConfirmed: false,
+        });
+      },
+    },
   );
 };
 


### PR DESCRIPTION
## Summary

- Tracks `auth.login.success` after successful login and identifies the user by stable user id.
- Tracks `auth.register.completed` after successful registration without sending raw email/password as analytics properties.
- Tracks `auth.logout` before resetting the analytics provider during logout.
- Expands auth mutation hook tests around analytics calls and PII avoidance.

## Screenshots

Not applicable. This PR only changes auth hook instrumentation and tests.

## Validation

- `npm test -- features/auth/hooks/use-auth-mutations.test.ts --runInBand`
- `npm run lint`
- `npm run typecheck`
- `npm run quality-check`
- `git push -u origin feat/410-auth-analytics` pre-push checks

Part of #305.
Closes #410