### PR TITLE
feat(transactions): add installment form flow

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -69,6 +69,16 @@
       "status": "enabled-prod",
       "description": "Controla a coleta minimizada de analytics de produto no app com provider PostHog e opt-out LGPD.",
       "repositories": ["auraxis-app"]
+    },
+    {
+      "key": "app.transactions.installments",
+      "owner": "platform",
+      "createdAt": "2026-05-17",
+      "removeBy": "2026-12-31",
+      "type": "release",
+      "status": "enabled-dev",
+      "description": "Controla o fluxo mobile installments_v1 para selecionar cartao de credito e parcelar transacoes.",
+      "repositories": ["auraxis-app", "auraxis-api", "auraxis-web"]
     }
   ]
 }

--- a/features/dashboard/components/dashboard-quick-add-fab.tsx
+++ b/features/dashboard/components/dashboard-quick-add-fab.tsx
@@ -8,7 +8,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import type { z } from "zod";
 
 import { useCreateTransactionMutation } from "@/features/transactions/hooks/use-transaction-mutations";
-import { createTransactionSchema } from "@/features/transactions/validators";
+import { createTransactionFieldsSchema } from "@/features/transactions/validators";
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
@@ -16,7 +16,7 @@ import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { triggerHapticImpact } from "@/shared/feedback/haptics";
 import { useT } from "@/shared/i18n";
 
