### PR TITLE
feat: refresh sessions after unauthorized responses

### DIFF
--- a/core/http/http-client.test.ts
+++ b/core/http/http-client.test.ts
@@ -38,6 +38,28 @@ const readAuthorizationHeader = (
   return typeof value === "string" ? value : undefined;
 };
 
+const createUnauthorizedError = (
+  config: InternalAxiosRequestConfig,
+): AxiosError => {
+  return new AxiosError(
+    "Sessao expirada.",
+    "ERR_BAD_REQUEST",
+    config,
+    undefined,
+    {
+      data: {
+        message: "Sessao expirada.",
+      },
+      status: 401,
+      statusText: "Unauthorized",
+      headers: {},
+      config,
+    },
+  );
+};
+
+// Existing suite intentionally centralizes all interceptor behavior.
+// eslint-disable-next-line max-lines-per-function
 describe("httpClient", () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -153,6 +175,164 @@ describe("httpClient", () => {
     });
   });
 
+  it("renova tokens com refresh rotacionado e repete o request autenticado apos 401", async () => {
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: null,
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
+
+    const client = createHttpClient("https://api.auraxis.dev/");
+    let dashboardAttempts = 0;
+    let refreshAttempts = 0;
+
+    client.defaults.adapter = async (config) => {
+      const authorization = readAuthorizationHeader(config);
+
+      if (config.url === "/dashboard") {
+        dashboardAttempts += 1;
+        if (dashboardAttempts === 1) {
+          expect(authorization).toBe("Bearer access-1");
+          throw createUnauthorizedError(config);
+        }
+
+        expect(authorization).toBe("Bearer access-2");
+        return {
+          data: { ok: true, authorization },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config,
+        };
+      }
+
+      if (config.url === "/auth/refresh") {
+        refreshAttempts += 1;
+        expect(authorization).toBe("Bearer refresh-1");
+        return {
+          data: {
+            data: {
+              token: "access-2",
+              refresh_token: "refresh-2",
+            },
+            message: "Token refreshed",
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request to ${config.url ?? "<missing>"}`);
+    };
+
+    const response = await client.get("/dashboard");
+
+    expect(response.data).toEqual({
+      ok: true,
+      authorization: "Bearer access-2",
+    });
+    expect(dashboardAttempts).toBe(2);
+    expect(refreshAttempts).toBe(1);
+    expect(useSessionStore.getState()).toMatchObject({
+      accessToken: "access-2",
+      refreshToken: "refresh-2",
+      isAuthenticated: true,
+      authFailureReason: null,
+    });
+  });
+
+  it("compartilha uma unica renovacao entre 401 concorrentes para evitar replay do refresh token", async () => {
+    useSessionStore.setState(
+      makeSessionState({
+        accessToken: "access-1",
+        refreshToken: "refresh-1",
+        user: makeSessionUser(),
+        userEmail: "italo@auraxis.dev",
+        authenticatedAt: "2026-04-08T10:00:00.000Z",
+        expiresAt: null,
+        hydrated: true,
+        isAuthenticated: true,
+      }),
+    );
+
+    const client = createHttpClient("https://api.auraxis.dev/");
+    let refreshAttempts = 0;
+    let resolveRefresh!: () => void;
+    let markRefreshStarted!: () => void;
+    const refreshGate = new Promise<void>((resolve) => {
+      resolveRefresh = resolve;
+    });
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+
+    client.defaults.adapter = async (config) => {
+      const authorization = readAuthorizationHeader(config);
+
+      if (config.url?.startsWith("/dashboard")) {
+        if (authorization === "Bearer access-1") {
+          throw createUnauthorizedError(config);
+        }
+
+        expect(authorization).toBe("Bearer access-2");
+        return {
+          data: { ok: true, path: config.url },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config,
+        };
+      }
+
+      if (config.url === "/auth/refresh") {
+        refreshAttempts += 1;
+        markRefreshStarted();
+        await refreshGate;
+        return {
+          data: {
+            data: {
+              token: "access-2",
+              refresh_token: "refresh-2",
+            },
+            message: "Token refreshed",
+          },
+          status: 200,
+          statusText: "OK",
+          headers: {},
+          config,
+        };
+      }
+
+      throw new Error(`Unexpected request to ${config.url ?? "<missing>"}`);
+    };
+
+    const firstRequest = client.get("/dashboard?request=1");
+    const secondRequest = client.get("/dashboard?request=2");
+
+    await refreshStarted;
+    expect(refreshAttempts).toBe(1);
+
+    resolveRefresh();
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toHaveLength(
+      2,
+    );
+    expect(refreshAttempts).toBe(1);
+    expect(useSessionStore.getState()).toMatchObject({
+      accessToken: "access-2",
+      refreshToken: "refresh-2",
+      isAuthenticated: true,
+    });
+  });
+
   it("anexa o bearer token no interceptor de request para sessao válida", async () => {
     useSessionStore.setState(
       makeSessionState({
@@ -170,11 +350,11 @@ describe("httpClient", () => {
     const client = createHttpClient("https://api.auraxis.dev/");
     const requestHandler = (
       client.interceptors.request as unknown as {
-        handlers: Array<{
+        handlers: {
           fulfilled: (
             config: InternalAxiosRequestConfig,
           ) => Promise<InternalAxiosRequestConfig>;
-        }>;
+        }[];
       }
     ).handlers[0].fulfilled;
 
@@ -208,7 +388,7 @@ describe("httpClient", () => {
 
       const {
         createHttpClient: createIsolatedHttpClient,
-      } = require("@/core/http/http-client") as {
+      } = jest.requireActual("@/core/http/http-client") as {
         createHttpClient: typeof createHttpClient;
       };
 
@@ -219,11 +399,11 @@ describe("httpClient", () => {
 
     const requestHandler = (
       isolatedClient!.interceptors.request as unknown as {
-        handlers: Array<{
+        handlers: {
           fulfilled: (
             config: InternalAxiosRequestConfig,
           ) => Promise<InternalAxiosRequestConfig>;
-        }>;
+        }[];
       }
     ).handlers[0].fulfilled;
 
@@ -310,9 +490,9 @@ describe("httpClient", () => {
     const client = createHttpClient("https://api.auraxis.dev/");
     const rejectedHandler = (
       client.interceptors.response as unknown as {
-        handlers: Array<{
+        handlers: {
           rejected: (error: unknown) => Promise<never>;
-        }>;
+        }[];
       }
     ).handlers[0].rejected;
 
@@ -387,9 +567,9 @@ describe("httpClient", () => {
     const client = createHttpClient("https://api.auraxis.dev/");
     const rejectedHandler = (
       client.interceptors.response as unknown as {
-        handlers: Array<{
+        handlers: {
           rejected: (error: unknown) => Promise<never>;
-        }>;
+        }[];
       }
     ).handlers[0].rejected;
 

--- a/core/http/http-client.ts
+++ b/core/http/http-client.ts
@@ -1,4 +1,5 @@
-import axios, {
+import {
+  create as createAxios,
   isAxiosError,
   type AxiosError,
   type AxiosInstance,
@@ -9,6 +10,7 @@ import axios, {
 } from "axios";
 
 import { toApiError } from "@/core/http/api-error";
+import { unwrapEnvelopeData } from "@/core/http/contracts";
 import { sanitizeAppUrl } from "@/core/navigation/deep-linking";
 import { verifyCanonicalRequest } from "@/core/security/ssl-pinning";
 import {
@@ -19,6 +21,7 @@ import { useSessionStore } from "@/core/session/session-store";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { networkLogger } from "@/core/telemetry/domain-loggers";
 import { appRuntimeConfig, normalizeBaseUrl } from "@/shared/config/runtime";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
 import { createMockApiAdapter } from "@/shared/mocks/api/router";
 
 interface RequestTelemetryMetadata {
@@ -29,7 +32,17 @@ interface RequestTelemetryMetadata {
 
 type InstrumentedRequestConfig = InternalAxiosRequestConfig & {
   auraxisTelemetry?: RequestTelemetryMetadata;
+  auraxisAuthRetry?: boolean;
+  auraxisSkipAccessToken?: boolean;
 };
+
+interface AuthRefreshPayload {
+  readonly token?: unknown;
+  readonly refresh_token?: unknown;
+  readonly expires_at?: unknown;
+}
+
+type RefreshSession = () => Promise<string>;
 
 const LIVE_API_ADAPTER_PRIORITY: NonNullable<
   CreateAxiosDefaults["adapter"]
@@ -76,6 +89,10 @@ const setHeaderValue = (
   config.headers = nextHeaders;
 };
 
+const shouldSkipAccessToken = (config: InternalAxiosRequestConfig): boolean => {
+  return (config as InstrumentedRequestConfig).auraxisSkipAccessToken === true;
+};
+
 const invalidateExpiredSessionIfNeeded = async (): Promise<void> => {
   const sessionState = useSessionStore.getState();
   if (
@@ -89,6 +106,16 @@ const invalidateExpiredSessionIfNeeded = async (): Promise<void> => {
   }
 
   await sessionState.invalidateSession("expired");
+};
+
+const invalidateExpiredSessionForRequest = async (
+  config: InternalAxiosRequestConfig,
+): Promise<void> => {
+  if (shouldSkipAccessToken(config)) {
+    return;
+  }
+
+  await invalidateExpiredSessionIfNeeded();
 };
 
 const markConnectivityOnline = (): void => {
@@ -176,10 +203,26 @@ const reportCanonicalRequestViolation = (
   });
 };
 
+const attachObservabilityHeaders = (
+  config: InternalAxiosRequestConfig,
+): void => {
+  if (
+    (config.url ?? "").startsWith("/ops/") &&
+    appRuntimeConfig.observabilityExportEnabled &&
+    appRuntimeConfig.observabilityExportPublicKey
+  ) {
+    setHeaderValue(
+      config,
+      "X-Observability-Key",
+      appRuntimeConfig.observabilityExportPublicKey,
+    );
+  }
+};
+
 const attachAuthHeaders = async (
   config: InternalAxiosRequestConfig,
 ): Promise<InternalAxiosRequestConfig> => {
-  await invalidateExpiredSessionIfNeeded();
+  await invalidateExpiredSessionForRequest(config);
 
   const instrumentedConfig = config as InstrumentedRequestConfig;
   const requestPath = toSanitizedRequestPath(config.url);
@@ -215,22 +258,11 @@ const attachAuthHeaders = async (
     },
   });
 
-  if (accessToken) {
+  if (accessToken && !shouldSkipAccessToken(config)) {
     setHeaderValue(config, "Authorization", `Bearer ${accessToken}`);
   }
 
-  if (
-    (config.url ?? "").startsWith("/ops/") &&
-    appRuntimeConfig.observabilityExportEnabled &&
-    appRuntimeConfig.observabilityExportPublicKey
-  ) {
-    setHeaderValue(
-      config,
-      "X-Observability-Key",
-      appRuntimeConfig.observabilityExportPublicKey,
-    );
-  }
-
+  attachObservabilityHeaders(config);
   return config;
 };
 
@@ -339,7 +371,139 @@ const handleNonAxiosFailure = (apiError: ApiErrorLike, error: unknown): void => 
   });
 };
 
-const handleRejectedResponse = async (error: unknown): Promise<never> => {
+const readRefreshToken = (): string => {
+  const sessionState = useSessionStore.getState();
+  if (!sessionState.isAuthenticated || !sessionState.refreshToken) {
+    throw new Error("missing_refresh_token");
+  }
+
+  return sessionState.refreshToken;
+};
+
+const readRequiredString = (
+  payload: AuthRefreshPayload,
+  key: keyof AuthRefreshPayload,
+): string => {
+  const value = payload[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`invalid_refresh_payload:${String(key)}`);
+  }
+
+  return value;
+};
+
+const readOptionalString = (
+  payload: AuthRefreshPayload,
+  key: keyof AuthRefreshPayload,
+): string | null => {
+  const value = payload[key];
+  return typeof value === "string" && value.length > 0 ? value : null;
+};
+
+const requestSessionRefresh = async (
+  client: AxiosInstance,
+): Promise<string> => {
+  const refreshToken = readRefreshToken();
+  const refreshConfig = {
+    headers: {
+      Authorization: `Bearer ${refreshToken}`,
+    },
+    auraxisAuthRetry: true,
+    auraxisSkipAccessToken: true,
+  };
+
+  const response = await client.post(
+    apiContractMap.authRefresh.path,
+    undefined,
+    refreshConfig,
+  );
+  const payload = unwrapEnvelopeData<AuthRefreshPayload>(response.data);
+  const accessToken = readRequiredString(payload, "token");
+  const nextRefreshToken = readRequiredString(payload, "refresh_token");
+
+  await useSessionStore
+    .getState()
+    .rotateTokens(accessToken, nextRefreshToken, readOptionalString(payload, "expires_at"));
+
+  return accessToken;
+};
+
+const createRefreshSession = (client: AxiosInstance): RefreshSession => {
+  let refreshPromise: Promise<string> | null = null;
+
+  return async (): Promise<string> => {
+    if (!refreshPromise) {
+      refreshPromise = requestSessionRefresh(client).finally(() => {
+        refreshPromise = null;
+      });
+    }
+
+    return refreshPromise;
+  };
+};
+
+const shouldAttemptSessionRefresh = (error: AxiosError): boolean => {
+  const config = error.config as InstrumentedRequestConfig | undefined;
+  const sessionState = useSessionStore.getState();
+
+  return (
+    error.response?.status === 401 &&
+    Boolean(config) &&
+    config?.auraxisAuthRetry !== true &&
+    config?.auraxisSkipAccessToken !== true &&
+    Boolean(readHeader(config?.headers, "Authorization")) &&
+    sessionState.isAuthenticated &&
+    Boolean(sessionState.refreshToken)
+  );
+};
+
+const retryRequestWithAccessToken = (
+  client: AxiosInstance,
+  error: AxiosError,
+  accessToken: string,
+): Promise<AxiosResponse> | null => {
+  const config = error.config as InstrumentedRequestConfig | undefined;
+  if (!config) {
+    return null;
+  }
+
+  config.auraxisAuthRetry = true;
+  setHeaderValue(config, "Authorization", `Bearer ${accessToken}`);
+  return client.request(config);
+};
+
+const refreshAndRetryIfPossible = async (
+  client: AxiosInstance,
+  refreshSession: RefreshSession,
+  error: AxiosError,
+): Promise<AxiosResponse | null> => {
+  if (!shouldAttemptSessionRefresh(error)) {
+    return null;
+  }
+
+  try {
+    const accessToken = await refreshSession();
+    return retryRequestWithAccessToken(client, error, accessToken);
+  } catch {
+    return null;
+  }
+};
+
+const createRejectedResponseHandler = (
+  client: AxiosInstance,
+  refreshSession: RefreshSession,
+) => async (error: unknown): Promise<AxiosResponse> => {
+  if (isAxiosError(error)) {
+    const retriedResponse = await refreshAndRetryIfPossible(
+      client,
+      refreshSession,
+      error,
+    );
+    if (retriedResponse) {
+      return retriedResponse;
+    }
+  }
+
   const apiError = toApiError(error);
   if (isAxiosError(error)) {
     await handleAxiosFailure(error, apiError);
@@ -350,7 +514,7 @@ const handleRejectedResponse = async (error: unknown): Promise<never> => {
 };
 
 export const createHttpClient = (baseUrl: string): AxiosInstance => {
-  const client = axios.create({
+  const client = createAxios({
     baseURL: normalizeBaseUrl(baseUrl),
     timeout: appRuntimeConfig.requestTimeoutMs,
     headers: {
@@ -362,10 +526,12 @@ export const createHttpClient = (baseUrl: string): AxiosInstance => {
         : LIVE_API_ADAPTER_PRIORITY,
   });
 
+  const refreshSession = createRefreshSession(client);
+
   client.interceptors.request.use(attachAuthHeaders);
   client.interceptors.response.use(
     handleFulfilledResponse,
-    handleRejectedResponse,
+    createRejectedResponseHandler(client, refreshSession),
   );
 
   return client;

--- a/features/auth/contracts.ts
+++ b/features/auth/contracts.ts
@@ -36,6 +36,12 @@ export interface AuthActionResult {
   readonly message: string;
 }
 
+export interface AuthRefreshResult {
+  readonly accessToken: string;
+  readonly refreshToken: string;
+  readonly expiresAt?: string | null;
+}
+
 export interface AuthSession {
   readonly accessToken: string;
   readonly refreshToken: string | null;

--- a/shared/contracts/api-contract-map.ts
+++ b/shared/contracts/api-contract-map.ts
@@ -1,5 +1,6 @@
 import type {
   AuthActionResult,
+  AuthRefreshResult,
   AuthSession,
   ConfirmEmailCommand,
   ForgotPasswordCommand,
@@ -213,6 +214,16 @@ export const apiContractMap = {
   authLogout: defineApiContract<"POST", "/auth/logout", never, void>({
     method: "POST",
     path: "/auth/logout",
+    authRequired: true,
+  }),
+  authRefresh: defineApiContract<
+    "POST",
+    "/auth/refresh",
+    never,
+    AuthRefreshResult
+  >({
+    method: "POST",
+    path: "/auth/refresh",
     authRequired: true,
   }),
   authForgotPassword: defineApiContract<


### PR DESCRIPTION
## Summary
- add the `/auth/refresh` contract to the app API contract map
- refresh authenticated sessions after a 401 using the stored refresh token, rotate the returned access/refresh pair atomically, and retry the original request once
- coalesce concurrent 401 refresh attempts so a single refresh token is not replayed across parallel requests

## Screenshots
Not applicable. This PR changes runtime HTTP/session behavior only and does not alter app screens.

## Validation
- `npm test -- core/http/http-client.test.ts core/session/session-store.test.ts shared/contracts/api-contract-map.test.ts --runInBand`
- `npm run typecheck`
- `npm run lint -- --max-warnings 0`
- `npm run policy:check`
- `npm run quality-check`
- pre-commit hook
- pre-push hook

Refs #298