### PR TITLE
feat: track transaction analytics events

### DIFF
--- a/features/transactions/hooks/use-transaction-mutations.test.ts
+++ b/features/transactions/hooks/use-transaction-mutations.test.ts
@@ -1,0 +1,214 @@
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+import { queryKeys } from "@/core/query/query-keys";
+import type {
+  CreateTransactionCommand,
+  TransactionCollection,
+  TransactionRecord,
+} from "@/features/transactions/contracts";
+import {
+  useCreateTransactionMutation,
+  useDeleteTransactionMutation,
+  useRestoreTransactionMutation,
+} from "@/features/transactions/hooks/use-transaction-mutations";
+import { transactionFixture } from "@/features/transactions/mocks";
+
+const mockAnalyticsClient: jest.Mocked<AnalyticsClient> = {
+  capture: jest.fn(),
+  identify: jest.fn(),
+  reset: jest.fn(),
+};
+const mockUseMutation = jest.fn();
+const mockUseQueryClient = jest.fn();
+const mockInvalidateQueries = jest.fn();
+const mockGetQueriesData = jest.fn();
+const mockCreateTransaction = jest.fn();
+const mockUpdateTransaction = jest.fn();
+const mockDeleteTransaction = jest.fn();
+const mockRestoreTransaction = jest.fn();
+
+jest.mock("@tanstack/react-query", () => ({
+  useMutation: (...args: readonly unknown[]) => mockUseMutation(...args),
+  useQueryClient: () => mockUseQueryClient(),
+}));
+
+jest.mock("@/core/observability/use-analytics", () => ({
+  useAnalytics: () => mockAnalyticsClient,
+}));
+
+jest.mock("@/features/transactions/services/transactions-service", () => ({
+  transactionsService: {
+    createTransaction: (...args: readonly unknown[]) =>
+      mockCreateTransaction(...args),
+    updateTransaction: (...args: readonly unknown[]) =>
+      mockUpdateTransaction(...args),
+    deleteTransaction: (...args: readonly unknown[]) =>
+      mockDeleteTransaction(...args),
+    restoreTransaction: (...args: readonly unknown[]) =>
+      mockRestoreTransaction(...args),
+  },
+}));
+
+interface MutationConfig<TData, TVariables, TContext = unknown> {
+  readonly mutationFn: (variables: TVariables) => Promise<TData>;
+  readonly onMutate?: (variables: TVariables) => TContext;
+  readonly onSuccess?: (
+    data: TData,
+    variables: TVariables,
+    onMutateResult: TContext,
+  ) => Promise<void>;
+}
+
+const buildCollection = (
+  transaction: TransactionRecord,
+): TransactionCollection => ({
+  transactions: [transaction],
+  pagination: {
+    total: 1,
+    page: 1,
+    perPage: 10,
+    pages: 1,
+    hasNextPage: false,
+  },
+});
+
+const expectedAnalyticsProperties = (
+  transaction: TransactionRecord,
+) => ({
+  transactionType: transaction.type,
+  source: transaction.source,
+  status: transaction.status,
+  isRecurring: transaction.isRecurring,
+  isInstallment: transaction.isInstallment,
+  currency: transaction.currency,
+});
+
+describe("useTransactionMutations analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseMutation.mockImplementation((options: unknown) => options);
+    mockInvalidateQueries.mockResolvedValue(undefined);
+    mockGetQueriesData.mockReturnValue([]);
+    mockUseQueryClient.mockReturnValue({
+      invalidateQueries: mockInvalidateQueries,
+      getQueriesData: mockGetQueriesData,
+    });
+  });
+
+  it("captures transaction.created without PII when creation succeeds", async () => {
+    const command: CreateTransactionCommand = {
+      title: "Confidential vendor",
+      amount: "123.45",
+      type: "expense",
+      dueDate: "2026-05-17",
+      description: "private memo",
+    };
+    const createdTransaction: TransactionRecord = {
+      ...transactionFixture,
+      id: "tx-created",
+      title: command.title,
+      type: "expense",
+      source: "manual",
+    };
+    mockCreateTransaction.mockResolvedValue(createdTransaction);
+
+    const mutation =
+      useCreateTransactionMutation() as unknown as MutationConfig<
+        TransactionRecord,
+        CreateTransactionCommand
+      >;
+
+    await expect(mutation.mutationFn(command)).resolves.toEqual(
+      createdTransaction,
+    );
+    await mutation.onSuccess?.(createdTransaction, command, undefined);
+
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
+      "transaction.created",
+      expectedAnalyticsProperties(createdTransaction),
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      command.title,
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      command.description,
+    );
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.transactions.root,
+    });
+  });
+
+  it("captures transaction.deleted using cached non-PII properties", async () => {
+    const deletedTransaction: TransactionRecord = {
+      ...transactionFixture,
+      id: "tx-deleted",
+      title: "Private deleted title",
+      type: "income",
+      source: "import",
+    };
+    mockGetQueriesData.mockReturnValue([
+      [queryKeys.transactions.list(), buildCollection(deletedTransaction)],
+    ]);
+    mockDeleteTransaction.mockResolvedValue(undefined);
+
+    const mutation =
+      useDeleteTransactionMutation() as unknown as MutationConfig<
+        void,
+        string,
+        { readonly transaction?: TransactionRecord }
+      >;
+
+    const mutationContext = mutation.onMutate?.(deletedTransaction.id);
+    await expect(mutation.mutationFn(deletedTransaction.id)).resolves.toBeUndefined();
+    await mutation.onSuccess?.(
+      undefined,
+      deletedTransaction.id,
+      mutationContext ?? {},
+    );
+
+    expect(mutationContext).toEqual({ transaction: deletedTransaction });
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
+      "transaction.deleted",
+      expectedAnalyticsProperties(deletedTransaction),
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      deletedTransaction.title,
+    );
+  });
+
+  it("captures transaction.restored without PII when restore succeeds", async () => {
+    const restoredTransaction: TransactionRecord = {
+      ...transactionFixture,
+      id: "tx-restored",
+      title: "Restored private title",
+      type: "expense",
+      source: "manual",
+    };
+    mockRestoreTransaction.mockResolvedValue(restoredTransaction);
+
+    const mutation =
+      useRestoreTransactionMutation() as unknown as MutationConfig<
+        TransactionRecord,
+        string
+      >;
+
+    await expect(mutation.mutationFn(restoredTransaction.id)).resolves.toEqual(
+      restoredTransaction,
+    );
+    await mutation.onSuccess?.(
+      restoredTransaction,
+      restoredTransaction.id,
+      undefined,
+    );
+
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
+      "transaction.restored",
+      expectedAnalyticsProperties(restoredTransaction),
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      restoredTransaction.title,
+    );
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.transactions.root,
+    });
+  });
+});