-const quickAddSchema = createTransactionSchema.pick({
+const quickAddSchema = createTransactionFieldsSchema.pick({
   title: true,
   amount: true,
   type: true,

--- a/features/transactions/components/transaction-form.test.tsx
+++ b/features/transactions/components/transaction-form.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, waitFor } from "@testing-library/react-native";
+
+import { TransactionForm } from "@/features/transactions/components/transaction-form";
+import { useCreditCardsQuery } from "@/features/credit-cards/hooks/use-credit-cards-query";
+import { isFeatureEnabled } from "@/shared/feature-flags";
+import { AppProviders } from "@/core/providers/app-providers";
+
+jest.mock("@/features/credit-cards/hooks/use-credit-cards-query", () => ({
+  useCreditCardsQuery: jest.fn(),
+}));
+
+jest.mock("@/shared/feature-flags", () => ({
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockedUseCreditCardsQuery = jest.mocked(useCreditCardsQuery);
+const mockedIsFeatureEnabled = jest.mocked(isFeatureEnabled);
+
+const renderForm = (onSubmit = jest.fn()) => {
+  const rendered = render(
+    <AppProviders>
+      <TransactionForm
+        isSubmitting={false}
+        submitError={null}
+        onSubmit={onSubmit}
+        onCancel={jest.fn()}
+        onDismissError={jest.fn()}
+      />
+    </AppProviders>,
+  );
+  return { ...rendered, onSubmit };
+};
+
+describe("TransactionForm installments", () => {
+  beforeEach(() => {
+    mockedIsFeatureEnabled.mockReturnValue(true);
+    mockedUseCreditCardsQuery.mockReturnValue({
+      data: {
+        creditCards: [
+          {
+            id: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+            name: "Nubank",
+            brand: "mastercard",
+            limitAmount: 5000,
+            closingDay: 20,
+            dueDay: 27,
+            lastFourDigits: "1234",
+          },
+        ],
+      },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+  });
+
+  it("exibe cartoes apenas para despesa quando flag esta habilitada", () => {
+    const { getByText, queryByText } = renderForm();
+
+    expect(getByText("Nubank final 1234")).toBeTruthy();
+
+    fireEvent.press(getByText("Receita"));
+
+    expect(queryByText("Nubank final 1234")).toBeNull();
+  });
+
+  it("habilita parcelamento apos selecionar cartao e submete os campos novos", async () => {
+    const { getByText, getByLabelText, onSubmit } = renderForm();
+
+    fireEvent.changeText(getByLabelText("Titulo"), "Notebook");
+    fireEvent.changeText(getByLabelText("Valor (R$)"), "1200");
+    fireEvent.changeText(getByLabelText("Data"), "2026-05-17");
+    fireEvent.press(getByText("Nubank final 1234"));
+    fireEvent(getByLabelText("Compra parcelada"), "onCheckedChange", true);
+    fireEvent.changeText(getByLabelText("Quantidade de parcelas"), "12");
+    fireEvent.press(getByText("Criar transacao"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Notebook",
+          creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+          isInstallment: true,
+          installmentCount: 12,
+        }),
+      );
+    });
+    expect(getByText("12x de R$ 100,00")).toBeTruthy();
+  });
+
+  it("nao renderiza selecao de cartao quando flag de parcelamento esta desligada", () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+
+    const { queryByText } = renderForm();
+
+    expect(queryByText("Nubank final 1234")).toBeNull();
+  });
+});

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -1,16 +1,22 @@
-import { useEffect, type ReactElement } from "react";
+import { useEffect, useMemo, type ReactElement } from "react";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   Controller,
   useForm,
+  useWatch,
   type Control,
   type FieldErrors,
   type Resolver,
+  type UseFormSetValue,
 } from "react-hook-form";
-import { XStack, YStack } from "tamagui";
+import { Paragraph, XStack, YStack } from "tamagui";
 
+import type { CreditCard } from "@/features/credit-cards/contracts";
+import { useCreditCardsQuery } from "@/features/credit-cards/hooks/use-credit-cards-query";
 import type { TransactionRecord } from "@/features/transactions/contracts";
+import { TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY } from "@/features/transactions/installments-config";
+import { previewInstallments } from "@/features/transactions/utils/preview-installments";
 import {
   createTransactionSchema,
   type CreateTransactionFormValues,
@@ -19,6 +25,9 @@ import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { AppToggleRow } from "@/shared/components/app-toggle-row";
+import { isFeatureEnabled } from "@/shared/feature-flags";
+import { formatCurrency, formatShortDate } from "@/shared/utils/formatters";
 
 const transactionToFormValues = (
   transaction: TransactionRecord | null | undefined,
@@ -31,6 +40,9 @@ const transactionToFormValues = (
       dueDate: new Date().toISOString().slice(0, 10),
       description: null,
       isRecurring: false,
+      creditCardId: null,
+      isInstallment: false,
+      installmentCount: null,
     };
   }
   return {
@@ -40,6 +52,9 @@ const transactionToFormValues = (
     dueDate: transaction.dueDate.slice(0, 10),
     description: transaction.description,
     isRecurring: transaction.isRecurring,
+    creditCardId: transaction.creditCardId,
+    isInstallment: transaction.isInstallment,
+    installmentCount: transaction.installmentCount,
   };
 };
 
@@ -65,6 +80,7 @@ export function TransactionForm({
   onCancel,
   onDismissError,
 }: TransactionFormProps): ReactElement {
+  const installmentsEnabled = isFeatureEnabled(TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY);
   const form = useForm<CreateTransactionFormValues>({
     mode: "onBlur",
     reValidateMode: "onChange",
@@ -88,6 +104,13 @@ export function TransactionForm({
       <YStack gap="$4">
         <TypeToggle control={form.control} />
         <TransactionFormFields control={form.control} errors={form.formState.errors} />
+        {installmentsEnabled ? (
+          <TransactionInstallmentFields
+            control={form.control}
+            errors={form.formState.errors}
+            setValue={form.setValue}
+          />
+        ) : null}
         <AppButton
           onPress={() => {
             void handleSubmit();
@@ -222,3 +245,358 @@ function TransactionFormFields({
     </YStack>
   );
 }
+
+interface TransactionInstallmentFieldsProps {
+  readonly control: Control<CreateTransactionFormValues>;
+  readonly errors: FieldErrors<CreateTransactionFormValues>;
+  readonly setValue: UseFormSetValue<CreateTransactionFormValues>;
+}
+
+function TransactionInstallmentFields({
+  control,
+  errors,
+  setValue,
+}: TransactionInstallmentFieldsProps): ReactElement | null {
+  const creditCardsQuery = useCreditCardsQuery();
+  const transactionType = useWatch({ control, name: "type" });
+  const creditCardId = useWatch({ control, name: "creditCardId" });
+  const isInstallment = useWatch({ control, name: "isInstallment" });
+  const installmentCount = useWatch({ control, name: "installmentCount" });
+  const amount = useWatch({ control, name: "amount" });
+  const dueDate = useWatch({ control, name: "dueDate" });
+
+  useResetInstallmentFields({
+    creditCardId,
+    installmentCount,
+    isInstallment,
+    setValue,
+    transactionType,
+  });
+
+  const creditCards = creditCardsQuery.data?.creditCards ?? [];
+
+  if (transactionType !== "expense") {
+    return null;
+  }
+
+  return (
+    <YStack gap="$3">
+      <CreditCardSelector
+        creditCardId={creditCardId}
+        creditCards={creditCards}
+        creditCardsQuery={creditCardsQuery}
+        errorText={errors.creditCardId?.message}
+        setValue={setValue}
+      />
+      {creditCardId ? <InstallmentToggle control={control} setValue={setValue} /> : null}
+      {creditCardId && isInstallment ? (
+        <InstallmentCountSection
+          amount={amount}
+          control={control}
+          dueDate={dueDate}
+          errorText={errors.installmentCount?.message}
+          installmentCount={installmentCount}
+        />
+      ) : null}
+    </YStack>
+  );
+}
+
+interface ResetInstallmentFieldsInput {
+  readonly creditCardId: string | null;
+  readonly installmentCount: number | null;
+  readonly isInstallment: boolean;
+  readonly setValue: UseFormSetValue<CreateTransactionFormValues>;
+  readonly transactionType: CreateTransactionFormValues["type"];
+}
+
+function useResetInstallmentFields({
+  creditCardId,
+  installmentCount,
+  isInstallment,
+  setValue,
+  transactionType,
+}: ResetInstallmentFieldsInput): void {
+  useEffect(() => {
+    if (transactionType === "expense") {
+      return;
+    }
+    resetInstallmentValues(setValue, { clearCreditCard: creditCardId !== null });
+  }, [creditCardId, setValue, transactionType]);
+
+  useEffect(() => {
+    if (creditCardId) {
+      return;
+    }
+    if (isInstallment || installmentCount !== null) {
+      resetInstallmentValues(setValue);
+    }
+  }, [creditCardId, installmentCount, isInstallment, setValue]);
+}
+
+const resetInstallmentValues = (
+  setValue: UseFormSetValue<CreateTransactionFormValues>,
+  options: { readonly clearCreditCard?: boolean } = {},
+): void => {
+  if (options.clearCreditCard) {
+    setValue("creditCardId", null, { shouldDirty: true, shouldValidate: true });
+  }
+  setValue("isInstallment", false, { shouldDirty: true, shouldValidate: true });
+  setValue("installmentCount", null, { shouldDirty: true, shouldValidate: true });
+};
+
+interface CreditCardSelectorProps {
+  readonly creditCardId: string | null;
+  readonly creditCards: readonly CreditCard[];
+  readonly creditCardsQuery: ReturnType<typeof useCreditCardsQuery>;
+  readonly errorText?: string;
+  readonly setValue: UseFormSetValue<CreateTransactionFormValues>;
+}
+
+function CreditCardSelector({
+  creditCardId,
+  creditCards,
+  creditCardsQuery,
+  errorText,
+  setValue,
+}: CreditCardSelectorProps): ReactElement {
+  return (
+    <YStack gap="$2">
+      <Paragraph color="$color" fontFamily="$body" fontSize="$3">
+        Cartao de credito
+      </Paragraph>
+      <XStack gap="$2" flexWrap="wrap">
+        {creditCardId ? (
+          <AppButton
+            tone="secondary"
+            onPress={() => resetInstallmentValues(setValue, { clearCreditCard: true })}
+          >
+            Sem cartao
+          </AppButton>
+        ) : null}
+        {creditCards.map((creditCard) => (
+          <CreditCardOptionButton
+            key={creditCard.id}
+            creditCard={creditCard}
+            selected={creditCardId === creditCard.id}
+            onSelect={(nextCreditCardId) => {
+              setValue("creditCardId", nextCreditCardId, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+            }}
+          />
+        ))}
+      </XStack>
+      <CreditCardsQueryState query={creditCardsQuery} creditCardsCount={creditCards.length} />
+      {errorText ? (
+        <Paragraph color="$danger" fontFamily="$body" fontSize="$2">
+          {errorText}
+        </Paragraph>
+      ) : null}
+    </YStack>
+  );
+}
+
+interface InstallmentToggleProps {
+  readonly control: Control<CreateTransactionFormValues>;
+  readonly setValue: UseFormSetValue<CreateTransactionFormValues>;
+}
+
+function InstallmentToggle({
+  control,
+  setValue,
+}: InstallmentToggleProps): ReactElement {
+  return (
+    <Controller
+      control={control}
+      name="isInstallment"
+      render={({ field: { value, onChange } }) => (
+        <AppToggleRow
+          label="Compra parcelada"
+          description="Divida a despesa no cartao e visualize o calendario de parcelas."
+          checked={Boolean(value)}
+          testID="transaction-installment-toggle"
+          onCheckedChange={(checked) => {
+            onChange(checked);
+            if (!checked) {
+              setValue("installmentCount", null, {
+                shouldDirty: true,
+                shouldValidate: true,
+              });
+            }
+          }}
+        />
+      )}
+    />
+  );
+}
+
+interface InstallmentCountSectionProps {
+  readonly amount: string;
+  readonly control: Control<CreateTransactionFormValues>;
+  readonly dueDate: string;
+  readonly errorText?: string;
+  readonly installmentCount: number | null;
+}
+
+function InstallmentCountSection({
+  amount,
+  control,
+  dueDate,
+  errorText,
+  installmentCount,
+}: InstallmentCountSectionProps): ReactElement {
+  return (
+    <>
+      <Controller
+        control={control}
+        name="installmentCount"
+        render={({ field: { onBlur, onChange, value } }) => (
+          <AppInputField
+            id="tx-installment-count"
+            label="Quantidade de parcelas"
+            placeholder="12"
+            keyboardType="number-pad"
+            value={value === null ? "" : String(value)}
+            onBlur={onBlur}
+            onChangeText={(text) => onChange(parseInstallmentCountInput(text))}
+            errorText={errorText}
+            helperText="De 2 a 60 parcelas."
+          />
+        )}
+      />
+      <InstallmentsPreview
+        amount={amount}
+        dueDate={dueDate}
+        installmentCount={installmentCount}
+      />
+    </>
+  );
+}
+
+interface CreditCardOptionButtonProps {
+  readonly creditCard: CreditCard;
+  readonly selected: boolean;
+  readonly onSelect: (creditCardId: string) => void;
+}
+
+function CreditCardOptionButton({
+  creditCard,
+  selected,
+  onSelect,
+}: CreditCardOptionButtonProps): ReactElement {
+  const label = formatCreditCardLabel(creditCard);
+  return (
+    <AppButton
+      tone={selected ? "primary" : "secondary"}
+      accessibilityState={{ selected }}
+      onPress={() => onSelect(creditCard.id)}
+    >
+      {label}
+    </AppButton>
+  );
+}
+
+interface CreditCardsQueryStateProps {
+  readonly query: ReturnType<typeof useCreditCardsQuery>;
+  readonly creditCardsCount: number;
+}
+
+function CreditCardsQueryState({
+  query,
+  creditCardsCount,
+}: CreditCardsQueryStateProps): ReactElement | null {
+  if (query.isLoading) {
+    return (
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+        Carregando cartoes.
+      </Paragraph>
+    );
+  }
+  if (query.isError) {
+    return (
+      <Paragraph color="$danger" fontFamily="$body" fontSize="$2">
+        Nao foi possivel carregar cartoes.
+      </Paragraph>
+    );
+  }
+  if (creditCardsCount === 0) {
+    return (
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+        Cadastre um cartao para parcelar despesas.
+      </Paragraph>
+    );
+  }
+  return null;
+}
+
+interface InstallmentsPreviewProps {
+  readonly amount: string;
+  readonly dueDate: string;
+  readonly installmentCount: number | null;
+}
+
+function InstallmentsPreview({
+  amount,
+  dueDate,
+  installmentCount,
+}: InstallmentsPreviewProps): ReactElement | null {
+  const preview = useMemo(() => {
+    if (installmentCount === null || installmentCount < 2 || amount.trim().length === 0) {
+      return null;
+    }
+    const firstDueDate = parseDueDateForPreview(dueDate);
+    if (!firstDueDate) {
+      return null;
+    }
+    try {
+      return previewInstallments({ amount, installmentCount, firstDueDate });
+    } catch {
+      return null;
+    }
+  }, [amount, dueDate, installmentCount]);
+
+  if (!preview) {
+    return null;
+  }
+
+  const lastInstallment = preview.installments.at(-1);
+  return (
+    <YStack gap="$1" backgroundColor="$surfaceRaised" padding="$3" borderRadius="$1">
+      <Paragraph color="$color" fontFamily="$body" fontSize="$3">
+        {installmentCount}x de {formatPreviewCurrency(preview.perInstallmentAmount)}
+      </Paragraph>
+      {lastInstallment ? (
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+          Primeira em {formatShortDate(preview.installments[0].dueDate)} - ultima em{" "}
+          {formatShortDate(lastInstallment.dueDate)}
+        </Paragraph>
+      ) : null}
+    </YStack>
+  );
+}
+
+const parseInstallmentCountInput = (text: string): number | null => {
+  const digits = text.replace(/\D/g, "");
+  if (digits.length === 0) {
+    return null;
+  }
+  return Number.parseInt(digits, 10);
+};
+
+const parseDueDateForPreview = (value: string): Date | null => {
+  const date = new Date(`${value}T00:00:00.000Z`);
+  return Number.isNaN(date.getTime()) ? null : date;
+};
+
+const formatCreditCardLabel = (creditCard: CreditCard): string => {
+  if (creditCard.lastFourDigits) {
+    return `${creditCard.name} final ${creditCard.lastFourDigits}`;
+  }
+  return creditCard.name;
+};
+
+const formatPreviewCurrency = (value: string): string => {
+  return formatCurrency(Number(value)).replace(/\u00A0/g, " ");
+};

--- a/features/transactions/hooks/use-transactions-screen-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.test.ts
@@ -95,6 +95,52 @@ describe("useTransactionsScreenController data projection", () => {
     });
     expect(result.current.transactions.map((t) => t.id)).toEqual(["a"]);
   });
+
+  it("projeta numero da parcela e filtra outras parcelas do grupo", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        transactions: [
+          buildRecord({
+            id: "p2",
+            dueDate: "2026-06-17",
+            isInstallment: true,
+            installmentCount: 2,
+            installmentGroupId: "grp-1",
+          }),
+          buildRecord({
+            id: "cash",
+            dueDate: "2026-05-20",
+            isInstallment: false,
+            installmentCount: null,
+            installmentGroupId: null,
+          }),
+          buildRecord({
+            id: "p1",
+            dueDate: "2026-05-17",
+            isInstallment: true,
+            installmentCount: 2,
+            installmentGroupId: "grp-1",
+          }),
+        ],
+        pagination: { total: 3 },
+      },
+    } as never);
+
+    const { result } = renderHook(() => useTransactionsScreenController());
+
+    expect(result.current.transactions.find((item) => item.id === "p1")).toEqual(
+      expect.objectContaining({ installmentNumber: 1 }),
+    );
+    expect(result.current.transactions.find((item) => item.id === "p2")).toEqual(
+      expect.objectContaining({ installmentNumber: 2 }),
+    );
+
+    act(() => {
+      result.current.handleShowInstallmentGroup("grp-1");
+    });
+
+    expect(result.current.transactions.map((item) => item.id)).toEqual(["p2", "p1"]);
+  });
 });
 
 describe("useTransactionsScreenController mutations", () => {
@@ -117,12 +163,43 @@ describe("useTransactionsScreenController mutations", () => {
         dueDate: "2026-04-30",
         description: null,
         isRecurring: false,
+        creditCardId: null,
+        isInstallment: false,
+        installmentCount: null,
       });
     });
     expect(createStub.mutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Conta", amount: "150.75", type: "expense" }),
     );
     expect(result.current.formMode.kind).toBe("closed");
+  });
+
+  it("create preserva dados de cartao e parcelamento no payload", async () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    act(() => {
+      result.current.handleOpenCreate();
+    });
+    await act(async () => {
+      await result.current.handleSubmit({
+        title: "Notebook",
+        amount: "1200",
+        type: "expense",
+        dueDate: "2026-05-17",
+        description: null,
+        isRecurring: false,
+        creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+        isInstallment: true,
+        installmentCount: 12,
+      });
+    });
+
+    expect(createStub.mutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+        isInstallment: true,
+        installmentCount: 12,
+      }),
+    );
   });
 
   it("edit dispara updateMutation com transactionId", async () => {
@@ -138,6 +215,9 @@ describe("useTransactionsScreenController mutations", () => {
         dueDate: "2026-04-30",
         description: null,
         isRecurring: false,
+        creditCardId: null,
+        isInstallment: false,
+        installmentCount: null,
       });
     });
     expect(updateStub.mutateAsync).toHaveBeenCalledWith(
@@ -159,6 +239,9 @@ describe("useTransactionsScreenController mutations", () => {
         dueDate: "2026-04-30",
         description: null,
         isRecurring: false,
+        creditCardId: null,
+        isInstallment: false,
+        installmentCount: null,
       });
     });
     expect(result.current.submitError).toBeInstanceOf(Error);
