### PR TITLE
feat: add csv xlsx import flow

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -14,6 +14,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -33,9 +34,9 @@ jobs:
         id: claude
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+          github_token: ${{ github.token }}
           max_turns: "40"
-          prompt: |
+          direct_prompt: |
             You are the autonomous frontend implementation agent for Auraxis App — a personal
             finance mobile application built with React Native, Expo, TypeScript strict,
             npm, and jest-expo.

--- a/.github/workflows/agent-qa.yml
+++ b/.github/workflows/agent-qa.yml
@@ -14,6 +14,7 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
+      id-token: write
 
     steps:
       - uses: actions/checkout@v4
@@ -23,9 +24,9 @@ jobs:
       - uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          github_token: ${{ secrets.TOKEN_GITHUB_ADMIN }}
+          github_token: ${{ github.token }}
           max_turns: "20"
-          prompt: |
+          direct_prompt: |
             You are the QA agent for Auraxis — a personal finance platform built with
             Python 3.13, Flask, SQLAlchemy, Graphene 3 (GraphQL), and PostgreSQL.
 

--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -17,6 +17,7 @@ const HIDDEN_TAB_NAMES: readonly string[] = [
   "confirm-email-pending",
   "compartilhamentos",
   "transacoes",
+  "importar-transacoes",
   "perfil",
   "fiscal",
   "questionario",

--- a/app/(private)/importar-transacoes.tsx
+++ b/app/(private)/importar-transacoes.tsx
@@ -1,0 +1,1 @@
+export { ImportScreen as default } from "@/features/import/screens/import-screen";

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -31,6 +31,16 @@
       "repositories": ["auraxis-app", "auraxis-web", "auraxis-api"]
     },
     {
+      "key": "app.import.csv-xlsx",
+      "owner": "platform",
+      "createdAt": "2026-05-17",
+      "removeBy": "2026-12-31",
+      "type": "release",
+      "status": "enabled-dev",
+      "description": "Controla o fluxo mobile de importacao CSV/XLSX com mapeamento, preview e confirmacao.",
+      "repositories": ["auraxis-app", "auraxis-api-v2", "auraxis-web"]
+    },
+    {
       "key": "app.notifications.push",
       "owner": "platform",
       "createdAt": "2026-05-17",

--- a/contracts/known-openapi-gaps.json
+++ b/contracts/known-openapi-gaps.json
@@ -40,6 +40,9 @@
     "PUT /credit-cards/{credit_card_id}",
     "DELETE /credit-cards/{credit_card_id}",
     "GET /v1/insights/latest",
-    "POST /v1/insights/{insight_id}/read"
+    "POST /v1/insights/{insight_id}/read",
+    "POST /v2/import/detect",
+    "POST /v2/import/preview",
+    "POST /v2/import/confirm"
   ]
 }

--- a/core/navigation/routes.ts
+++ b/core/navigation/routes.ts
@@ -33,6 +33,7 @@ export const appRoutes = {
     confirmEmailPending: "/confirm-email-pending",
     sharedEntries: "/compartilhamentos",
     transactions: "/transacoes",
+    importTransactions: "/importar-transacoes",
     profile: "/perfil",
     fiscal: "/fiscal",
     questionnaire: "/questionario",
@@ -246,6 +247,13 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
   {
     key: "transactions",
     path: appRoutes.private.transactions,
+    access: "private",
+    tabVisible: false,
+    supportsHostedCheckoutReturn: false,
+  },
+  {
+    key: "importTransactions",
+    path: appRoutes.private.importTransactions,
     access: "private",
     tabVisible: false,
     supportsHostedCheckoutReturn: false,

--- a/core/query/query-keys.ts
+++ b/core/query/query-keys.ts
@@ -11,6 +11,10 @@ export const queryKeys = {
     root: ["insights"] as const,
     latest: () => ["insights", "latest"] as const,
   },
+  import: {
+    root: ["import"] as const,
+    preview: () => ["import", "preview"] as const,
+  },
   transactions: {
     root: ["transactions"] as const,
     list: () => ["transactions", "list"] as const,

--- a/features/import/contracts.ts
+++ b/features/import/contracts.ts
@@ -1,0 +1,83 @@
+export type ImportFileType = "csv" | "xlsx";
+export type ImportTransactionType = "income" | "expense";
+
+export interface ImportFileAsset {
+  readonly uri: string;
+  readonly name: string;
+  readonly mimeType: string;
+  readonly size?: number | null;
+}
+
+export interface ImportColumnMapping {
+  readonly dateColumn: string;
+  readonly descriptionColumn: string;
+  readonly amountColumn: string;
+  readonly typeColumn: string;
+  readonly sheetName?: string | null;
+}
+
+export interface ImportConfidence {
+  readonly dateColumn: number;
+  readonly descriptionColumn: number;
+  readonly amountColumn: number;
+  readonly typeColumn: number;
+}
+
+export interface ImportDetectResult {
+  readonly fileType: ImportFileType;
+  readonly sheetNames: readonly string[];
+  readonly activeSheet: string | null;
+  readonly headers: readonly string[];
+  readonly sampleRows: readonly (readonly string[])[];
+  readonly suggestedMapping: ImportColumnMapping;
+  readonly confidence: ImportConfidence;
+}
+
+export interface ImportPreviewCommand {
+  readonly file: ImportFileAsset;
+  readonly mapping: ImportColumnMapping;
+}
+
+export interface ImportTransactionDraft {
+  readonly id: string;
+  readonly date: string;
+  readonly description: string;
+  readonly amount: string;
+  readonly type: ImportTransactionType;
+  readonly category: string | null;
+  readonly confidence: number | null;
+  readonly isDuplicate: boolean;
+}
+
+export interface ImportPreview {
+  readonly previewToken: string;
+  readonly expiresAt: string;
+  readonly fileType: ImportFileType;
+  readonly totalCount: number;
+  readonly duplicatesCount: number;
+  readonly transactions: readonly ImportTransactionDraft[];
+}
+
+export interface ConfirmImportCommand {
+  readonly previewToken: string;
+  readonly excludeIds: readonly string[];
+}
+
+export interface ConfirmImportResult {
+  readonly importedCount: number;
+  readonly skippedCount: number;
+}
+
+export type ImportMappingFieldKey =
+  | "dateColumn"
+  | "descriptionColumn"
+  | "amountColumn"
+  | "typeColumn";
+
+export interface ImportMappingFieldViewModel {
+  readonly key: ImportMappingFieldKey;
+  readonly label: string;
+  readonly value: string;
+  readonly confidence: number;
+  readonly sampleValues: readonly string[];
+}

--- a/features/import/hooks/use-import-mutations.ts
+++ b/features/import/hooks/use-import-mutations.ts
@@ -1,0 +1,42 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import { createApiMutation } from "@/core/query/create-api-mutation";
+import { queryKeys } from "@/core/query/query-keys";
+import type {
+  ConfirmImportCommand,
+  ConfirmImportResult,
+  ImportDetectResult,
+  ImportFileAsset,
+  ImportPreview,
+  ImportPreviewCommand,
+} from "@/features/import/contracts";
+import { importService } from "@/features/import/services/import-service";
+
+export const useDetectImportMutation = () => {
+  return createApiMutation<ImportDetectResult, ImportFileAsset>((file) =>
+    importService.detectFile(file),
+  );
+};
+
+export const usePreviewImportMutation = () => {
+  return createApiMutation<ImportPreview, ImportPreviewCommand>((command) =>
+    importService.previewFile(command),
+  );
+};
+
+export const useConfirmImportMutation = () => {
+  const queryClient = useQueryClient();
+
+  return createApiMutation<ConfirmImportResult, ConfirmImportCommand>(
+    (command) => importService.confirmImport(command),
+    {
+      onSuccess: async () => {
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.root }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.import.root }),
+        ]);
+      },
+    },
+  );
+};

