### PR TITLE
feat: gate checkout with biometrics

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -50,9 +50,12 @@ posture see `auraxis-platform/.context/`.
 - User-facing toggle lives in **Profile → Security**. When the device
   reports unsupported / not-enrolled, the toggle disables itself with
   helper copy explaining why.
-- Application of the gate to specific flows (account deletion,
-  password change, checkout) ships incrementally per epic — see
-  `#298` follow-ups and `#304`.
+- Mandatory gates currently cover account deletion and checkout
+  finalization. Account deletion uses biometrics-only mode; checkout
+  allows the OS credential fallback when the biometric prompt offers it.
+- Password change does not have an authenticated in-app flow yet. When
+  that screen lands, it must call `useBiometricGate({ required: true })`
+  before submitting the mutation.
 
 ## Active scaffolding
 
@@ -73,6 +76,6 @@ posture see `auraxis-platform/.context/`.
 
 - **Backend session and refresh contracts** — see `auraxis-api`.
 - **Frontend (web) security headers and CSP** — see `auraxis-web`.
-- **CAPTCHA on login / register** — paridade com web ainda pendente
-  no app; tracking em `#298` (Cloudflare Turnstile via WebView).
+- **CAPTCHA on login / register** — Cloudflare Turnstile is active in
+  the auth forms; provider/key changes remain tracked in `#298`.
 - **Penetration test cadence** — owned by platform `.context/`.

--- a/features/subscription/hooks/use-checkout-flow.test.tsx
+++ b/features/subscription/hooks/use-checkout-flow.test.tsx
@@ -3,15 +3,21 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
 import { ApiError } from "@/core/http/api-error";
+import { useBiometricGate } from "@/core/security/use-biometric-gate";
 import type { CheckoutSession } from "@/features/subscription/contracts";
 import { useCheckoutFlow } from "@/features/subscription/hooks/use-checkout-flow";
 import { useCreateCheckoutMutation } from "@/features/subscription/hooks/use-subscription-mutations";
 import type { CheckoutProvider } from "@/features/subscription/services/checkout-provider-service";
 
+jest.mock("@/core/security/use-biometric-gate", () => ({
+  useBiometricGate: jest.fn(),
+}));
+
 jest.mock("@/features/subscription/hooks/use-subscription-mutations", () => ({
   useCreateCheckoutMutation: jest.fn(),
 }));
 
