### PR TITLE
feat: enforce deep link allowlist

### DIFF
--- a/core/navigation/deep-linking.test.ts
+++ b/core/navigation/deep-linking.test.ts
@@ -1,12 +1,22 @@
 import {
+  ALLOWED_DEEP_LINK_PATHS,
   buildAppUrl,
   buildCheckoutReturnUrl,
   parseAppUrl,
   sanitizeAppUrl,
 } from "@/core/navigation/deep-linking";
-import { appRoutes } from "@/core/navigation/routes";
+import { appRouteRegistry, appRoutes } from "@/core/navigation/routes";
 
+// eslint-disable-next-line max-lines-per-function
 describe("deep linking", () => {
+  it("mantem a allowlist explicita sincronizada com o registry canonico", () => {
+    const registeredPaths = appRouteRegistry
+      .map((route) => route.path)
+      .toSorted();
+
+    expect([...ALLOWED_DEEP_LINK_PATHS].toSorted()).toEqual(registeredPaths);
+  });
+
   it("resolve rotas publicas a partir do scheme do app", () => {
     expect(parseAppUrl("auraxisapp://login")).toEqual({
       kind: "route",
@@ -54,6 +64,19 @@ describe("deep linking", () => {
     });
   });
 
+  it("aceita rotas legais por scheme e universal link confiavel", () => {
+    expect(parseAppUrl("auraxisapp://privacy-policy")).toEqual({
+      kind: "route",
+      href: appRoutes.legal.privacyPolicy,
+      rawUrl: "auraxisapp://privacy-policy",
+    });
+    expect(parseAppUrl("https://auraxis.app/terms-of-service")).toEqual({
+      kind: "route",
+      href: appRoutes.legal.termsOfService,
+      rawUrl: "https://auraxis.app/terms-of-service",
+    });
+  });
+
   it("normaliza status desconhecido e ignora rotas invalidas", () => {
     expect(
       parseAppUrl("auraxisapp://assinatura?result=unexpected"),
@@ -63,6 +86,11 @@ describe("deep linking", () => {
     });
     expect(parseAppUrl("auraxisapp://rota-inexistente")).toBeNull();
     expect(parseAppUrl("nao-e-uma-url")).toBeNull();
+  });
+
+  it("rejeita universal links fora dos hosts confiaveis", () => {
+    expect(parseAppUrl("https://evil.example/dashboard")).toBeNull();
+    expect(parseAppUrl("http://auraxis.app/dashboard")).toBeNull();
   });
 
   it("gera URLs internas com e sem querystring", () => {

--- a/core/navigation/deep-linking.ts
+++ b/core/navigation/deep-linking.ts
@@ -1,5 +1,7 @@
 import {
   appRoutes,
+  appRouteRegistry,
+  isLegalAppRoute,
   isPrivateAppRoute,
   isPublicAppRoute,
   type AppRoute,
@@ -35,6 +37,17 @@ export type AppLinkIntent = RouteLinkIntent | CheckoutReturnIntent;
 
 type QueryValue = string | null;
 
+export const ALLOWED_DEEP_LINK_PATHS: readonly AppRoute[] = Object.freeze(
+  appRouteRegistry.map((route) => route.path),
+);
+
+const ALLOWED_DEEP_LINK_PATH_SET = new Set<AppRoute>(ALLOWED_DEEP_LINK_PATHS);
+const TRUSTED_UNIVERSAL_LINK_HOSTS = new Set(["auraxis.app", "www.auraxis.app"]);
+
+const isAllowedDeepLinkPath = (path: string): path is AppRoute => {
+  return ALLOWED_DEEP_LINK_PATH_SET.has(path as AppRoute);
+};
+
 const normalizeRoutePath = (path: string): string => {
   if (path.length === 0 || path === "/") {
     return appRoutes.root;
@@ -50,10 +63,9 @@ const configuredCheckoutReturnPath = normalizeRoutePath(
 
 const resolveUrlPath = (url: URL): string => {
   const pathname = normalizeRoutePath(url.pathname);
-  const isAppScheme =
-    url.protocol !== "http:" && url.protocol !== "https:" && url.host.length > 0;
+  const isAppScheme = url.protocol === `${appRuntimeConfig.appScheme}:`;
 
-  if (isAppScheme) {
+  if (isAppScheme && url.host.length > 0) {
     if (pathname === appRoutes.root) {
       return normalizeRoutePath(url.host);
     }
@@ -61,6 +73,18 @@ const resolveUrlPath = (url: URL): string => {
   }
 
   return pathname;
+};
+
+const isTrustedIncomingUrl = (url: URL): boolean => {
+  if (url.protocol === `${appRuntimeConfig.appScheme}:`) {
+    return true;
+  }
+
+  if (url.protocol !== "https:") {
+    return false;
+  }
+
+  return TRUSTED_UNIVERSAL_LINK_HOSTS.has(url.hostname.toLowerCase());
 };
 
 const readQueryValue = (
@@ -190,6 +214,18 @@ export const parseAppUrl = (rawUrl: string): AppLinkIntent | null => {
     return null;
   }
 
+  if (!isTrustedIncomingUrl(url)) {
+    navigationLogger.log("navigation.deep_link_rejected", {
+      level: "warn",
+      context: {
+        rawUrl: sanitizeAppUrl(rawUrl),
+        path: normalizeRoutePath(url.pathname),
+        reason: "untrusted_scheme_or_host",
+      },
+    });
+    return null;
+  }
+
   const path = resolveUrlPath(url);
 
   if (path === appRoutes.root) {
@@ -204,7 +240,12 @@ export const parseAppUrl = (rawUrl: string): AppLinkIntent | null => {
     return buildCheckoutReturnIntent(rawUrl, path, url.searchParams);
   }
 
-  if (isPrivateAppRoute(path) || isPublicAppRoute(path)) {
+  if (
+    isAllowedDeepLinkPath(path) ||
+    isPrivateAppRoute(path) ||
+    isPublicAppRoute(path) ||
+    isLegalAppRoute(path)
+  ) {
     return {
       kind: "route",
       href: path,
@@ -221,6 +262,12 @@ export const parseAppUrl = (rawUrl: string): AppLinkIntent | null => {
     },
   });
   return null;
+};
+
+export const resolveDeepLinkFallbackRoute = (
+  isAuthenticated: boolean,
+): PrivateAppRoute | (typeof appRoutes.public.login) => {
+  return isAuthenticated ? appRoutes.private.dashboard : appRoutes.public.login;
 };
 
 export const buildAppUrl = (

--- a/core/shell/use-runtime-lifecycle.edge.test.tsx
+++ b/core/shell/use-runtime-lifecycle.edge.test.tsx
@@ -5,6 +5,7 @@ import { AppState, type AppStateStatus } from "react-native";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { reachabilityService } from "@/core/shell/reachability-service";
 import { useRuntimeLifecycle } from "@/core/shell/use-runtime-lifecycle";
+import { appRoutes } from "@/core/navigation/routes";
 import {
   makeAppShellState,
   makeSessionState,
@@ -18,6 +19,16 @@ const mockRevalidate = jest.fn().mockResolvedValue({
   signedOut: false,
   entitlementsVersion: 4,
 });
+const mockRouterReplace = jest.fn();
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: mockRouterReplace,
+    back: jest.fn(),
+    canGoBack: jest.fn(() => false),
+  }),
+}));
 
 jest.mock("expo-linking", () => ({
   getInitialURL: jest.fn(),
@@ -44,6 +55,7 @@ const createLinkingSubscription = (): ReturnType<
   } as unknown as ReturnType<typeof Linking.addEventListener>;
 };
 
+// eslint-disable-next-line max-lines-per-function
 describe("useRuntimeLifecycle - edge cases", () => {
   let appStateListener: ((state: AppStateStatus) => void) | null;
 
@@ -87,7 +99,7 @@ describe("useRuntimeLifecycle - edge cases", () => {
     });
   });
 
-  it("ignora links invalidos e nao duplica o processamento do mesmo retorno", async () => {
+  it("redireciona link inicial invalido e nao duplica o processamento do mesmo retorno", async () => {
     const urlListenerRef: {
       current: ((event: { readonly url: string }) => void) | null;
     } = {
@@ -112,8 +124,11 @@ describe("useRuntimeLifecycle - edge cases", () => {
     });
 
     await waitFor(() => {
-      expect(useAppShellStore.getState().lastHandledUrl).toBeNull();
+      expect(useAppShellStore.getState().lastHandledUrl).toBe(
+        "auraxisapp://desconhecido",
+      );
     });
+    expect(mockRouterReplace).toHaveBeenCalledWith(appRoutes.private.dashboard);
 
     urlListenerRef.current?.({
       url: "auraxisapp://assinatura?status=success&provider=asaas",
@@ -127,6 +142,62 @@ describe("useRuntimeLifecycle - edge cases", () => {
     });
 
     expect(mockRevalidate).toHaveBeenCalledTimes(1);
+  });
+
+  it("redireciona deep link invalido para dashboard quando a sessao esta autenticada", async () => {
+    jest.mocked(Linking.getInitialURL).mockResolvedValue("auraxisapp://admin");
+    jest.mocked(Linking.addEventListener).mockImplementation(
+      ((..._args) => createLinkingSubscription()) as typeof Linking.addEventListener,
+    );
+
+    renderHook(() => useRuntimeLifecycle(), {
+      wrapper: createTestHookWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith(appRoutes.private.dashboard);
+    });
+  });
+
+  it("redireciona deep link invalido para login quando a sessao nao esta autenticada", async () => {
+    const urlListenerRef: {
+      current: ((event: { readonly url: string }) => void) | null;
+    } = {
+      current: null,
+    };
+
+    resetRuntimeStores({
+      appShell: makeAppShellState({
+        fontsReady: true,
+        startupReady: true,
+      }),
+      session: makeSessionState({
+        hydrated: true,
+        isAuthenticated: false,
+      }),
+    });
+    jest.mocked(Linking.getInitialURL).mockResolvedValue(null);
+    jest.mocked(Linking.addEventListener).mockImplementation(
+      ((event, listener) => {
+        if (event === "url") {
+          urlListenerRef.current = listener as unknown as (
+            event: { readonly url: string },
+          ) => void;
+        }
+
+        return createLinkingSubscription();
+      }) as typeof Linking.addEventListener,
+    );
+
+    renderHook(() => useRuntimeLifecycle(), {
+      wrapper: createTestHookWrapper(),
+    });
+
+    urlListenerRef.current?.({ url: "https://evil.example/dashboard" });
+
+    await waitFor(() => {
+      expect(mockRouterReplace).toHaveBeenCalledWith(appRoutes.public.login);
+    });
   });
 
   it("nao sincroniza quando o app muda para inactive sem voltar ao foreground", async () => {

--- a/core/shell/use-runtime-lifecycle.ts
+++ b/core/shell/use-runtime-lifecycle.ts
@@ -1,5 +1,6 @@
 import { useQueryClient } from "@tanstack/react-query";
 import * as Linking from "expo-linking";
+import { useRouter } from "expo-router";
 import {
   useEffect,
   useMemo,
@@ -10,9 +11,11 @@ import { AppState, type AppStateStatus } from "react-native";
 
 import {
   parseAppUrl,
+  resolveDeepLinkFallbackRoute,
   sanitizeAppUrl,
   type CheckoutReturnIntent,
 } from "@/core/navigation/deep-linking";
+import type { AppRoute } from "@/core/navigation/routes";
 import { performanceTracker } from "@/core/performance/performance-tracker";
 import {
   type RuntimeAppState,
@@ -66,12 +69,15 @@ const resolveRuntimeFailureReason = (
 interface IncomingUrlHandlerDependencies {
   readonly setPendingCheckoutReturn: (value: CheckoutReturnIntent | null) => void;
   readonly setLastHandledUrl: (value: string | null) => void;
+  readonly replaceRoute: (href: AppRoute) => void;
+  readonly resolveFallbackRoute: () => AppRoute;
   readonly revalidate: (reason: "checkout-return") => Promise<unknown>;
 }
 
 const createIncomingUrlHandler = (
   dependencies: IncomingUrlHandlerDependencies,
 ) => {
+  // eslint-disable-next-line max-statements
   return async (rawUrl: string | null): Promise<void> => {
     if (!rawUrl) {
       return;
@@ -90,11 +96,15 @@ const createIncomingUrlHandler = (
 
     const intent = parseAppUrl(rawUrl);
     if (!intent) {
+      const fallbackRoute = dependencies.resolveFallbackRoute();
       navigationLogger.log("navigation.deep_link_ignored", {
         context: {
           url: sanitizedUrl,
+          fallbackRoute,
         },
       });
+      dependencies.setLastHandledUrl(sanitizedUrl);
+      dependencies.replaceRoute(fallbackRoute);
       return;
     }
 
@@ -176,7 +186,9 @@ const bindAppStateLifecycle = (
   return createSubscriptionTeardown(subscription);
 };
 
+// eslint-disable-next-line max-lines-per-function, max-statements
 export const useRuntimeLifecycle = (enabled = true): void => {
+  const router = useRouter();
   const queryClient = useQueryClient();
   const setAppState = useAppShellStore((state) => state.setAppState);
   const setConnectivityStatus = useAppShellStore(
@@ -327,9 +339,16 @@ export const useRuntimeLifecycle = (enabled = true): void => {
       createIncomingUrlHandler({
         setPendingCheckoutReturn,
         setLastHandledUrl,
+        replaceRoute: (href) => {
+          router.replace(href);
+        },
+        resolveFallbackRoute: () =>
+          resolveDeepLinkFallbackRoute(
+            useSessionStore.getState().isAuthenticated,
+          ),
         revalidate: (reason) => syncRuntime(reason),
       }),
-    [setLastHandledUrl, setPendingCheckoutReturn, syncRuntime],
+    [router, setLastHandledUrl, setPendingCheckoutReturn, syncRuntime],
   );
 
   useEffect(() => {
@@ -350,7 +369,7 @@ export const useRuntimeLifecycle = (enabled = true): void => {
 
   useEffect(() => {
     if (!enabled) {
-      return;
+      return undefined;
     }
 
     return bindInitialUrlLifecycle(handleIncomingUrl);
@@ -358,7 +377,7 @@ export const useRuntimeLifecycle = (enabled = true): void => {
 
   useEffect(() => {
     if (!enabled) {
-      return;
+      return undefined;
     }
 
     return bindAppStateLifecycle(


### PR DESCRIPTION
## Summary

- adds an explicit deep-link allowlist derived from the canonical route registry
- rejects untrusted universal-link hosts and non-HTTPS web links before route resolution
- redirects invalid incoming deep links to `/dashboard` for authenticated sessions or `/login` for unauthenticated sessions

## Screenshots

Not applicable. This is a runtime/security change with no visual UI changes.

## Validation

- `npm test -- core/navigation/deep-linking.test.ts core/shell/use-runtime-lifecycle.edge.test.tsx --runInBand` (RED first, failed as expected before implementation)
- `npm test -- core/navigation/deep-linking.test.ts core/shell/use-runtime-lifecycle.edge.test.tsx core/shell/use-runtime-lifecycle.base.test.tsx core/notifications/listener.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint -- --max-warnings 0`
- `npm run policy:check`
- `npm run quality-check` (286 suites, 1763 tests, 94.23% statement coverage)
- pre-commit and pre-push hooks passed

Refs #298