--- a/features/import/hooks/use-import-screen-controller.test.tsx
+++ b/features/import/hooks/use-import-screen-controller.test.tsx
@@ -1,0 +1,198 @@
+import { act, renderHook } from "@testing-library/react-native";
+import * as DocumentPicker from "expo-document-picker";
+
+import type {
+  ImportDetectResult,
+  ImportPreview,
+} from "@/features/import/contracts";
+import {
+  useConfirmImportMutation,
+  useDetectImportMutation,
+  usePreviewImportMutation,
+} from "@/features/import/hooks/use-import-mutations";
+import { useImportScreenController } from "@/features/import/hooks/use-import-screen-controller";
+
+jest.mock("expo-document-picker", () => ({
+  getDocumentAsync: jest.fn(),
+}));
+jest.mock("@/features/import/hooks/use-import-mutations", () => ({
+  useDetectImportMutation: jest.fn(),
+  usePreviewImportMutation: jest.fn(),
+  useConfirmImportMutation: jest.fn(),
+}));
+
+const mockedDocumentPicker = jest.mocked(DocumentPicker.getDocumentAsync);
+const mockedUseDetect = jest.mocked(useDetectImportMutation);
+const mockedUsePreview = jest.mocked(usePreviewImportMutation);
+const mockedUseConfirm = jest.mocked(useConfirmImportMutation);
+
+const detectResult: ImportDetectResult = {
+  fileType: "csv",
+  sheetNames: ["Janeiro"],
+  activeSheet: "Janeiro",
+  headers: ["Data", "Descricao", "Valor", "Tipo"],
+  sampleRows: [
+    ["2026-05-01", "Uber", "25,50", "saida"],
+    ["2026-05-02", "Salario", "5000,00", "entrada"],
+  ],
+  suggestedMapping: {
+    dateColumn: "Data",
+    descriptionColumn: "Descricao",
+    amountColumn: "Valor",
+    typeColumn: "Tipo",
+    sheetName: "Janeiro",
+  },
+  confidence: {
+    dateColumn: 0.95,
+    descriptionColumn: 0.65,
+    amountColumn: 0.9,
+    typeColumn: 0.6,
+  },
+};
+
+const preview: ImportPreview = {
+  previewToken: "preview-1",
+  expiresAt: "2026-05-17T14:00:00Z",
+  fileType: "csv",
+  totalCount: 2,
+  duplicatesCount: 1,
+  transactions: [
+    {
+      id: "draft-1",
+      date: "2026-05-01",
+      description: "Uber",
+      amount: "25.50",
+      type: "expense",
+      category: "transporte",
+      confidence: 0.92,
+      isDuplicate: false,
+    },
+    {
+      id: "draft-2",
+      date: "2026-05-02",
+      description: "Salario",
+      amount: "5000.00",
+      type: "income",
+      category: "receita",
+      confidence: null,
+      isDuplicate: true,
+    },
+  ],
+};
+
+const buildMutation = <TData, TVariables>(resolvedValue: TData) => ({
+  mutateAsync: jest.fn<Promise<TData>, [TVariables]>().mockResolvedValue(resolvedValue),
+  reset: jest.fn(),
+  isPending: false,
+});
+
+describe("useImportScreenController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedDocumentPicker.mockResolvedValue({
+      canceled: false,
+      assets: [
+        {
+          uri: "file:///cache/extrato.csv",
+          name: "extrato.csv",
+          mimeType: "text/csv",
+          size: 1024,
+          lastModified: 0,
+        },
+      ],
+    });
+    mockedUseDetect.mockReturnValue(buildMutation(detectResult) as never);
+    mockedUsePreview.mockReturnValue(buildMutation(preview) as never);
+    mockedUseConfirm.mockReturnValue(
+      buildMutation({ importedCount: 1, skippedCount: 1 }) as never,
+    );
+  });
+
+  it("inicia na fase de selecao", () => {
+    const { result } = renderHook(() => useImportScreenController());
+    expect(result.current.phase).toBe("select");
+    expect(result.current.file).toBeNull();
+  });
+
+  it("seleciona arquivo nativo, detecta colunas e abre mapping para campos incertos", async () => {
+    const { result } = renderHook(() => useImportScreenController());
+
+    await act(async () => {
+      await result.current.handlePickFile();
+    });
+
+    expect(mockedDocumentPicker).toHaveBeenCalledWith(
+      expect.objectContaining({
+        copyToCacheDirectory: true,
+        multiple: false,
+      }),
+    );
+    expect(result.current.phase).toBe("mapping");
+    expect(result.current.mappingFields.map((field) => field.key)).toEqual([
+      "descriptionColumn",
+      "typeColumn",
+    ]);
+    expect(result.current.currentMappingField?.sampleValues).toEqual([
+      "Uber",
+      "Salario",
+    ]);
+  });
+
+  it("pula mapeamento e gera preview quando deteccao vem com alta confianca", async () => {
+    const highConfidenceDetectResult: ImportDetectResult = {
+      ...detectResult,
+      confidence: {
+        dateColumn: 0.95,
+        descriptionColumn: 0.95,
+        amountColumn: 0.95,
+        typeColumn: 0.95,
+      },
+    };
+    const previewMutation = buildMutation(preview);
+    mockedUseDetect.mockReturnValue(buildMutation(highConfidenceDetectResult) as never);
+    mockedUsePreview.mockReturnValue(previewMutation as never);
+    const { result } = renderHook(() => useImportScreenController());
+
+    await act(async () => {
+      await result.current.handlePickFile();
+    });
+
+    expect(previewMutation.mutateAsync).toHaveBeenCalledWith({
+      file: expect.objectContaining({ name: "extrato.csv" }),
+      mapping: highConfidenceDetectResult.suggestedMapping,
+    });
+    expect(result.current.phase).toBe("preview");
+    expect(result.current.selectedImportCount).toBe(1);
+  });
+
+  it("gera preview, deixa duplicatas desmarcadas e confirma apenas selecionadas", async () => {
+    const { result } = renderHook(() => useImportScreenController());
+
+    await act(async () => {
+      await result.current.handlePickFile();
+    });
+    await act(async () => {
+      await result.current.handleConfirmMapping();
+    });
+
+    expect(result.current.phase).toBe("preview");
+    expect(result.current.selectedImportCount).toBe(1);
+    expect(result.current.isTransactionSelected("draft-1")).toBe(true);
+    expect(result.current.isTransactionSelected("draft-2")).toBe(false);
+
+    await act(async () => {
+      await result.current.handleConfirmImport();
+    });
+
+    const confirmMutation = mockedUseConfirm.mock.results[0]?.value;
+    expect(confirmMutation.mutateAsync).toHaveBeenCalledWith({
+      previewToken: "preview-1",
+      excludeIds: ["draft-2"],
+    });
+    expect(result.current.phase).toBe("success");
+    expect(result.current.confirmationResult).toEqual({
+      importedCount: 1,
+      skippedCount: 1,
+    });
+  });
+});

