### PR TITLE
feat: track goal analytics events

### DIFF
--- a/features/goals/hooks/use-goals-mutations.test.ts
+++ b/features/goals/hooks/use-goals-mutations.test.ts
@@ -4,11 +4,22 @@ import {
   useUpdateGoalMutation,
 } from "@/features/goals/hooks/use-goals-mutations";
 import { goalsService } from "@/features/goals/services/goals-service";
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+import type { CreateGoalCommand, GoalRecord } from "@/features/goals/contracts";
 
 const mockCreateApiMutation = jest.fn();
+const mockAnalyticsClient: jest.Mocked<AnalyticsClient> = {
+  capture: jest.fn(),
+  identify: jest.fn(),
+  reset: jest.fn(),
+};
 
 jest.mock("@/core/query/create-api-mutation", () => ({
   createApiMutation: (...args: readonly unknown[]) => mockCreateApiMutation(...args),
+}));
+
+jest.mock("@/core/observability/use-analytics", () => ({
+  useAnalytics: () => mockAnalyticsClient,
 }));
 
 jest.mock("@tanstack/react-query", () => ({
@@ -45,6 +56,44 @@ describe("goals mutations", () => {
       title: "X",
       targetAmount: 1,
     });
+  });
+
+  it("captura goal.created sem enviar titulo ou valor bruto", async () => {
+    const command: CreateGoalCommand = {
+      title: "Casa da familia",
+      targetAmount: 100000,
+      currentAmount: 25000,
+    };
+    const createdGoal: GoalRecord = {
+      id: "goal-analytics",
+      title: command.title,
+      targetAmount: command.targetAmount,
+      currentAmount: command.currentAmount ?? 0,
+      targetDate: null,
+      status: "in_progress",
+    };
+
+    useCreateGoalMutation();
+    const [, options] = mockCreateApiMutation.mock.calls[0] ?? [];
+
+    await (
+      options as {
+        readonly onSuccess: (
+          data: GoalRecord,
+          variables: CreateGoalCommand,
+        ) => Promise<void>;
+      }
+    ).onSuccess(createdGoal, command);
+
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith("goal.created", {
+      targetAmountBucket: "100k_plus",
+    });
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      command.title,
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      String(command.targetAmount),
+    );
   });
 
   it("update dispara goalsService.updateGoal", async () => {

--- a/features/goals/hooks/use-goals-mutations.ts
+++ b/features/goals/hooks/use-goals-mutations.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 
+import { useAnalytics } from "@/core/observability/use-analytics";
 import { createApiMutation } from "@/core/query/create-api-mutation";
 import { queryKeys } from "@/core/query/query-keys";
 import type {
@@ -7,6 +8,7 @@ import type {
   GoalRecord,
   UpdateGoalCommand,
 } from "@/features/goals/contracts";
+import { buildGoalCreatedAnalyticsProperties } from "@/features/goals/services/goal-analytics";
 import { goalsService } from "@/features/goals/services/goals-service";
 
 const useInvalidateGoals = () => {
@@ -17,10 +19,19 @@ const useInvalidateGoals = () => {
 };
 
 export const useCreateGoalMutation = () => {
+  const analytics = useAnalytics();
   const invalidate = useInvalidateGoals();
   return createApiMutation<GoalRecord, CreateGoalCommand>(
     (command) => goalsService.createGoal(command),
-    { onSuccess: invalidate },
+    {
+      onSuccess: (goal) => {
+        analytics.capture(
+          "goal.created",
+          buildGoalCreatedAnalyticsProperties(goal),
+        );
+        invalidate();
+      },
+    },
   );
 };
 

--- a/features/goals/hooks/use-goals-simulator-mutation.test.ts
+++ b/features/goals/hooks/use-goals-simulator-mutation.test.ts
@@ -1,0 +1,95 @@
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+import type {
+  SimulateGoalPlanCommand,
+  SimulatedGoalPlan,
+} from "@/features/goals/contracts";
+import { useSimulateGoalMutation } from "@/features/goals/hooks/use-goals-simulator-mutation";
+import { goalsService } from "@/features/goals/services/goals-service";
+
+const mockCreateApiMutation = jest.fn();
+const mockAnalyticsClient: jest.Mocked<AnalyticsClient> = {
+  capture: jest.fn(),
+  identify: jest.fn(),
+  reset: jest.fn(),
+};
+
+jest.mock("@/core/query/create-api-mutation", () => ({
+  createApiMutation: (...args: readonly unknown[]) => mockCreateApiMutation(...args),
+}));
+
+jest.mock("@/core/observability/use-analytics", () => ({
+  useAnalytics: () => mockAnalyticsClient,
+}));
+
+jest.mock("@/features/goals/services/goals-service", () => ({
+  goalsService: {
+    simulatePlan: jest.fn(),
+  },
+}));
+
+const mockedService = goalsService as jest.Mocked<typeof goalsService>;
+
+describe("useSimulateGoalMutation analytics", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCreateApiMutation.mockImplementation((fn: unknown, options: unknown) => ({
+      fn,
+      options,
+    }));
+  });
+
+  it("dispara goalsService.simulatePlan", async () => {
+    const command: SimulateGoalPlanCommand = {
+      targetAmount: 50000,
+      currentAmount: 10000,
+      monthlyContribution: 500,
+    };
+
+    useSimulateGoalMutation();
+    const [fn] = mockCreateApiMutation.mock.calls[0] ?? [];
+
+    await (fn as (cmd: SimulateGoalPlanCommand) => Promise<unknown>)(command);
+
+    expect(mockedService.simulatePlan).toHaveBeenCalledWith(command);
+  });
+
+  it("captura goal.simulated sem enviar valores financeiros brutos", async () => {
+    const command: SimulateGoalPlanCommand = {
+      targetAmount: 50000,
+      currentAmount: 10000,
+      monthlyIncome: 12000,
+      monthlyExpenses: 7000,
+      monthlyContribution: 500,
+    };
+    const plan: SimulatedGoalPlan = {
+      monthlyContribution: 500,
+      monthsToTarget: 24,
+      recommendedSavingsRate: 0.1,
+      projectedFinishDate: "2028-01-01",
+      disclaimer: null,
+    };
+
+    useSimulateGoalMutation();
+    const [, options] = mockCreateApiMutation.mock.calls[0] ?? [];
+
+    (
+      options as {
+        readonly onSuccess: (
+          data: SimulatedGoalPlan,
+          variables: SimulateGoalPlanCommand,
+        ) => void;
+      }
+    ).onSuccess(plan, command);
+
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith("goal.simulated", {
+      horizonMonths: 24,
+      contributionBucket: "under_1k",
+    });
+    const capturedPayload = JSON.stringify(mockAnalyticsClient.capture.mock.calls);
+    expect(capturedPayload).not.toContain(String(command.targetAmount));
+    expect(capturedPayload).not.toContain(String(command.currentAmount));
+    expect(capturedPayload).not.toContain(String(command.monthlyIncome));
+    expect(capturedPayload).not.toContain(String(command.monthlyExpenses));
+    expect(capturedPayload).not.toContain(String(command.monthlyContribution));
+  });
+});

--- a/features/goals/hooks/use-goals-simulator-mutation.ts
+++ b/features/goals/hooks/use-goals-simulator-mutation.ts
@@ -1,12 +1,23 @@
+import { useAnalytics } from "@/core/observability/use-analytics";
 import { createApiMutation } from "@/core/query/create-api-mutation";
 import type {
   SimulateGoalPlanCommand,
   SimulatedGoalPlan,
 } from "@/features/goals/contracts";
+import { buildGoalSimulatedAnalyticsProperties } from "@/features/goals/services/goal-analytics";
 import { goalsService } from "@/features/goals/services/goals-service";
 
 export const useSimulateGoalMutation = () => {
+  const analytics = useAnalytics();
   return createApiMutation<SimulatedGoalPlan, SimulateGoalPlanCommand>(
     (command) => goalsService.simulatePlan(command),
+    {
+      onSuccess: (plan) => {
+        analytics.capture(
+          "goal.simulated",
+          buildGoalSimulatedAnalyticsProperties(plan),
+        );
+      },
+    },
   );
 };

--- a/features/goals/services/goal-analytics.ts
+++ b/features/goals/services/goal-analytics.ts
@@ -1,0 +1,34 @@
+import type {
+  GoalCreatedAnalyticsProperties,
+  GoalSimulatedAnalyticsProperties,
+} from "@/core/observability/analytics-types";
+import type { GoalRecord, SimulatedGoalPlan } from "@/features/goals/contracts";
+
+const bucketAmount = (amount: number | null | undefined): string => {
+  if (typeof amount !== "number" || !Number.isFinite(amount) || amount <= 0) {
+    return "unknown";
+  }
+  if (amount < 1_000) {
+    return "under_1k";
+  }
+  if (amount < 10_000) {
+    return "1k_10k";
+  }
+  if (amount < 100_000) {
+    return "10k_100k";
+  }
+  return "100k_plus";
+};
+
+export const buildGoalCreatedAnalyticsProperties = (
+  goal: GoalRecord,
+): GoalCreatedAnalyticsProperties => ({
+  targetAmountBucket: bucketAmount(goal.targetAmount),
+});
+
+export const buildGoalSimulatedAnalyticsProperties = (
+  plan: SimulatedGoalPlan,
+): GoalSimulatedAnalyticsProperties => ({
+  horizonMonths: plan.monthsToTarget ?? undefined,
+  contributionBucket: bucketAmount(plan.monthlyContribution),
+});


### PR DESCRIPTION
## Summary

- Capture `goal.created` after successful goal creation using a target amount bucket.
- Capture `goal.simulated` after successful goal plan simulation using horizon months and contribution bucket.
- Add analytics payload tests to prevent leaking goal titles or raw financial values.

## Screenshots

Not applicable. This PR changes analytics instrumentation only and has no visual UI changes.

## Validation

- `npm test -- features/goals/hooks/use-goals-mutations.test.ts features/goals/hooks/use-goals-simulator-mutation.test.ts --runInBand`
- `npm test -- features/goals/hooks/use-goals-mutations.test.ts features/goals/hooks/use-goals-simulator-mutation.test.ts features/goals/hooks/use-goal-simulator-screen-controller.test.tsx features/goals/hooks/use-goals-screen-controller.test.tsx features/goals/hooks/use-goal-scenario-screen-controller.test.tsx __tests__/e2e/goals.test.tsx --runInBand` (35 assertions passed; local Jest process was stopped after completion because this subset left an open handle)
- `npm run typecheck`
- `npm run lint`
- `node scripts/check-feature-flags.cjs`
- `npm run quality-check` (286 suites, 1758 tests, 94.21% statement coverage)
- Pre-push hook passed: governance, contracts, typecheck, coverage

Refs #305