@@ -188,6 +271,9 @@ describe("useTransactionsScreenController mutations", () => {
         dueDate: "2026-04-30",
         description: null,
         isRecurring: false,
+        creditCardId: null,
+        isInstallment: false,
+        installmentCount: null,
       });
     });
     act(() => {

--- a/features/transactions/hooks/use-transactions-screen-controller.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.ts
@@ -28,6 +28,10 @@ export interface TransactionViewModel {
   readonly dueDate: string;
   readonly status: string;
   readonly isRecurring: boolean;
+  readonly isInstallment: boolean;
+  readonly installmentCount: number | null;
+  readonly installmentGroupId: string | null;
+  readonly installmentNumber: number | null;
 }
 
 export interface TransactionsScreenController {
@@ -36,6 +40,7 @@ export interface TransactionsScreenController {
   readonly total: number;
   readonly typeFilter: TransactionsTypeFilter;
   readonly setTypeFilter: (filter: TransactionsTypeFilter) => void;
+  readonly installmentGroupFilter: string | null;
   readonly viewMode: TransactionsViewMode;
   readonly setViewMode: (mode: TransactionsViewMode) => void;
   readonly formMode: TransactionFormMode;
@@ -49,10 +54,15 @@ export interface TransactionsScreenController {
   readonly handleSubmit: (values: CreateTransactionFormValues) => Promise<void>;
   readonly handleDelete: (transactionId: string) => Promise<void>;
   readonly handleDuplicate: (transactionId: string) => Promise<void>;
+  readonly handleShowInstallmentGroup: (installmentGroupId: string) => void;
+  readonly handleClearInstallmentGroupFilter: () => void;
   readonly dismissSubmitError: () => void;
 }
 
-const toViewModel = (record: TransactionRecord): TransactionViewModel => ({
+const toViewModel = (
+  record: TransactionRecord,
+  installmentNumber: number | null,
+): TransactionViewModel => ({
   id: record.id,
   title: record.title,
   amount: record.amount,
@@ -60,6 +70,10 @@ const toViewModel = (record: TransactionRecord): TransactionViewModel => ({
   dueDate: record.dueDate,
   status: record.status,
   isRecurring: record.isRecurring,
+  isInstallment: record.isInstallment,
+  installmentCount: record.installmentCount,
+  installmentGroupId: record.installmentGroupId,
+  installmentNumber,
 });
 
 const matchesFilter = (
@@ -72,6 +86,34 @@ const matchesFilter = (
   return type === filter;
 };
 
+const buildInstallmentNumberMap = (
+  records: readonly TransactionRecord[],
+): ReadonlyMap<string, number> => {
+  const groups = new Map<string, TransactionRecord[]>();
+  records.forEach((record) => {
+    if (!record.isInstallment || !record.installmentGroupId) {
+      return;
+    }
+    const group = groups.get(record.installmentGroupId) ?? [];
+    group.push(record);
+    groups.set(record.installmentGroupId, group);
+  });
+
+  const installmentNumbers = new Map<string, number>();
+  groups.forEach((group) => {
+    group
+      .sort((a, b) => {
+        const dateComparison = a.dueDate.localeCompare(b.dueDate);
+        return dateComparison === 0 ? a.id.localeCompare(b.id) : dateComparison;
+      })
+      .forEach((record, index) => {
+        installmentNumbers.set(record.id, index + 1);
+      });
+  });
+
+  return installmentNumbers;
+};
+
 const buildSubmitPayload = (values: CreateTransactionFormValues) => ({
   title: values.title,
   amount: normalizeAmount(values.amount),
@@ -79,6 +121,13 @@ const buildSubmitPayload = (values: CreateTransactionFormValues) => ({
   dueDate: values.dueDate,
   description: values.description,
   isRecurring: values.isRecurring ?? false,
+  creditCardId: values.type === "expense" ? values.creditCardId : null,
+  isInstallment:
+    values.type === "expense" && values.creditCardId ? values.isInstallment : false,
+  installmentCount:
+    values.type === "expense" && values.creditCardId && values.isInstallment
+      ? values.installmentCount
+      : null,
 });
 
 /**
@@ -98,13 +147,18 @@ export function useTransactionsScreenController(): TransactionsScreenController 
   const [duplicatingTransactionId, setDuplicatingTransactionId] = useState<string | null>(null);
   const [typeFilter, setTypeFilter] = useState<TransactionsTypeFilter>("all");
   const [viewMode, setViewMode] = useState<TransactionsViewMode>("list");
+  const [installmentGroupFilter, setInstallmentGroupFilter] = useState<string | null>(null);
 
   const transactions = useMemo<readonly TransactionViewModel[]>(() => {
     const records = transactionsQuery.data?.transactions ?? [];
+    const installmentNumbers = buildInstallmentNumberMap(records);
     return records
       .filter((record) => matchesFilter(record.type, typeFilter))
-      .map(toViewModel);
-  }, [transactionsQuery.data, typeFilter]);
+      .filter((record) =>
+        installmentGroupFilter ? record.installmentGroupId === installmentGroupFilter : true,
+      )
+      .map((record) => toViewModel(record, installmentNumbers.get(record.id) ?? null));
+  }, [installmentGroupFilter, transactionsQuery.data, typeFilter]);
 
   const handleSubmit = async (values: CreateTransactionFormValues): Promise<void> => {
     setSubmitError(null);
@@ -154,6 +208,9 @@ export function useTransactionsScreenController(): TransactionsScreenController 
         dueDate: new Date().toISOString().slice(0, 10),
         description: original.description ?? null,
         isRecurring: original.isRecurring,
+        creditCardId: original.type === "expense" ? original.creditCardId : null,
+        isInstallment: false,
+        installmentCount: null,
       });
     } catch (error) {
       setSubmitError(error);
@@ -168,6 +225,7 @@ export function useTransactionsScreenController(): TransactionsScreenController 
     total: transactionsQuery.data?.pagination.total ?? 0,
     typeFilter,
     setTypeFilter,
+    installmentGroupFilter,
     viewMode,
     setViewMode,
     formMode,
@@ -190,6 +248,13 @@ export function useTransactionsScreenController(): TransactionsScreenController 
     handleSubmit,
     handleDelete,
     handleDuplicate,
+    handleShowInstallmentGroup: (installmentGroupId) => {
+      setInstallmentGroupFilter(installmentGroupId);
+      setTypeFilter("expense");
+    },
+    handleClearInstallmentGroupFilter: () => {
+      setInstallmentGroupFilter(null);
+    },
     dismissSubmitError: () => {
       setSubmitError(null);
       createMutation.reset();

--- a/features/transactions/installments-config.ts
+++ b/features/transactions/installments-config.ts
@@ -1,0 +1,2 @@
+export const TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY =
+  "app.transactions.installments";

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -121,42 +121,15 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
       title="Transacoes"
       description={`${controller.total} registradas`}
     >
-      <YStack gap="$3">
-        <ViewToggle
-          mode={controller.viewMode}
-          onChange={controller.setViewMode}
-          listLabel={t("transactions.view.list")}
-          calendarLabel={t("transactions.view.calendar")}
-        />
-        <XStack gap="$2" flexWrap="wrap">
-          {FILTER_ORDER.map((filter) => (
-            <AppButton
-              key={filter}
-              tone={controller.typeFilter === filter ? "primary" : "secondary"}
-              onPress={() => controller.setTypeFilter(filter)}
-            >
-              {FILTER_LABELS[filter]}
-            </AppButton>
-          ))}
-        </XStack>
-        <XStack gap="$2">
-          <AppButton flex={1} onPress={controller.handleOpenCreate}>
-            Nova transacao
-          </AppButton>
-          <AppButton
-            flex={1}
-            tone="secondary"
-            onPress={() => setExportSheetOpen(true)}
-          >
-            {t("transactions.export.title")}
-          </AppButton>
-        </XStack>
-        {importEnabled ? (
-          <AppButton tone="secondary" onPress={handleOpenImport}>
-            Importar planilha
-          </AppButton>
-        ) : null}
-      </YStack>
+      <FilterHeaderControls
+        controller={controller}
+        importEnabled={importEnabled}
+        listLabel={t("transactions.view.list")}
+        calendarLabel={t("transactions.view.calendar")}
+        exportLabel={t("transactions.export.title")}
+        onOpenExport={() => setExportSheetOpen(true)}
+        onOpenImport={handleOpenImport}
+      />
       <Modal
         visible={exportSheetOpen}
         transparent
@@ -173,6 +146,86 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
         />
       </Modal>
     </AppSurfaceCard>
+  );
+}
+
+interface FilterHeaderControlsProps extends ControllerProps {
+  readonly importEnabled: boolean;
+  readonly listLabel: string;
+  readonly calendarLabel: string;
+  readonly exportLabel: string;
+  readonly onOpenExport: () => void;
+  readonly onOpenImport: () => void;
+}
+
+function FilterHeaderControls({
+  controller,
+  importEnabled,
+  listLabel,
+  calendarLabel,
+  exportLabel,
+  onOpenExport,
+  onOpenImport,
+}: FilterHeaderControlsProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      <ViewToggle
+        mode={controller.viewMode}
+        onChange={controller.setViewMode}
+        listLabel={listLabel}
+        calendarLabel={calendarLabel}
+      />
+      <TransactionTypeFilter controller={controller} />
+      <XStack gap="$2">
+        <AppButton flex={1} onPress={controller.handleOpenCreate}>
+          Nova transacao
+        </AppButton>
+        <AppButton flex={1} tone="secondary" onPress={onOpenExport}>
+          {exportLabel}
+        </AppButton>
+      </XStack>
+      {importEnabled ? (
+        <AppButton tone="secondary" onPress={onOpenImport}>
+          Importar planilha
+        </AppButton>
+      ) : null}
+      <InstallmentGroupFilterNotice controller={controller} />
+    </YStack>
+  );
+}
+
+function TransactionTypeFilter({ controller }: ControllerProps): ReactElement {
+  return (
+    <XStack gap="$2" flexWrap="wrap">
+      {FILTER_ORDER.map((filter) => (
+        <AppButton
+          key={filter}
+          tone={controller.typeFilter === filter ? "primary" : "secondary"}
+          onPress={() => controller.setTypeFilter(filter)}
+        >
+          {FILTER_LABELS[filter]}
+        </AppButton>
+      ))}
+    </XStack>
+  );
+}
+
+function InstallmentGroupFilterNotice({
+  controller,
+}: ControllerProps): ReactElement | null {
+  if (!controller.installmentGroupFilter) {
+    return null;
+  }
+
+  return (
+    <XStack alignItems="center" gap="$2">
+      <Paragraph color="$muted" flex={1} fontFamily="$body" fontSize="$2">
+        Mostrando parcelas da mesma compra.
+      </Paragraph>
+      <AppButton tone="secondary" onPress={controller.handleClearInstallmentGroupFilter}>
+        Mostrar todas
+      </AppButton>
+    </XStack>
   );
 }
 
@@ -338,6 +391,11 @@ function TransactionsListCard({ controller }: ControllerProps): ReactElement {
 
 function TransactionsList({ controller }: ControllerProps): ReactElement {
   const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
+  const [detailTransactionId, setDetailTransactionId] = useState<string | null>(null);
+  const detailTransaction = useMemo(
+    () => controller.transactions.find((item) => item.id === detailTransactionId) ?? null,
+    [controller.transactions, detailTransactionId],
+  );
 
   const handleEdit = useCallback(
     (txId: string): void => {
@@ -365,12 +423,21 @@ function TransactionsList({ controller }: ControllerProps): ReactElement {
     [controller],
   );
 
+  const handleDetails = useCallback((txId: string): void => {
+    setDetailTransactionId(txId);
+  }, []);
+
+  const handleCloseDetails = useCallback((): void => {
+    setDetailTransactionId(null);
+  }, []);
+
   const renderItem = useCallback(
     ({ item }: { readonly item: TransactionViewModel }) => (
       <TransactionRow
         tx={item}
         isDeleting={controller.deletingTransactionId === item.id}
         isDuplicating={controller.duplicatingTransactionId === item.id}
+        onDetails={handleDetails}
         onEdit={handleEdit}
         onDelete={handleDelete}
         onDuplicate={handleDuplicate}
@@ -380,23 +447,31 @@ function TransactionsList({ controller }: ControllerProps): ReactElement {
       controller.deletingTransactionId,
       controller.duplicatingTransactionId,
       handleDelete,
+      handleDetails,
       handleDuplicate,
       handleEdit,
     ],
   );
 
   return (
-    <FlashList
-      data={controller.transactions}
-      keyExtractor={extractTransactionKey}
-      renderItem={renderItem}
-      contentContainerStyle={listContainerStyle}
-      ItemSeparatorComponent={ListSeparator}
-      refreshControl={
-        <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-      }
-      testID="transactions-flashlist"
-    />
+    <>
+      <FlashList
+        data={controller.transactions}
+        keyExtractor={extractTransactionKey}
+        renderItem={renderItem}
+        contentContainerStyle={listContainerStyle}
+        ItemSeparatorComponent={ListSeparator}
+        refreshControl={
+          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
+        }
+        testID="transactions-flashlist"
+      />
+      <TransactionDetailModal
+        transaction={detailTransaction}
+        onClose={handleCloseDetails}
+        onShowInstallmentGroup={controller.handleShowInstallmentGroup}
+      />
+    </>
   );
 }
 
@@ -412,6 +487,7 @@ interface TransactionRowProps {
   readonly tx: TransactionViewModel;
   readonly isDeleting: boolean;
   readonly isDuplicating: boolean;
+  readonly onDetails: (txId: string) => void;
   readonly onEdit: (txId: string) => void;
   readonly onDelete: (txId: string) => void;
   readonly onDuplicate: (txId: string) => void;
@@ -421,10 +497,16 @@ const TransactionRow = function TransactionRow({
   tx,
   isDeleting,
   isDuplicating,
+  onDetails,
   onEdit,
   onDelete,
   onDuplicate,
 }: TransactionRowProps): ReactElement {
+  const installmentLabel = getInstallmentLabel(tx);
+  const handleDetails = useCallback(() => {
+    onDetails(tx.id);
+  }, [onDetails, tx.id]);
+
   const handleEdit = useCallback(() => {
     onEdit(tx.id);
   }, [onEdit, tx.id]);
@@ -455,12 +537,22 @@ const TransactionRow = function TransactionRow({
               <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
                 {formatShortDate(tx.dueDate)}
               </Paragraph>
+              {installmentLabel ? (
+                <AppBadge tone="default">{installmentLabel}</AppBadge>
+              ) : null}
             </YStack>
             <AppBadge tone={STATUS_TONE[tx.status] ?? "default"}>{tx.status}</AppBadge>
           </XStack>
         }
       />
       <XStack gap="$2" flexWrap="wrap">
+        <AppButton
+          tone="secondary"
+          onPress={handleDetails}
+          disabled={isDeleting || isDuplicating}
+        >
+          Detalhes
+        </AppButton>
         <AppButton tone="secondary" onPress={handleEdit} disabled={isDeleting || isDuplicating}>
           Editar
         </AppButton>
@@ -477,4 +569,77 @@ const TransactionRow = function TransactionRow({
       </XStack>
     </YStack>
   );
+};
+
+interface TransactionDetailModalProps {
+  readonly transaction: TransactionViewModel | null;
+  readonly onClose: () => void;
+  readonly onShowInstallmentGroup: (installmentGroupId: string) => void;
+}
+
+function TransactionDetailModal({
+  transaction,
+  onClose,
+  onShowInstallmentGroup,
+}: TransactionDetailModalProps): ReactElement {
+  const installmentLabel = transaction ? getInstallmentLabel(transaction) : null;
+  const installmentGroupId = transaction?.installmentGroupId ?? null;
+  const visible = Boolean(transaction);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={onClose}
+    >
+      <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
+        <YStack
+          backgroundColor="$background"
+          padding="$4"
+          gap="$3"
+          borderTopLeftRadius="$3"
+          borderTopRightRadius="$3"
+        >
+          {transaction ? (
+            <AppSurfaceCard title="Detalhes da transacao" description={transaction.title}>
+              <YStack gap="$3">
+                <AppKeyValueRow
+                  label="Valor"
+                  value={`${transaction.type === "income" ? "+" : "-"}${transaction.amount}`}
+                  helperText={formatShortDate(transaction.dueDate)}
+                />
+                <AppKeyValueRow label="Status" value={transaction.status} />
+                {installmentLabel ? (
+                  <AppKeyValueRow label="Parcelamento" value={installmentLabel} />
+                ) : null}
+                {installmentGroupId ? (
+                  <AppButton
+                    tone="secondary"
+                    onPress={() => {
+                      onShowInstallmentGroup(installmentGroupId);
+                      onClose();
+                    }}
+                  >
+                    Ver outras parcelas
+                  </AppButton>
+                ) : null}
+                <AppButton onPress={onClose}>Fechar</AppButton>
+              </YStack>
+            </AppSurfaceCard>
+          ) : null}
+        </YStack>
+      </YStack>
+    </Modal>
+  );
+}
+
+const getInstallmentLabel = (tx: TransactionViewModel): string | null => {
+  if (!tx.isInstallment || !tx.installmentCount) {
+    return null;
+  }
+  if (tx.installmentNumber) {
+    return `Parcela ${tx.installmentNumber}/${tx.installmentCount}`;
+  }
+  return `Parcelado em ${tx.installmentCount}x`;
 };

--- a/features/transactions/utils/preview-installments.test.ts
+++ b/features/transactions/utils/preview-installments.test.ts
@@ -1,0 +1,52 @@
+import { previewInstallments } from "@/features/transactions/utils/preview-installments";
+
+describe("previewInstallments", () => {
+  it("gera 12 parcelas de R$ 100 a partir de 2026-05-17", () => {
+    const preview = previewInstallments({
+      amount: "1200.00",
+      installmentCount: 12,
+      firstDueDate: new Date("2026-05-17T00:00:00.000Z"),
+    });
+
+    expect(preview.perInstallmentAmount).toBe("100.00");
+    expect(preview.installments).toHaveLength(12);
+    expect(preview.installments[0]).toEqual({
+      installmentNumber: 1,
+      dueDate: "2026-05-17",
+      amount: "100.00",
+    });
+    expect(preview.installments[11]).toEqual({
+      installmentNumber: 12,
+      dueDate: "2027-04-17",
+      amount: "100.00",
+    });
+  });
+
+  it("distribui centavos quando a divisao nao e inteira", () => {
+    const preview = previewInstallments({
+      amount: "100.00",
+      installmentCount: 3,
+      firstDueDate: new Date("2026-05-17T00:00:00.000Z"),
+    });
+
+    expect(preview.installments.map((item) => item.amount)).toEqual([
+      "33.34",
+      "33.33",
+      "33.33",
+    ]);
+    expect(preview.totalAmount).toBe("100.00");
+  });
+
+  it("ancora fim de mes em 31/01 + 1 mes = 28/02", () => {
+    const preview = previewInstallments({
+      amount: "200.00",
+      installmentCount: 2,
+      firstDueDate: new Date("2026-01-31T00:00:00.000Z"),
+    });
+
+    expect(preview.installments.map((item) => item.dueDate)).toEqual([
+      "2026-01-31",
+      "2026-02-28",
+    ]);
+  });
+});

--- a/features/transactions/utils/preview-installments.ts
+++ b/features/transactions/utils/preview-installments.ts
@@ -1,0 +1,93 @@
+export interface InstallmentPreviewInput {
+  readonly amount: string;
+  readonly installmentCount: number;
+  readonly firstDueDate: Date;
+}
+
+export interface InstallmentPreviewItem {
+  readonly installmentNumber: number;
+  readonly dueDate: string;
+  readonly amount: string;
+}
+
+export interface InstallmentPreview {
+  readonly totalAmount: string;
+  readonly perInstallmentAmount: string;
+  readonly installments: readonly InstallmentPreviewItem[];
+}
+
+const formatCents = (cents: number): string => {
+  const sign = cents < 0 ? "-" : "";
+  const absolute = Math.abs(cents);
+  const units = Math.trunc(absolute / 100);
+  const decimals = String(absolute % 100).padStart(2, "0");
+  return `${sign}${units}.${decimals}`;
+};
+
+const parseAmountToCents = (amount: string): number => {
+  const trimmed = amount.trim();
+  const normalized = trimmed.includes(",")
+    ? trimmed.replace(/\./g, "").replace(",", ".")
+    : trimmed;
+  const [unitsRaw = "0", decimalsRaw = ""] = normalized.split(".");
+  const units = Number.parseInt(unitsRaw, 10);
+  const decimals = Number.parseInt(decimalsRaw.padEnd(2, "0").slice(0, 2), 10);
+
+  if (!Number.isFinite(units) || !Number.isFinite(decimals)) {
+    throw new Error("Invalid amount for installment preview.");
+  }
+
+  return units * 100 + decimals;
+};
+
+const toIsoDate = (date: Date): string => date.toISOString().slice(0, 10);
+
+const getLastDayOfUtcMonth = (year: number, monthIndex: number): number => {
+  return new Date(Date.UTC(year, monthIndex + 1, 0)).getUTCDate();
+};
+
+const addUtcMonthsClamped = (date: Date, monthsToAdd: number): Date => {
+  const year = date.getUTCFullYear();
+  const monthIndex = date.getUTCMonth();
+  const day = date.getUTCDate();
+  const targetMonthStart = new Date(Date.UTC(year, monthIndex + monthsToAdd, 1));
+  const targetYear = targetMonthStart.getUTCFullYear();
+  const targetMonthIndex = targetMonthStart.getUTCMonth();
+  const clampedDay = Math.min(
+    day,
+    getLastDayOfUtcMonth(targetYear, targetMonthIndex),
+  );
+
+  return new Date(Date.UTC(targetYear, targetMonthIndex, clampedDay));
+};
+
+export const previewInstallments = ({
+  amount,
+  installmentCount,
+  firstDueDate,
+}: InstallmentPreviewInput): InstallmentPreview => {
+  if (!Number.isInteger(installmentCount) || installmentCount < 1) {
+    throw new Error("Invalid installment count.");
+  }
+  if (Number.isNaN(firstDueDate.getTime())) {
+    throw new Error("Invalid first due date.");
+  }
+
+  const totalCents = parseAmountToCents(amount);
+  const baseCents = Math.trunc(totalCents / installmentCount);
+  const remainderCents = totalCents % installmentCount;
+  const installments = Array.from({ length: installmentCount }, (_, index) => {
+    const amountCents = baseCents + (index < remainderCents ? 1 : 0);
+    return {
+      installmentNumber: index + 1,
+      dueDate: toIsoDate(addUtcMonthsClamped(firstDueDate, index)),
+      amount: formatCents(amountCents),
+    };
+  });
+
+  return {
+    totalAmount: formatCents(totalCents),
+    perInstallmentAmount: installments[0]?.amount ?? "0.00",
+    installments,
+  };
+};

--- a/features/transactions/validators.test.ts
+++ b/features/transactions/validators.test.ts
@@ -9,6 +9,9 @@ const validBase = {
   amount: "2300.00",
   type: "expense" as const,
   dueDate: "2026-04-30",
+  creditCardId: null,
+  isInstallment: false,
+  installmentCount: null,
 };
 
 describe("createTransactionSchema", () => {
@@ -52,6 +55,61 @@ describe("createTransactionSchema", () => {
   it("rejeita titulo curto", () => {
     expect(() =>
       createTransactionSchema.parse({ ...validBase, title: "A" }),
+    ).toThrow();
+  });
+
+  it("aceita despesa parcelada com cartao e quantidade valida", () => {
+    const parsed = createTransactionSchema.parse({
+      ...validBase,
+      creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+      isInstallment: true,
+      installmentCount: 12,
+    });
+
+    expect(parsed).toEqual(
+      expect.objectContaining({
+        creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+        isInstallment: true,
+        installmentCount: 12,
+      }),
+    );
+  });
+
+  it("exige quantidade de parcelas quando despesa parcelada esta ativa", () => {
+    expect(() =>
+      createTransactionSchema.parse({
+        ...validBase,
+        creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+        isInstallment: true,
+        installmentCount: null,
+      }),
+    ).toThrow();
+  });
+
+  it("limita quantidade de parcelas entre 2 e 60", () => {
+    const creditCardId = "018f3a22-6ec3-7dc2-a93a-1bbdecb02000";
+
+    expect(() =>
+      createTransactionSchema.parse({
+        ...validBase,
+        creditCardId,
+        isInstallment: true,
+        installmentCount: 1,
+      }),
+    ).toThrow();
+    expect(() =>
+      createTransactionSchema.parse({
+        ...validBase,
+        creditCardId,
+        isInstallment: true,
+        installmentCount: 61,
+      }),
+    ).toThrow();
+  });
+
+  it("rejeita cartao de credito sem formato uuid", () => {
+    expect(() =>
+      createTransactionSchema.parse({ ...validBase, creditCardId: "card-1" }),
     ).toThrow();
   });
 });

--- a/features/transactions/validators.ts
+++ b/features/transactions/validators.ts
@@ -24,14 +24,49 @@ const isoDate = z
 
 export const transactionTypeSchema = z.enum(["income", "expense"]);
 
-export const createTransactionSchema = z.object({
+const creditCardIdSchema = z.string().uuid("Cartao invalido.").nullable();
+
+const installmentCountSchema = z
+  .number()
+  .int("Informe uma quantidade inteira de parcelas.")
+  .min(2, "Use pelo menos 2 parcelas.")
+  .max(60, "Use no maximo 60 parcelas.")
+  .nullable();
+
+const validateInstallmentRequirements = (
+  values: {
+    readonly isInstallment?: boolean | null;
+    readonly installmentCount?: number | null;
+  },
+  ctx: z.RefinementCtx,
+): void => {
+  if (
+    values.isInstallment === true &&
+    (values.installmentCount === null || values.installmentCount === undefined)
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["installmentCount"],
+      message: "Informe a quantidade de parcelas.",
+    });
+  }
+};
+
+export const createTransactionFieldsSchema = z.object({
   title: trimmedString(2, 120, "Informe um titulo de 2 a 120 caracteres."),
   amount: decimalAmount,
   type: transactionTypeSchema,
   dueDate: isoDate,
   description: z.string().trim().max(500, "Descricao muito longa.").optional().nullable(),
   isRecurring: z.boolean().optional(),
+  creditCardId: creditCardIdSchema.default(null),
+  isInstallment: z.boolean().default(false),
+  installmentCount: installmentCountSchema.default(null),
 });
+
+export const createTransactionSchema = createTransactionFieldsSchema.superRefine(
+  validateInstallmentRequirements,
+);
 
 export const updateTransactionSchema = z
   .object({
@@ -41,10 +76,14 @@ export const updateTransactionSchema = z
     dueDate: isoDate.optional(),
     description: z.string().trim().max(500).optional().nullable(),
     isRecurring: z.boolean().optional(),
+    creditCardId: creditCardIdSchema.optional(),
+    isInstallment: z.boolean().optional(),
+    installmentCount: installmentCountSchema.optional(),
     status: z
       .enum(["paid", "pending", "cancelled", "postponed", "overdue"])
       .optional(),
   })
+  .superRefine(validateInstallmentRequirements)
   .refine(
     (values) => Object.values(values).some((value) => value !== undefined),
     { message: "Nenhuma alteracao informada." },


### PR DESCRIPTION
## Summary
- adds installments_v1 behind `app.transactions.installments` with credit card selection, installment toggle/count and preview in the transaction form
- sends `creditCardId`, `isInstallment` and `installmentCount` through create/update payloads and keeps dashboard quick-add compatible with the refined schema
- shows installment labels/details in the transactions list, including a group filter via "Ver outras parcelas"

## Tests
- `npm test -- --runTestsByPath features/transactions/validators.test.ts features/transactions/utils/preview-installments.test.ts features/transactions/components/transaction-form.test.tsx features/transactions/hooks/use-transactions-screen-controller.test.ts`
- `npm run quality-check`
- pre-push hooks passed on `git push -u origin feat/421-transaction-installments`

## Screenshots
- Not captured in this run; no simulator session was started in the current workspace.

Closes #421