+const mockedUseBiometricGate = jest.mocked(useBiometricGate);
 const mockedUseCreate = jest.mocked(useCreateCheckoutMutation);
 
 const buildSession = (
@@ -37,6 +43,7 @@ type CheckoutFlowTestState = {
   readonly mutateAsync: jest.Mock;
   readonly reset: jest.Mock;
   readonly openCheckout: jest.Mock;
+  readonly biometricGate: jest.Mock;
   readonly client: QueryClient;
 };
 
@@ -47,6 +54,10 @@ const setupCheckoutFlowTest = (): CheckoutFlowTestState => {
   const openCheckout = jest
     .fn()
     .mockResolvedValue({ type: "success", returnUrl: "x://" });
+  const biometricGate = jest
+    .fn()
+    .mockResolvedValue({ authorised: true, via: "biometric" });
+  mockedUseBiometricGate.mockReturnValue(biometricGate as never);
   mockedUseCreate.mockReturnValue({
       mutateAsync,
       reset,
@@ -54,12 +65,13 @@ const setupCheckoutFlowTest = (): CheckoutFlowTestState => {
       error: null,
     } as never);
   const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return { mutateAsync, reset, openCheckout, client };
+  return { mutateAsync, reset, openCheckout, biometricGate, client };
 };
 
-describe("useCheckoutFlow", () => {
+describe("useCheckoutFlow success states", () => {
   it("invalida subscription e entitlements em sucesso e retorna completed", async () => {
-    const { client, mutateAsync, openCheckout } = setupCheckoutFlowTest();
+    const { client, mutateAsync, openCheckout, biometricGate } =
+      setupCheckoutFlowTest();
     const invalidateSpy = jest.spyOn(client, "invalidateQueries");
     const { result } = renderHook(
       () =>
@@ -75,6 +87,10 @@ describe("useCheckoutFlow", () => {
     });
     const outcome = outcomeRef.current;
 
+    expect(biometricGate).toHaveBeenCalledWith({
+      promptMessage: "Confirme para finalizar checkout",
+      required: true,
+    });
     expect(mutateAsync).toHaveBeenCalledWith({ planSlug: "premium-monthly" });
     expect(openCheckout).toHaveBeenCalled();
     expect(outcome?.outcome).toBe("completed");
@@ -108,7 +124,43 @@ describe("useCheckoutFlow", () => {
     expect(outcome?.outcome).toBe("canceled");
     expect(invalidateSpy).not.toHaveBeenCalled();
   });
+});
 
+describe("useCheckoutFlow biometric gate", () => {
+  it("bloqueia o checkout sem criar sessao quando o gate biometrico nega", async () => {
+    const { client, mutateAsync, openCheckout, biometricGate } =
+      setupCheckoutFlowTest();
+    biometricGate.mockResolvedValueOnce({
+      authorised: false,
+      outcome: { outcome: "cancelled" },
+    });
+
+    const { result } = renderHook(
+      () =>
+        useCheckoutFlow({
+          checkoutService: { openCheckout, dismissCheckout: jest.fn() } as never,
+        }),
+      { wrapper: wrapper(client) },
+    );
+
+    const outcomeRef: { current: { outcome: string } | null } = { current: null };
+    await act(async () => {
+      outcomeRef.current = await result.current.start({ planSlug: "premium-monthly" });
+    });
+    const outcome = outcomeRef.current;
+
+    expect(biometricGate).toHaveBeenCalledWith({
+      promptMessage: "Confirme para finalizar checkout",
+      required: true,
+    });
+    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(openCheckout).not.toHaveBeenCalled();
+    expect(outcome).toEqual({ outcome: "locked", session: null });
+    expect(result.current.lastError).toBeNull();
+  });
+});
+
+describe("useCheckoutFlow error states", () => {
   it("captura erro quando createCheckout falha e nao abre browser", async () => {
     const { client, mutateAsync, openCheckout } = setupCheckoutFlowTest();
     mutateAsync.mockRejectedValueOnce(

--- a/features/subscription/hooks/use-checkout-flow.ts
+++ b/features/subscription/hooks/use-checkout-flow.ts
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { ApiError } from "@/core/http/api-error";
 import { queryKeys } from "@/core/query/query-keys";
+import { useBiometricGate } from "@/core/security/use-biometric-gate";
 import type {
   CheckoutSession,
   CreateCheckoutCommand,
@@ -66,6 +67,7 @@ export function useCheckoutFlow(
 ): CheckoutFlowController {
   const queryClient = useQueryClient();
   const createCheckout = useCreateCheckoutMutation();
+  const requestBiometricGate = useBiometricGate();
   const [lastError, setLastError] = useState<unknown | null>(null);
   const checkoutProvider = resolveCheckoutProvider(dependencies);
 
@@ -78,6 +80,14 @@ export function useCheckoutFlow(
     command: CreateCheckoutCommand,
   ): Promise<CheckoutFlowResult> => {
     setLastError(null);
+
+    const gate = await requestBiometricGate({
+      promptMessage: "Confirme para finalizar checkout",
+      required: true,
+    });
+    if (!gate.authorised) {
+      return { outcome: "locked", session: null };
+    }
 
     let session: CheckoutSession | null = null;
     if (checkoutProvider.requiresCheckoutSession) {


### PR DESCRIPTION
## Summary
- Force the existing biometric gate before starting the subscription checkout flow.
- Return `locked` without creating a checkout session or opening a provider when the gate is denied.
- Update `docs/security.md` to reflect the delivered checkout/account-deletion gates and keep password change/native SSL pinning scoped to #298 follow-ups.

## Test Plan
- `npm test -- features/subscription/hooks/use-checkout-flow.test.tsx --runInBand`
- `npm test -- features/subscription/hooks/use-checkout-flow.test.tsx core/security/use-biometric-gate.test.ts core/security/biometric-gate.test.ts features/user-profile/hooks/use-danger-zone-screen-controller.test.tsx --runInBand`
- `npm run quality-check`
- Pre-push hook: policy, contracts, typecheck, coverage

Screenshots: N/A. This changes checkout runtime gating and docs, not React Native screen layout.

Closes #424
Refs #298