--- a/features/import/hooks/use-import-screen-controller.ts
+++ b/features/import/hooks/use-import-screen-controller.ts
@@ -1,0 +1,303 @@
+import { useMemo, useState } from "react";
+import * as DocumentPicker from "expo-document-picker";
+
+import type {
+  ConfirmImportResult,
+  ImportColumnMapping,
+  ImportDetectResult,
+  ImportFileAsset,
+  ImportMappingFieldKey,
+  ImportMappingFieldViewModel,
+  ImportPreview,
+} from "@/features/import/contracts";
+import {
+  IMPORT_CONFIDENCE_THRESHOLD,
+  IMPORT_SUPPORTED_MIME_TYPES,
+} from "@/features/import/import-config";
+import {
+  useConfirmImportMutation,
+  useDetectImportMutation,
+  usePreviewImportMutation,
+} from "@/features/import/hooks/use-import-mutations";
+
+export type ImportScreenPhase = "select" | "mapping" | "preview" | "success";
+
+export interface ImportScreenController {
+  readonly phase: ImportScreenPhase;
+  readonly file: ImportFileAsset | null;
+  readonly detectResult: ImportDetectResult | null;
+  readonly preview: ImportPreview | null;
+  readonly currentMappingIndex: number;
+  readonly currentMappingField: ImportMappingFieldViewModel | null;
+  readonly mappingFields: readonly ImportMappingFieldViewModel[];
+  readonly selectedImportCount: number;
+  readonly totalPreviewCount: number;
+  readonly duplicateCount: number;
+  readonly confirmationResult: ConfirmImportResult | null;
+  readonly error: unknown | null;
+  readonly isBusy: boolean;
+  readonly handlePickFile: () => Promise<void>;
+  readonly handleCancelMapping: () => void;
+  readonly handlePreviousMappingField: () => void;
+  readonly handleNextMappingField: () => void;
+  readonly handleMappingChange: (field: ImportMappingFieldKey, value: string) => void;
+  readonly handleConfirmMapping: () => Promise<void>;
+  readonly handleToggleTransaction: (transactionId: string) => void;
+  readonly handleConfirmImport: () => Promise<void>;
+  readonly handleReset: () => void;
+  readonly dismissError: () => void;
+  readonly isTransactionSelected: (transactionId: string) => boolean;
+}
+
+const FIELD_LABELS: Record<ImportMappingFieldKey, string> = {
+  dateColumn: "Coluna de Data",
+  descriptionColumn: "Coluna de Descricao",
+  amountColumn: "Coluna de Valor",
+  typeColumn: "Coluna de Tipo",
+};
+
+const FIELD_ORDER: readonly ImportMappingFieldKey[] = [
+  "dateColumn",
+  "descriptionColumn",
+  "amountColumn",
+  "typeColumn",
+];
+
+const emptyMapping: ImportColumnMapping = {
+  dateColumn: "",
+  descriptionColumn: "",
+  amountColumn: "",
+  typeColumn: "",
+  sheetName: null,
+};
+
+const toAsset = (asset: DocumentPicker.DocumentPickerAsset): ImportFileAsset => ({
+  uri: asset.uri,
+  name: asset.name,
+  mimeType: asset.mimeType ?? resolveMimeTypeFromName(asset.name),
+  size: asset.size ?? null,
+});
+
+const resolveMimeTypeFromName = (name: string): string => {
+  const normalized = name.trim().toLowerCase();
+  if (normalized.endsWith(".xlsx")) {
+    return "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+  }
+  return "text/csv";
+};
+
+const shouldShowMappingField = (
+  detectResult: ImportDetectResult,
+  mapping: ImportColumnMapping,
+  field: ImportMappingFieldKey,
+): boolean => {
+  return (
+    detectResult.confidence[field] < IMPORT_CONFIDENCE_THRESHOLD ||
+    mapping[field].trim().length === 0
+  );
+};
+
+const fieldsRequiringMapping = (
+  detectResult: ImportDetectResult,
+  mapping: ImportColumnMapping,
+): readonly ImportMappingFieldKey[] => {
+  return FIELD_ORDER.filter((field) =>
+    shouldShowMappingField(detectResult, mapping, field),
+  );
+};
+
+const sampleValuesForField = (
+  detectResult: ImportDetectResult,
+  columnName: string,
+): readonly string[] => {
+  const columnIndex = detectResult.headers.findIndex((header) => header === columnName);
+  if (columnIndex < 0) {
+    return [];
+  }
+  return detectResult.sampleRows
+    .map((row) => String(row[columnIndex] ?? ""))
+    .filter((value) => value.trim().length > 0)
+    .slice(0, 3);
+};
+
+const buildMappingFields = (
+  detectResult: ImportDetectResult | null,
+  mapping: ImportColumnMapping,
+): readonly ImportMappingFieldViewModel[] => {
+  if (!detectResult) {
+    return [];
+  }
+  const fields = fieldsRequiringMapping(detectResult, mapping);
+
+  return fields.map((field) => ({
+    key: field,
+    label: FIELD_LABELS[field],
+    value: mapping[field],
+    confidence: detectResult.confidence[field],
+    sampleValues: sampleValuesForField(detectResult, mapping[field]),
+  }));
+};
+
+// eslint-disable-next-line max-lines-per-function, max-statements
+export function useImportScreenController(): ImportScreenController {
+  const detectMutation = useDetectImportMutation();
+  const previewMutation = usePreviewImportMutation();
+  const confirmMutation = useConfirmImportMutation();
+  const [phase, setPhase] = useState<ImportScreenPhase>("select");
+  const [file, setFile] = useState<ImportFileAsset | null>(null);
+  const [detectResult, setDetectResult] = useState<ImportDetectResult | null>(null);
+  const [mapping, setMapping] = useState<ImportColumnMapping>(emptyMapping);
+  const [preview, setPreview] = useState<ImportPreview | null>(null);
+  const [selectedIds, setSelectedIds] = useState<ReadonlySet<string>>(new Set());
+  const [currentMappingIndex, setCurrentMappingIndex] = useState<number>(0);
+  const [confirmationResult, setConfirmationResult] =
+    useState<ConfirmImportResult | null>(null);
+  const [error, setError] = useState<unknown | null>(null);
+
+  const mappingFields = useMemo(
+    () => buildMappingFields(detectResult, mapping),
+    [detectResult, mapping],
+  );
+  const currentMappingField = mappingFields[currentMappingIndex] ?? null;
+  const totalPreviewCount = preview?.transactions.length ?? 0;
+  const duplicateCount = preview?.duplicatesCount ?? 0;
+
+  const handlePickFile = async (): Promise<void> => {
+    setError(null);
+    const result = await DocumentPicker.getDocumentAsync({
+      type: [...IMPORT_SUPPORTED_MIME_TYPES],
+      copyToCacheDirectory: true,
+      multiple: false,
+    });
+    if (result.canceled || !result.assets[0]) {
+      return;
+    }
+
+    const selectedFile = toAsset(result.assets[0]);
+    setFile(selectedFile);
+    try {
+      const detected = await detectMutation.mutateAsync(selectedFile);
+      const nextMapping = detected.suggestedMapping;
+      setDetectResult(detected);
+      setMapping(nextMapping);
+      setCurrentMappingIndex(0);
+      if (fieldsRequiringMapping(detected, nextMapping).length > 0) {
+        setPhase("mapping");
+        return;
+      }
+      await generatePreview(selectedFile, nextMapping);
+    } catch (caughtError) {
+      setError(caughtError);
+    }
+  };
+
+  const generatePreview = async (
+    selectedFile: ImportFileAsset | null,
+    selectedMapping: ImportColumnMapping,
+  ): Promise<void> => {
+    if (!selectedFile) {
+      return;
+    }
+    setError(null);
+    try {
+      const nextPreview = await previewMutation.mutateAsync({
+        file: selectedFile,
+        mapping: selectedMapping,
+      });
+      setPreview(nextPreview);
+      setSelectedIds(
+        new Set(
+          nextPreview.transactions
+            .filter((transaction) => !transaction.isDuplicate)
+            .map((transaction) => transaction.id),
+        ),
+      );
+      setPhase("preview");
+    } catch (caughtError) {
+      setError(caughtError);
+    }
+  };
+
+  const handleConfirmMapping = async (): Promise<void> => {
+    await generatePreview(file, mapping);
+  };
+
+  const handleConfirmImport = async (): Promise<void> => {
+    if (!preview) {
+      return;
+    }
+    setError(null);
+    const excludeIds = preview.transactions
+      .filter((transaction) => !selectedIds.has(transaction.id))
+      .map((transaction) => transaction.id);
+    try {
+      const result = await confirmMutation.mutateAsync({
+        previewToken: preview.previewToken,
+        excludeIds,
+      });
+      setConfirmationResult(result);
+      setPhase("success");
+    } catch (caughtError) {
+      setError(caughtError);
+    }
+  };
+
+  return {
+    phase,
+    file,
+    detectResult,
+    preview,
+    currentMappingIndex,
+    currentMappingField,
+    mappingFields,
+    selectedImportCount: selectedIds.size,
+    totalPreviewCount,
+    duplicateCount,
+    confirmationResult,
+    error,
+    isBusy:
+      detectMutation.isPending || previewMutation.isPending || confirmMutation.isPending,
+    handlePickFile,
+    handleCancelMapping: () => setPhase("select"),
+    handlePreviousMappingField: () => {
+      setCurrentMappingIndex((index) => Math.max(0, index - 1));
+    },
+    handleNextMappingField: () => {
+      setCurrentMappingIndex((index) =>
+        Math.min(mappingFields.length - 1, index + 1),
+      );
+    },
+    handleMappingChange: (field, value) => {
+      setMapping((current) => ({ ...current, [field]: value }));
+    },
+    handleConfirmMapping,
+    handleToggleTransaction: (transactionId) => {
+      setSelectedIds((current) => {
+        const next = new Set(current);
+        if (next.has(transactionId)) {
+          next.delete(transactionId);
+        } else {
+          next.add(transactionId);
+        }
+        return next;
+      });
+    },
+    handleConfirmImport,
+    handleReset: () => {
+      setPhase("select");
+      setFile(null);
+      setDetectResult(null);
+      setMapping(emptyMapping);
+      setPreview(null);
+      setSelectedIds(new Set());
+      setCurrentMappingIndex(0);
+      setConfirmationResult(null);
+      setError(null);
+      detectMutation.reset();
+      previewMutation.reset();
+      confirmMutation.reset();
+    },
+    dismissError: () => setError(null),
+    isTransactionSelected: (transactionId) => selectedIds.has(transactionId),
+  };
+}

--- a/features/import/import-config.ts
+++ b/features/import/import-config.ts
@@ -1,0 +1,10 @@
+export const IMPORT_FEATURE_FLAG_KEY = "app.import.csv-xlsx";
+
+export const IMPORT_SUPPORTED_MIME_TYPES = [
+  "text/csv",
+  "text/comma-separated-values",
+  "application/vnd.ms-excel",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+] as const;
+
+export const IMPORT_CONFIDENCE_THRESHOLD = 0.7;

--- a/features/import/mocks.ts
+++ b/features/import/mocks.ts
@@ -1,0 +1,75 @@
+import type {
+  ConfirmImportResult,
+  ImportDetectResult,
+  ImportPreview,
+} from "@/features/import/contracts";
+
+export const importDetectFixture: ImportDetectResult = {
+  fileType: "csv",
+  sheetNames: ["Janeiro"],
+  activeSheet: "Janeiro",
+  headers: ["Data", "Descricao", "Valor", "Tipo"],
+  sampleRows: [
+    ["2026-05-01", "Uber", "25,50", "saida"],
+    ["2026-05-02", "Salario", "5000,00", "entrada"],
+    ["2026-05-03", "Mercado", "180,30", "saida"],
+  ],
+  suggestedMapping: {
+    dateColumn: "Data",
+    descriptionColumn: "Descricao",
+    amountColumn: "Valor",
+    typeColumn: "Tipo",
+    sheetName: "Janeiro",
+  },
+  confidence: {
+    dateColumn: 0.95,
+    descriptionColumn: 0.65,
+    amountColumn: 0.9,
+    typeColumn: 0.62,
+  },
+};
+
+export const importPreviewFixture: ImportPreview = {
+  previewToken: "preview-token-1",
+  expiresAt: "2026-05-17T14:00:00Z",
+  fileType: "csv",
+  totalCount: 3,
+  duplicatesCount: 1,
+  transactions: [
+    {
+      id: "draft-1",
+      date: "2026-05-01",
+      description: "Uber",
+      amount: "25.50",
+      type: "expense",
+      category: "transporte",
+      confidence: 0.92,
+      isDuplicate: false,
+    },
+    {
+      id: "draft-2",
+      date: "2026-05-02",
+      description: "Salario",
+      amount: "5000.00",
+      type: "income",
+      category: "receita",
+      confidence: 0.88,
+      isDuplicate: true,
+    },
+    {
+      id: "draft-3",
+      date: "2026-05-03",
+      description: "Mercado",
+      amount: "180.30",
+      type: "expense",
+      category: "alimentacao",
+      confidence: 0.78,
+      isDuplicate: false,
+    },
+  ],
+};
+
+export const confirmImportFixture: ConfirmImportResult = {
+  importedCount: 2,
+  skippedCount: 1,
+};

--- a/features/import/screens/import-screen.test.tsx
+++ b/features/import/screens/import-screen.test.tsx
@@ -1,0 +1,203 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { ApiError } from "@/core/http/api-error";
+import { AppProviders } from "@/core/providers/app-providers";
+import { useImportScreenController } from "@/features/import/hooks/use-import-screen-controller";
+import { ImportScreen } from "@/features/import/screens/import-screen";
+
+jest.mock("@/features/import/hooks/use-import-screen-controller", () => ({
+  useImportScreenController: jest.fn(),
+}));
+
+const mockedUseController = jest.mocked(useImportScreenController);
+
+const buildController = (
+  overrides: Partial<ReturnType<typeof useImportScreenController>> = {},
+) =>
+  ({
+    phase: "select",
+    file: null,
+    detectResult: null,
+    preview: null,
+    currentMappingIndex: 0,
+    currentMappingField: null,
+    mappingFields: [],
+    selectedImportCount: 0,
+    totalPreviewCount: 0,
+    duplicateCount: 0,
+    confirmationResult: null,
+    error: null,
+    isBusy: false,
+    handlePickFile: jest.fn(),
+    handleCancelMapping: jest.fn(),
+    handlePreviousMappingField: jest.fn(),
+    handleNextMappingField: jest.fn(),
+    handleMappingChange: jest.fn(),
+    handleConfirmMapping: jest.fn(),
+    handleToggleTransaction: jest.fn(),
+    handleConfirmImport: jest.fn(),
+    handleReset: jest.fn(),
+    dismissError: jest.fn(),
+    isTransactionSelected: jest.fn().mockReturnValue(true),
+    ...overrides,
+  }) as ReturnType<typeof useImportScreenController>;
+
+const renderScreen = (
+  controller: ReturnType<typeof buildController>,
+): ReturnType<typeof render> => {
+  mockedUseController.mockReturnValue(controller);
+  return render(
+    <AppProviders>
+      <ImportScreen />
+    </AppProviders>,
+  );
+};
+
+describe("ImportScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("renderiza selecao de arquivo e chama handlePickFile", () => {
+    const controller = buildController();
+    const { getByText } = renderScreen(controller);
+
+    fireEvent.press(getByText("Selecionar planilha"));
+
+    expect(controller.handlePickFile).toHaveBeenCalled();
+  });
+
+  it("renderiza step de mapeamento com progresso e preview da coluna", () => {
+    const controller = buildController({
+      phase: "mapping",
+      file: {
+        uri: "file:///cache/extrato.csv",
+        name: "extrato.csv",
+        mimeType: "text/csv",
+      },
+      detectResult: {
+        fileType: "csv",
+        sheetNames: ["Janeiro"],
+        activeSheet: "Janeiro",
+        headers: ["Data", "Descricao", "Valor", "Tipo"],
+        sampleRows: [["2026-05-01", "Uber", "25,50", "saida"]],
+        suggestedMapping: {
+          dateColumn: "Data",
+          descriptionColumn: "Descricao",
+          amountColumn: "Valor",
+          typeColumn: "Tipo",
+          sheetName: "Janeiro",
+        },
+        confidence: {
+          dateColumn: 0.95,
+          descriptionColumn: 0.65,
+          amountColumn: 0.9,
+          typeColumn: 0.8,
+        },
+      },
+      currentMappingIndex: 0,
+      mappingFields: [
+        {
+          key: "descriptionColumn",
+          label: "Coluna de Descricao",
+          value: "Descricao",
+          confidence: 0.65,
+          sampleValues: ["Uber", "Salario"],
+        },
+      ],
+      currentMappingField: {
+        key: "descriptionColumn",
+        label: "Coluna de Descricao",
+        value: "Descricao",
+        confidence: 0.65,
+        sampleValues: ["Uber", "Salario"],
+      },
+    });
+
+    const { getAllByText, getByText } = renderScreen(controller);
+
+    expect(getAllByText("Passo 1 de 1").length).toBeGreaterThan(0);
+    expect(getByText("Coluna de Descricao")).toBeTruthy();
+    expect(getByText(/Uber/)).toBeTruthy();
+  });
+
+  it("renderiza preview com banner de duplicatas e contador dinamico", () => {
+    const controller = buildController({
+      phase: "preview",
+      duplicateCount: 1,
+      selectedImportCount: 1,
+      totalPreviewCount: 2,
+      preview: {
+        previewToken: "preview-1",
+        expiresAt: "2026-05-17T14:00:00Z",
+        fileType: "csv",
+        totalCount: 2,
+        duplicatesCount: 1,
+        transactions: [
+          {
+            id: "draft-1",
+            date: "2026-05-01",
+            description: "Uber",
+            amount: "25.50",
+            type: "expense",
+            category: "transporte",
+            confidence: 0.92,
+            isDuplicate: false,
+          },
+          {
+            id: "draft-2",
+            date: "2026-05-02",
+            description: "Salario",
+            amount: "5000.00",
+            type: "income",
+            category: "receita",
+            confidence: null,
+            isDuplicate: true,
+          },
+        ],
+      },
+      isTransactionSelected: jest.fn((transactionId: string) => transactionId === "draft-1"),
+    });
+
+    const { getAllByText, getByText, getByTestId } = renderScreen(controller);
+
+    expect(getByText("1 possivel duplicata")).toBeTruthy();
+    expect(getAllByText("Importar 1 de 2 transacoes").length).toBeGreaterThan(0);
+    expect(getByText("Possivel duplicata")).toBeTruthy();
+
+    fireEvent.press(getByTestId("import-transaction-toggle-draft-2"));
+    expect(controller.handleToggleTransaction).toHaveBeenCalledWith("draft-2");
+  });
+
+  it("renderiza mensagem clara para preview expirado", () => {
+    const controller = buildController({
+      error: new ApiError({
+        message: "preview expired",
+        status: 422,
+      }),
+    });
+
+    const { getByText } = renderScreen(controller);
+
+    expect(getByText("Preview expirado")).toBeTruthy();
+    fireEvent.press(getByText("Enviar novamente"));
+    expect(controller.handleReset).toHaveBeenCalled();
+  });
+
+  it("renderiza sheet de upgrade quando limite gratuito e atingido", () => {
+    const controller = buildController({
+      error: new ApiError({
+        message: "free import limit reached",
+        status: 429,
+      }),
+    });
+
+    const { getByText } = renderScreen(controller);
+
+    expect(getByText("Limite gratuito atingido")).toBeTruthy();
+    expect(getByText(/3 importacoes gratuitas/)).toBeTruthy();
+
+    fireEvent.press(getByText("Fechar"));
+    expect(controller.dismissError).toHaveBeenCalled();
+  });
+});