--- a/features/transactions/hooks/use-transaction-mutations.ts
+++ b/features/transactions/hooks/use-transaction-mutations.ts
@@ -1,19 +1,69 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  type QueryClient,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
 
+import type { TransactionAnalyticsProperties } from "@/core/observability/analytics-types";
+import { useAnalytics } from "@/core/observability/use-analytics";
 import { queryKeys } from "@/core/query/query-keys";
 import type {
   CreateTransactionCommand,
+  TransactionCollection,
   TransactionRecord,
   UpdateTransactionCommand,
 } from "@/features/transactions/contracts";
 import { transactionsService } from "@/features/transactions/services/transactions-service";
 
+interface DeleteTransactionMutationContext {
+  readonly transaction?: TransactionRecord;
+}
+
+const toTransactionAnalyticsProperties = (
+  transaction: TransactionRecord,
+): TransactionAnalyticsProperties => ({
+  transactionType: transaction.type,
+  source: transaction.source || "unknown",
+  status: transaction.status,
+  isRecurring: transaction.isRecurring,
+  isInstallment: transaction.isInstallment,
+  currency: transaction.currency,
+});
+
+const findCachedTransaction = (
+  queryClient: QueryClient,
+  transactionId: string,
+): TransactionRecord | undefined => {
+  const transactionCollections =
+    queryClient.getQueriesData<TransactionCollection>({
+      queryKey: queryKeys.transactions.list(),
+    });
+
+  for (const [, collection] of transactionCollections) {
+    const transaction = collection?.transactions.find(
+      (item) => item.id === transactionId,
+    );
+    if (transaction) {
+      return transaction;
+    }
+  }
+
+  return undefined;
+};
+
 export const useCreateTransactionMutation = () => {
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
 
   return useMutation<TransactionRecord, Error, CreateTransactionCommand>({
     mutationFn: (command) => transactionsService.createTransaction(command),
-    onSuccess: async () => {
+    onSuccess: async (transaction) => {
+      if (transaction) {
+        analytics.capture(
+          "transaction.created",
+          toTransactionAnalyticsProperties(transaction),
+        );
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root });
     },
   });
@@ -38,23 +88,42 @@ export const useUpdateTransactionMutation = () => {
 };
 
 export const useDeleteTransactionMutation = () => {
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, string>({
+  return useMutation<void, Error, string, DeleteTransactionMutationContext>({
     mutationFn: (transactionId) => transactionsService.deleteTransaction(transactionId),
-    onSuccess: async () => {
+    onMutate: (transactionId) => ({
+      transaction: findCachedTransaction(queryClient, transactionId),
+    }),
+    onSuccess: async (_data, _transactionId, mutationContext) => {
+      if (mutationContext?.transaction) {
+        analytics.capture(
+          "transaction.deleted",
+          toTransactionAnalyticsProperties(mutationContext.transaction),
+        );
+      } else {
+        analytics.capture("transaction.deleted");
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root });
     },
   });
 };
 
 export const useRestoreTransactionMutation = () => {
+  const analytics = useAnalytics();
   const queryClient = useQueryClient();
 
   return useMutation<TransactionRecord, Error, string>({
     mutationFn: (transactionId) =>
       transactionsService.restoreTransaction(transactionId),
-    onSuccess: async () => {
+    onSuccess: async (transaction) => {
+      if (transaction) {
+        analytics.capture(
+          "transaction.restored",
+          toTransactionAnalyticsProperties(transaction),
+        );
+      }
       await queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root });
     },
   });


### PR DESCRIPTION
## Summary

- Capture `transaction.created` and `transaction.restored` from successful transaction mutation results.
- Capture `transaction.deleted` with cached non-PII transaction properties when available, falling back to an event-only capture.
- Add unit coverage for transaction analytics payload hygiene so titles/descriptions do not leak into events.

## Screenshots

Not applicable. This PR changes analytics instrumentation only and has no visual UI changes.

## Validation

- `npm test -- features/transactions/hooks/use-transaction-mutations.test.ts features/transactions/hooks/use-transactions-query.test.ts features/transactions/hooks/use-transactions-screen-controller.test.ts features/transactions/hooks/use-transactions-trash-screen-controller.test.tsx --runInBand`
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-feature-flags.cjs`
- `npm run quality-check` (285 suites, 1755 tests, 94.21% statement coverage)
- Pre-push hook passed: governance, contracts, typecheck, coverage

Refs #305