--- a/features/import/screens/import-screen.tsx
+++ b/features/import/screens/import-screen.tsx
@@ -1,0 +1,450 @@
+import { useCallback, type ReactElement } from "react";
+
+import { useRouter } from "expo-router";
+import { FlatList, Modal, Pressable } from "react-native";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { createAppErrorState } from "@/core/errors/app-error";
+import { appRoutes } from "@/core/navigation/routes";
+import type {
+  ImportMappingFieldKey,
+  ImportMappingFieldViewModel,
+  ImportTransactionDraft,
+} from "@/features/import/contracts";
+import {
+  useImportScreenController,
+  type ImportScreenController,
+} from "@/features/import/hooks/use-import-screen-controller";
+import { AppBadge } from "@/shared/components/app-badge";
+import { AppButton } from "@/shared/components/app-button";
+import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
+import { AppScreen } from "@/shared/components/app-screen";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { formatShortDate } from "@/shared/utils/formatters";
+
+const listContainerStyle = { paddingBottom: 96 } as const;
+
+const formatAmount = (transaction: ImportTransactionDraft): string => {
+  const prefix = transaction.type === "income" ? "+" : "-";
+  return `${prefix} R$ ${transaction.amount}`;
+};
+
+const transactionKey = (item: ImportTransactionDraft): string => item.id;
+
+function Separator(): ReactElement {
+  return <YStack height="$2" />;
+}
+
+export function ImportScreen(): ReactElement {
+  const controller = useImportScreenController();
+
+  return (
+    <AppScreen scrollable={controller.phase !== "preview"}>
+      <YStack gap="$3" flex={1}>
+        <HeaderCard controller={controller} />
+        <ImportErrorFeedback controller={controller} />
+        {controller.phase === "select" ? <SelectStep controller={controller} /> : null}
+        {controller.phase === "mapping" ? (
+          <MappingSheet controller={controller} />
+        ) : null}
+        {controller.phase === "preview" ? (
+          <PreviewStep controller={controller} />
+        ) : null}
+        {controller.phase === "success" ? (
+          <SuccessStep controller={controller} />
+        ) : null}
+      </YStack>
+    </AppScreen>
+  );
+}
+
+interface ControllerProps {
+  readonly controller: ImportScreenController;
+}
+
+function ImportErrorFeedback({ controller }: ControllerProps): ReactElement | null {
+  if (!controller.error) {
+    return null;
+  }
+
+  const errorState = createAppErrorState(controller.error, {
+    fallbackTitle: "Nao foi possivel importar a planilha",
+    fallbackDescription: "Revise o arquivo e tente novamente.",
+  });
+
+  if (errorState.status === 429) {
+    return <UpgradeLimitSheet onClose={controller.dismissError} />;
+  }
+
+  if (errorState.status === 422) {
+    return (
+      <AppErrorNotice
+        error={controller.error}
+        fallbackTitle="Preview expirado"
+        fallbackDescription="Faca o upload novamente para gerar uma nova previa."
+        actionLabel="Enviar novamente"
+        onAction={controller.handleReset}
+        secondaryActionLabel="Fechar aviso"
+        onSecondaryAction={controller.dismissError}
+      />
+    );
+  }
+
+  return (
+    <AppErrorNotice
+      error={controller.error}
+      fallbackTitle="Nao foi possivel importar a planilha"
+      fallbackDescription="Revise o arquivo e tente novamente."
+      actionLabel="Fechar aviso"
+      onAction={controller.dismissError}
+    />
+  );
+}
+
+interface UpgradeLimitSheetProps {
+  readonly onClose: () => void;
+}
+
+function UpgradeLimitSheet({ onClose }: UpgradeLimitSheetProps): ReactElement {
+  const router = useRouter();
+  const handleUpgrade = useCallback(() => {
+    onClose();
+    router.push(appRoutes.private.subscription);
+  }, [onClose, router]);
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={onClose}>
+      <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
+        <YStack
+          backgroundColor="$background"
+          padding="$4"
+          gap="$3"
+          borderTopLeftRadius="$3"
+          borderTopRightRadius="$3"
+        >
+          <AppSurfaceCard
+            title="Limite gratuito atingido"
+            description="Voce atingiu o limite de 3 importacoes gratuitas. Faca upgrade para importar sem limites."
+          >
+            <YStack gap="$3">
+              <AppButton onPress={handleUpgrade}>Assinar Premium</AppButton>
+              <AppButton tone="secondary" onPress={onClose}>
+                Fechar
+              </AppButton>
+            </YStack>
+          </AppSurfaceCard>
+        </YStack>
+      </YStack>
+    </Modal>
+  );
+}
+
+function HeaderCard({ controller }: ControllerProps): ReactElement {
+  return (
+    <AppSurfaceCard
+      title="Importar planilha"
+      description="Traga transacoes de arquivos CSV ou XLSX com revisao antes de salvar."
+    >
+      <YStack gap="$2">
+        {controller.file ? (
+          <AppKeyValueRow label="Arquivo" value={controller.file.name} />
+        ) : null}
+        <Paragraph color="$mutedColor">
+          O Auraxis detecta colunas, mostra duplicatas e so confirma o que voce
+          mantiver selecionado.
+        </Paragraph>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}
+
+function SelectStep({ controller }: ControllerProps): ReactElement {
+  return (
+    <AppSurfaceCard
+      title="Selecione o arquivo"
+      description="Use um CSV ou XLSX com colunas de data, descricao, valor e tipo."
+    >
+      <YStack gap="$3">
+        <Paragraph color="$mutedColor">
+          Arquivos ficam em cache local durante o fluxo e sao enviados para o
+          backend apenas para detectar, gerar preview e confirmar.
+        </Paragraph>
+        <AppButton
+          onPress={() => {
+            void controller.handlePickFile();
+          }}
+          disabled={controller.isBusy}
+        >
+          {controller.isBusy ? "Detectando colunas..." : "Selecionar planilha"}
+        </AppButton>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}
+
+function MappingSheet({ controller }: ControllerProps): ReactElement {
+  return (
+    <Modal
+      visible
+      transparent
+      animationType="slide"
+      onRequestClose={controller.handleCancelMapping}
+    >
+      <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
+        <YStack
+          backgroundColor="$background"
+          padding="$4"
+          gap="$3"
+          borderTopLeftRadius="$3"
+          borderTopRightRadius="$3"
+        >
+          <MappingStep controller={controller} />
+        </YStack>
+      </YStack>
+    </Modal>
+  );
+}
+
+function MappingStep({ controller }: ControllerProps): ReactElement | null {
+  const field = controller.currentMappingField;
+  if (!field || !controller.detectResult) {
+    return null;
+  }
+
+  const isFirst = controller.currentMappingIndex === 0;
+  const isLast = controller.currentMappingIndex === controller.mappingFields.length - 1;
+
+  return (
+    <AppSurfaceCard
+      title="Mapear colunas"
+      description={`Passo ${controller.currentMappingIndex + 1} de ${
+        controller.mappingFields.length
+      }`}
+    >
+      <YStack gap="$3">
+        <Paragraph fontWeight="700">
+          Passo {controller.currentMappingIndex + 1} de{" "}
+          {controller.mappingFields.length}
+        </Paragraph>
+        <MappingField
+          field={field}
+          headers={controller.detectResult.headers}
+          onChange={controller.handleMappingChange}
+        />
+        <XStack gap="$2">
+          <AppButton
+            flex={1}
+            tone="secondary"
+            onPress={isFirst ? controller.handleCancelMapping : controller.handlePreviousMappingField}
+          >
+            {isFirst ? "Cancelar" : "Voltar"}
+          </AppButton>
+          <AppButton
+            flex={1}
+            onPress={isLast ? () => {
+              void controller.handleConfirmMapping();
+            } : controller.handleNextMappingField}
+            disabled={controller.isBusy}
+          >
+            {isLast
+              ? controller.isBusy
+                ? "Gerando preview..."
+                : "Confirmar campos"
+              : "Proximo"}
+          </AppButton>
+        </XStack>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}
+
+interface MappingFieldProps {
+  readonly field: ImportMappingFieldViewModel;
+  readonly headers: readonly string[];
+  readonly onChange: (field: ImportMappingFieldKey, value: string) => void;
+}
+
+function MappingField({
+  field,
+  headers,
+  onChange,
+}: MappingFieldProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      <XStack alignItems="center" gap="$2" flexWrap="wrap">
+        <Paragraph fontWeight="700">{field.label}</Paragraph>
+        <AppBadge>{Math.round(field.confidence * 100)}% confianca</AppBadge>
+      </XStack>
+      <YStack gap="$2">
+        {headers.map((header) => (
+          <AppButton
+            key={header}
+            tone={field.value === header ? "primary" : "secondary"}
+            onPress={() => onChange(field.key, header)}
+            accessibilityState={{ selected: field.value === header }}
+          >
+            {header}
+          </AppButton>
+        ))}
+      </YStack>
+      <YStack gap="$1">
+        <Paragraph color="$mutedColor">Preview da coluna selecionada</Paragraph>
+        {field.sampleValues.length > 0 ? (
+          field.sampleValues.map((value) => (
+            <Paragraph key={value}>• {value}</Paragraph>
+          ))
+        ) : (
+          <Paragraph>Nenhum valor de amostra.</Paragraph>
+        )}
+      </YStack>
+    </YStack>
+  );
+}
+
+function PreviewStep({ controller }: ControllerProps): ReactElement | null {
+  const renderItem = useCallback(
+    ({ item }: { readonly item: ImportTransactionDraft }) => (
+      <TransactionPreviewRow
+        transaction={item}
+        selected={controller.isTransactionSelected(item.id)}
+        onToggle={controller.handleToggleTransaction}
+      />
+    ),
+    [controller],
+  );
+  const preview = controller.preview;
+  if (!preview) {
+    return null;
+  }
+
+  return (
+    <YStack flex={1} gap="$3">
+      <AppSurfaceCard
+        title="Revisar transacoes"
+        description={`Importar ${controller.selectedImportCount} de ${controller.totalPreviewCount} transacoes`}
+      >
+        <YStack gap="$3">
+          {controller.duplicateCount > 0 ? (
+            <AppBadge tone="danger">
+              {controller.duplicateCount} possivel duplicata
+            </AppBadge>
+          ) : null}
+          <Paragraph>
+            Importar {controller.selectedImportCount} de{" "}
+            {controller.totalPreviewCount} transacoes
+          </Paragraph>
+          <XStack gap="$2">
+            <AppButton flex={1} tone="secondary" onPress={controller.handleReset}>
+              Voltar
+            </AppButton>
+            <AppButton
+              flex={1}
+              disabled={controller.isBusy || controller.selectedImportCount === 0}
+              onPress={() => {
+                void controller.handleConfirmImport();
+              }}
+            >
+              {controller.isBusy ? "Confirmando..." : "Confirmar importacao"}
+            </AppButton>
+          </XStack>
+        </YStack>
+      </AppSurfaceCard>
+      <YStack flex={1} minHeight={320}>
+        <FlatList
+          data={preview.transactions}
+          keyExtractor={transactionKey}
+          renderItem={renderItem}
+          ItemSeparatorComponent={Separator}
+          contentContainerStyle={listContainerStyle}
+          testID="import-preview-list"
+        />
+      </YStack>
+    </YStack>
+  );
+}
+
+interface TransactionPreviewRowProps {
+  readonly transaction: ImportTransactionDraft;
+  readonly selected: boolean;
+  readonly onToggle: (transactionId: string) => void;
+}
+
+function TransactionPreviewRow({
+  transaction,
+  selected,
+  onToggle,
+}: TransactionPreviewRowProps): ReactElement {
+  const handleToggle = useCallback(
+    () => onToggle(transaction.id),
+    [onToggle, transaction.id],
+  );
+  const tone = transaction.type === "income" ? "primary" : "danger";
+
+  return (
+    <Pressable
+      onPress={handleToggle}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: selected }}
+      testID={`import-transaction-toggle-${transaction.id}`}
+    >
+      <AppSurfaceCard>
+        <YStack gap="$2">
+          <XStack justifyContent="space-between" gap="$3">
+            <YStack flex={1}>
+              <Paragraph fontWeight="700">{transaction.description}</Paragraph>
+              <Paragraph color="$mutedColor">
+                {formatShortDate(transaction.date)}
+              </Paragraph>
+            </YStack>
+            <Paragraph fontWeight="700">{formatAmount(transaction)}</Paragraph>
+          </XStack>
+          <XStack gap="$2" flexWrap="wrap">
+            <AppBadge tone={tone}>{transaction.category ?? "Sem categoria"}</AppBadge>
+            {transaction.isDuplicate ? (
+              <AppBadge tone="danger">Possivel duplicata</AppBadge>
+            ) : null}
+            <AppBadge>{selected ? "Selecionada" : "Ignorada"}</AppBadge>
+          </XStack>
+        </YStack>
+      </AppSurfaceCard>
+    </Pressable>
+  );
+}
+
+function SuccessStep({ controller }: ControllerProps): ReactElement {
+  const router = useRouter();
+  const handleOpenDashboard = useCallback(() => {
+    router.push(appRoutes.private.dashboard);
+  }, [router]);
+
+  return (
+    <AppSurfaceCard
+      title="Importacao concluida"
+      description="As transacoes selecionadas foram enviadas para sua lista."
+    >
+      <YStack gap="$3">
+        {controller.confirmationResult ? (
+          <>
+            <AppKeyValueRow
+              label="Importadas"
+              value={String(controller.confirmationResult.importedCount)}
+            />
+            <AppKeyValueRow
+              label="Ignoradas"
+              value={String(controller.confirmationResult.skippedCount)}
+            />
+          </>
+        ) : null}
+        <XStack gap="$2">
+          <AppButton flex={1} onPress={handleOpenDashboard}>
+            Ver no dashboard
+          </AppButton>
+          <AppButton flex={1} tone="secondary" onPress={controller.handleReset}>
+            Importar outra
+          </AppButton>
+        </XStack>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}

--- a/features/import/services/import-service.test.ts
+++ b/features/import/services/import-service.test.ts
@@ -1,0 +1,186 @@
+import type { AxiosInstance } from "axios";
+
+import type {
+  ImportColumnMapping,
+  ImportFileAsset,
+} from "@/features/import/contracts";
+import { createImportService } from "@/features/import/services/import-service";
+
+const buildClient = () =>
+  ({
+    post: jest.fn(),
+  }) as unknown as AxiosInstance & { post: jest.Mock };
+
+const file: ImportFileAsset = {
+  uri: "file:///cache/extrato.csv",
+  name: "extrato.csv",
+  mimeType: "text/csv",
+};
+
+const mapping: ImportColumnMapping = {
+  dateColumn: "Data",
+  descriptionColumn: "Descricao",
+  amountColumn: "Valor",
+  typeColumn: "Tipo",
+  sheetName: "Janeiro",
+};
+
+describe("createImportService.detectFile", () => {
+  it("detectFile envia multipart para /v2/import/detect e normaliza a resposta", async () => {
+    const client = buildClient();
+    client.post.mockResolvedValueOnce({
+      data: {
+        data: {
+          file_type: "csv",
+          sheet_names: ["Janeiro"],
+          active_sheet: "Janeiro",
+          headers: ["Data", "Descricao", "Valor", "Tipo"],
+          sample_rows: [["2026-05-01", "Uber", "25,50", "saida"]],
+          suggested_mapping: {
+            date_column: "Data",
+            description_column: "Descricao",
+            amount_column: "Valor",
+            type_column: "Tipo",
+          },
+          confidence: {
+            date_column: 0.95,
+            description_column: 0.65,
+            amount_column: 0.9,
+            type_column: 0.8,
+          },
+        },
+      },
+    });
+
+    const result = await createImportService(client).detectFile(file);
+
+    expect(client.post).toHaveBeenCalledWith(
+      "/v2/import/detect",
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "Content-Type": "multipart/form-data" }),
+      }),
+    );
+    expect(result).toEqual({
+      fileType: "csv",
+      sheetNames: ["Janeiro"],
+      activeSheet: "Janeiro",
+      headers: ["Data", "Descricao", "Valor", "Tipo"],
+      sampleRows: [["2026-05-01", "Uber", "25,50", "saida"]],
+      suggestedMapping: {
+        dateColumn: "Data",
+        descriptionColumn: "Descricao",
+        amountColumn: "Valor",
+        typeColumn: "Tipo",
+        sheetName: "Janeiro",
+      },
+      confidence: {
+        dateColumn: 0.95,
+        descriptionColumn: 0.65,
+        amountColumn: 0.9,
+        typeColumn: 0.8,
+      },
+    });
+  });
+});
+
+describe("createImportService.previewFile", () => {
+  it("previewFile envia arquivo e mapping confirmado e desnormaliza transacoes", async () => {
+    const client = buildClient();
+    client.post.mockResolvedValueOnce({
+      data: {
+        data: {
+          preview_token: "preview-1",
+          expires_at: "2026-05-17T14:00:00Z",
+          file_type: "xlsx",
+          total_count: 2,
+          duplicates_count: 1,
+          transactions: [
+            {
+              id: "draft-1",
+              date: "2026-05-01",
+              description: "Uber",
+              amount: "25.50",
+              transaction_type: "expense",
+              category: "transporte",
+              confidence: 0.92,
+              is_duplicate: false,
+            },
+            {
+              id: "draft-2",
+              date: "2026-05-02",
+              description: "Salario",
+              amount: "5000.00",
+              transaction_type: "income",
+              category: "receita",
+              confidence: null,
+              is_duplicate: true,
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await createImportService(client).previewFile({
+      file,
+      mapping,
+    });
+
+    expect(client.post).toHaveBeenCalledWith(
+      "/v2/import/preview",
+      expect.any(FormData),
+      expect.objectContaining({
+        headers: expect.objectContaining({ "Content-Type": "multipart/form-data" }),
+      }),
+    );
+    expect(result.transactions).toEqual([
+      {
+        id: "draft-1",
+        date: "2026-05-01",
+        description: "Uber",
+        amount: "25.50",
+        type: "expense",
+        category: "transporte",
+        confidence: 0.92,
+        isDuplicate: false,
+      },
+      {
+        id: "draft-2",
+        date: "2026-05-02",
+        description: "Salario",
+        amount: "5000.00",
+        type: "income",
+        category: "receita",
+        confidence: null,
+        isDuplicate: true,
+      },
+    ]);
+    expect(result.previewToken).toBe("preview-1");
+    expect(result.duplicatesCount).toBe(1);
+  });
+});
+
+describe("createImportService.confirmImport", () => {
+  it("confirmImport envia preview_token e exclude_ids em snake_case", async () => {
+    const client = buildClient();
+    client.post.mockResolvedValueOnce({
+      data: {
+        data: {
+          imported_count: 1,
+          skipped_count: 1,
+        },
+      },
+    });
+
+    const result = await createImportService(client).confirmImport({
+      previewToken: "preview-1",
+      excludeIds: ["draft-2"],
+    });
+
+    expect(client.post).toHaveBeenCalledWith("/v2/import/confirm", {
+      preview_token: "preview-1",
+      exclude_ids: ["draft-2"],
+    });
+    expect(result).toEqual({ importedCount: 1, skippedCount: 1 });
+  });
+});

--- a/features/import/services/import-service.ts
+++ b/features/import/services/import-service.ts
@@ -1,0 +1,186 @@
+import type { AxiosInstance } from "axios";
+
+import { unwrapEnvelopeData } from "@/core/http/contracts";
+import { httpClient } from "@/core/http/http-client";
+import type {
+  ConfirmImportCommand,
+  ConfirmImportResult,
+  ImportColumnMapping,
+  ImportConfidence,
+  ImportDetectResult,
+  ImportFileAsset,
+  ImportFileType,
+  ImportPreview,
+  ImportPreviewCommand,
+  ImportTransactionDraft,
+  ImportTransactionType,
+} from "@/features/import/contracts";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
+
+interface ImportDetectPayload {
+  readonly file_type: ImportFileType;
+  readonly sheet_names?: readonly string[];
+  readonly active_sheet?: string | null;
+  readonly headers: readonly string[];
+  readonly sample_rows: readonly (readonly string[])[];
+  readonly suggested_mapping: {
+    readonly date_column?: string | null;
+    readonly description_column?: string | null;
+    readonly amount_column?: string | null;
+    readonly type_column?: string | null;
+    readonly sheet_name?: string | null;
+  };
+  readonly confidence: {
+    readonly date_column?: number | null;
+    readonly description_column?: number | null;
+    readonly amount_column?: number | null;
+    readonly type_column?: number | null;
+  };
+}
+
+interface ImportPreviewPayload {
+  readonly preview_token: string;
+  readonly expires_at: string;
+  readonly file_type: ImportFileType;
+  readonly total_count: number;
+  readonly duplicates_count: number;
+  readonly transactions: readonly {
+    readonly id: string;
+    readonly date: string;
+    readonly description: string;
+    readonly amount: string | number;
+    readonly transaction_type: ImportTransactionType;
+    readonly category: string | null;
+    readonly confidence: number | null;
+    readonly is_duplicate: boolean;
+  }[];
+}
+
+interface ConfirmImportPayload {
+  readonly imported_count: number;
+  readonly skipped_count?: number | null;
+}
+
+type AppendableFormData = FormData & {
+  append: (name: string, value: unknown) => void;
+};
+
+const multipartHeaders = {
+  "Content-Type": "multipart/form-data",
+} as const;
+
+const appendFile = (formData: FormData, file: ImportFileAsset): void => {
+  (formData as AppendableFormData).append("file", {
+    uri: file.uri,
+    name: file.name,
+    type: file.mimeType,
+  });
+};
+
+const toApiMapping = (mapping: ImportColumnMapping): Record<string, string> => {
+  const payload: Record<string, string> = {
+    date_column: mapping.dateColumn,
+    description_column: mapping.descriptionColumn,
+    amount_column: mapping.amountColumn,
+    type_column: mapping.typeColumn,
+  };
+
+  if (mapping.sheetName) {
+    payload.sheet_name = mapping.sheetName;
+  }
+
+  return payload;
+};
+
+const toMapping = (payload: ImportDetectPayload): ImportColumnMapping => ({
+  dateColumn: payload.suggested_mapping.date_column ?? "",
+  descriptionColumn: payload.suggested_mapping.description_column ?? "",
+  amountColumn: payload.suggested_mapping.amount_column ?? "",
+  typeColumn: payload.suggested_mapping.type_column ?? "",
+  sheetName: payload.suggested_mapping.sheet_name ?? payload.active_sheet ?? null,
+});
+
+const toConfidence = (payload: ImportDetectPayload): ImportConfidence => ({
+  dateColumn: payload.confidence.date_column ?? 0,
+  descriptionColumn: payload.confidence.description_column ?? 0,
+  amountColumn: payload.confidence.amount_column ?? 0,
+  typeColumn: payload.confidence.type_column ?? 0,
+});
+
+const mapDetect = (payload: ImportDetectPayload): ImportDetectResult => ({
+  fileType: payload.file_type,
+  sheetNames: payload.sheet_names ?? [],
+  activeSheet: payload.active_sheet ?? null,
+  headers: payload.headers,
+  sampleRows: payload.sample_rows,
+  suggestedMapping: toMapping(payload),
+  confidence: toConfidence(payload),
+});
+
+const mapTransaction = (
+  payload: ImportPreviewPayload["transactions"][number],
+): ImportTransactionDraft => ({
+  id: payload.id,
+  date: payload.date,
+  description: payload.description,
+  amount: String(payload.amount),
+  type: payload.transaction_type,
+  category: payload.category,
+  confidence: payload.confidence,
+  isDuplicate: payload.is_duplicate,
+});
+
+const mapPreview = (payload: ImportPreviewPayload): ImportPreview => ({
+  previewToken: payload.preview_token,
+  expiresAt: payload.expires_at,
+  fileType: payload.file_type,
+  totalCount: payload.total_count,
+  duplicatesCount: payload.duplicates_count,
+  transactions: payload.transactions.map(mapTransaction),
+});
+
+export const createImportService = (client: AxiosInstance) => {
+  return {
+    detectFile: async (file: ImportFileAsset): Promise<ImportDetectResult> => {
+      const formData = new FormData();
+      appendFile(formData, file);
+      const response = await client.post(
+        apiContractMap.importDetect.path,
+        formData,
+        { headers: multipartHeaders },
+      );
+      return mapDetect(unwrapEnvelopeData<ImportDetectPayload>(response.data));
+    },
+    previewFile: async (
+      command: ImportPreviewCommand,
+    ): Promise<ImportPreview> => {
+      const formData = new FormData();
+      appendFile(formData, command.file);
+      (formData as AppendableFormData).append(
+        "mapping",
+        JSON.stringify(toApiMapping(command.mapping)),
+      );
+      const response = await client.post(
+        apiContractMap.importPreview.path,
+        formData,
+        { headers: multipartHeaders },
+      );
+      return mapPreview(unwrapEnvelopeData<ImportPreviewPayload>(response.data));
+    },
+    confirmImport: async (
+      command: ConfirmImportCommand,
+    ): Promise<ConfirmImportResult> => {
+      const response = await client.post(apiContractMap.importConfirm.path, {
+        preview_token: command.previewToken,
+        exclude_ids: command.excludeIds,
+      });
+      const payload = unwrapEnvelopeData<ConfirmImportPayload>(response.data);
+      return {
+        importedCount: payload.imported_count,
+        skippedCount: payload.skipped_count ?? command.excludeIds.length,
+      };
+    },
+  };
+};
+
+export const importService = createImportService(httpClient);

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useMemo, useState, type ReactElement } from "react";
 
 import { FlashList } from "@shopify/flash-list";
+import { useRouter } from "expo-router";
 import { Modal, RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { appRoutes } from "@/core/navigation/routes";
 import { queryKeys } from "@/core/query/query-keys";
+import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
 import { FinancialCalendar } from "@/features/transactions/components/financial-calendar";
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
 import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
@@ -24,6 +27,7 @@ import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { useListRefresh } from "@/shared/hooks/use-list-refresh";
+import { isFeatureEnabled } from "@/shared/feature-flags";
 import { useT } from "@/shared/i18n";
 import { TransactionListSkeleton } from "@/shared/skeletons";
 import { formatShortDate } from "@/shared/utils/formatters";
@@ -96,8 +100,10 @@ interface ControllerProps {
 
 function FilterHeader({ controller }: ControllerProps): ReactElement {
   const { t } = useT();
+  const router = useRouter();
   const [exportSheetOpen, setExportSheetOpen] = useState<boolean>(false);
   const exportRunner = useTransactionsExport();
+  const importEnabled = isFeatureEnabled(IMPORT_FEATURE_FLAG_KEY);
 
   const handleExportFormat = useCallback(
     async (format: "csv" | "pdf"): Promise<void> => {
@@ -106,6 +112,9 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
     },
     [exportRunner],
   );
+  const handleOpenImport = useCallback(() => {
+    router.push(appRoutes.private.importTransactions);
+  }, [router]);
 
   return (
     <AppSurfaceCard
@@ -142,6 +151,11 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
             {t("transactions.export.title")}
           </AppButton>
         </XStack>
+        {importEnabled ? (
+          <AppButton tone="secondary" onPress={handleOpenImport}>
+            Importar planilha
+          </AppButton>
+        ) : null}
       </YStack>
       <Modal
         visible={exportSheetOpen}

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "expo": "~54.0.34",
         "expo-constants": "~18.0.13",
         "expo-device": "~8.0.10",
+        "expo-document-picker": "~14.0.8",
         "expo-file-system": "~19.0.22",
         "expo-font": "~14.0.11",
         "expo-haptics": "~15.0.8",
@@ -13003,6 +13004,15 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/expo-document-picker": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-document-picker/-/expo-document-picker-14.0.8.tgz",
+      "integrity": "sha512-3tyQKpPqWWFlI8p9RiMX1+T1Zge5mEKeBuXWp1h8PEItFMUDSiOJbQ112sfdC6Hxt8wSxreV9bCRl/NgBdt+fA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "expo": "~54.0.34",
     "expo-constants": "~18.0.13",
     "expo-device": "~8.0.10",
+    "expo-document-picker": "~14.0.8",
     "expo-file-system": "~19.0.22",
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",

--- a/shared/contracts/api-contract-map.ts
+++ b/shared/contracts/api-contract-map.ts
@@ -75,6 +75,14 @@ import type {
   ReceivableRecord,
   RevenueSummary,
 } from "@/features/fiscal/contracts";
+import type {
+  ConfirmImportCommand,
+  ConfirmImportResult,
+  ImportDetectResult,
+  ImportFileAsset,
+  ImportPreview,
+  ImportPreviewCommand,
+} from "@/features/import/contracts";
 import type { LatestInsightResponse } from "@/features/insights/contracts";
 import type {
   PushSubscriptionCommand,
@@ -371,6 +379,36 @@ export const apiContractMap = {
   >({
     method: "POST",
     path: "/v1/insights/{insight_id}/read",
+    authRequired: true,
+  }),
+  importDetect: defineApiContract<
+    "POST",
+    "/v2/import/detect",
+    ImportFileAsset,
+    ImportDetectResult
+  >({
+    method: "POST",
+    path: "/v2/import/detect",
+    authRequired: true,
+  }),
+  importPreview: defineApiContract<
+    "POST",
+    "/v2/import/preview",
+    ImportPreviewCommand,
+    ImportPreview
+  >({
+    method: "POST",
+    path: "/v2/import/preview",
+    authRequired: true,
+  }),
+  importConfirm: defineApiContract<
+    "POST",
+    "/v2/import/confirm",
+    ConfirmImportCommand,
+    ConfirmImportResult
+  >({
+    method: "POST",
+    path: "/v2/import/confirm",
     authRequired: true,
   }),
   notificationsSubscribe: defineApiContract<

--- a/shared/contracts/api-endpoint-catalog.ts
+++ b/shared/contracts/api-endpoint-catalog.ts
@@ -29,6 +29,11 @@ export const apiEndpointCatalog = {
     "GET /v1/insights/latest",
     "POST /v1/insights/{insight_id}/read",
   ],
+  imports: [
+    "POST /v2/import/detect",
+    "POST /v2/import/preview",
+    "POST /v2/import/confirm",
+  ],
   notifications: [
     "POST /notifications/subscribe",
     "POST /notifications/unsubscribe",

--- a/shared/mocks/api/router.ts
+++ b/shared/mocks/api/router.ts
@@ -11,6 +11,11 @@ import {
   dashboardOverviewFixture,
   dashboardTrendsFixture,
 } from "@/features/dashboard/mocks";
+import {
+  confirmImportFixture,
+  importDetectFixture,
+  importPreviewFixture,
+} from "@/features/import/mocks";
 import { weeklyInsightFixture } from "@/features/insights/mocks";
 import { goalListFixture } from "@/features/goals/mocks";
 import {
@@ -337,6 +342,49 @@ const serializeWeeklyInsight = (): Record<string, unknown> => {
   };
 };
 
+const serializeImportDetect = (): Record<string, unknown> => {
+  return {
+    file_type: importDetectFixture.fileType,
+    sheet_names: importDetectFixture.sheetNames,
+    active_sheet: importDetectFixture.activeSheet,
+    headers: importDetectFixture.headers,
+    sample_rows: importDetectFixture.sampleRows,
+    suggested_mapping: {
+      date_column: importDetectFixture.suggestedMapping.dateColumn,
+      description_column: importDetectFixture.suggestedMapping.descriptionColumn,
+      amount_column: importDetectFixture.suggestedMapping.amountColumn,
+      type_column: importDetectFixture.suggestedMapping.typeColumn,
+      sheet_name: importDetectFixture.suggestedMapping.sheetName,
+    },
+    confidence: {
+      date_column: importDetectFixture.confidence.dateColumn,
+      description_column: importDetectFixture.confidence.descriptionColumn,
+      amount_column: importDetectFixture.confidence.amountColumn,
+      type_column: importDetectFixture.confidence.typeColumn,
+    },
+  };
+};
+
+const serializeImportPreview = (): Record<string, unknown> => {
+  return {
+    preview_token: importPreviewFixture.previewToken,
+    expires_at: importPreviewFixture.expiresAt,
+    file_type: importPreviewFixture.fileType,
+    total_count: importPreviewFixture.totalCount,
+    duplicates_count: importPreviewFixture.duplicatesCount,
+    transactions: importPreviewFixture.transactions.map((transaction) => ({
+      id: transaction.id,
+      date: transaction.date,
+      description: transaction.description,
+      amount: transaction.amount,
+      transaction_type: transaction.type,
+      category: transaction.category,
+      confidence: transaction.confidence,
+      is_duplicate: transaction.isDuplicate,
+    })),
+  };
+};
+
 const serializeWalletCollection = (): Record<string, unknown> => {
   return {
     items: walletCollectionFixture.items.map((item) => ({
@@ -532,6 +580,25 @@ const handleInsightRoutes: MockRouteHandler = (context) => {
   return null;
 };
 
+const handleImportRoutes: MockRouteHandler = (context) => {
+  if (context.method === "POST" && context.pathname === "/v2/import/detect") {
+    return ok(serializeImportDetect());
+  }
+
+  if (context.method === "POST" && context.pathname === "/v2/import/preview") {
+    return ok(serializeImportPreview());
+  }
+
+  if (context.method === "POST" && context.pathname === "/v2/import/confirm") {
+    return ok({
+      imported_count: confirmImportFixture.importedCount,
+      skipped_count: confirmImportFixture.skippedCount,
+    });
+  }
+
+  return null;
+};
+
 const handleWalletRoute: MockRouteHandler = (context) => {
   if (context.method !== "GET" || context.pathname !== "/wallet") {
     return null;
@@ -620,6 +687,7 @@ const routeHandlers: MockRouteHandler[] = [
   handleSubscriptionRoutes,
   handleDashboardRoutes,
   handleInsightRoutes,
+  handleImportRoutes,
   handleWalletRoute,
   handleGoalRoute,
   handleAlertRoutes,


### PR DESCRIPTION
## Summary
- Adds the mobile CSV/XLSX import route behind `app.import.csv-xlsx`, including native document picker, mapping sheet, preview list with duplicate selection, confirm flow, and success/error states.
- Wires v2 import contracts, mock API handlers, query keys, route registry, and the Transactions entry point.
- Adds focused service/controller/screen coverage for low-confidence mapping, high-confidence direct preview, duplicate exclusion, 422 retry copy, and 429 upgrade sheet.

## Issues
Closes #395
Closes #370

## Validation
- `npm run quality-check` passes: 284 suites / 1750 tests.
- `npm run flags:check` passes: `[feature-flags-hygiene] OK (7 flags)`.
- Pre-commit hook passed lint-staged, frontend governance, API contract governance, and OpenAPI secret hygiene.
- Pre-push hook passed policy, contracts, typecheck, and coverage before pushing.

## Screenshots
I attempted to capture screenshots before opening the PR, but this local environment could not render the app screens:
- `EXPO_PUBLIC_API_MODE=mock EXPO_PUBLIC_API_MOCK_LATENCY_MS=1 npx expo start --web --port 8095 --non-interactive` failed before render because Reanimated rejects the installed `react-native-worklets@0.8.3`; expected range is `0.5.x, 0.6.x, 0.7.x`.
- Native screenshot paths were unavailable here: `xcrun simctl` cannot find `simctl`, `maestro` is not installed, and `adb` is not installed.

No screenshots are attached because all available render targets were blocked by environment/tooling, not by this feature code.