### PR TITLE
fix: reject biometric PIN fallback for sensitive gates

### DIFF
--- a/core/security/use-biometric-gate.test.ts
+++ b/core/security/use-biometric-gate.test.ts
@@ -49,6 +49,20 @@ describe("useBiometricGate", () => {
     expect(outcome).toEqual({ authorised: true, via: "biometric" });
   });
 
+  it("nega fallback_pin quando o fluxo exige biometria real", async () => {
+    useAppShellStore.getState().setBiometricLockEnabled(true);
+    mockedRequest.mockResolvedValue({ outcome: "fallback_pin" });
+    const { result } = renderHook(() => useBiometricGate());
+    const outcome = await result.current({
+      promptMessage: "Auth",
+      biometricsOnly: true,
+    });
+    expect(outcome).toEqual({
+      authorised: false,
+      outcome: { outcome: "fallback_pin" },
+    });
+  });
+
   it("propaga cancelamento como nao autorizado", async () => {
     useAppShellStore.getState().setBiometricLockEnabled(true);
     mockedRequest.mockResolvedValue({ outcome: "cancelled" });

--- a/core/security/use-biometric-gate.ts
+++ b/core/security/use-biometric-gate.ts
@@ -67,7 +67,10 @@ export const useBiometricGate = (): ((
         biometricsOnly: options.biometricsOnly,
       });
 
-      if (outcome.outcome === "success" || outcome.outcome === "fallback_pin") {
+      if (
+        outcome.outcome === "success" ||
+        (outcome.outcome === "fallback_pin" && options.biometricsOnly !== true)
+      ) {
         return { authorised: true, via: "biometric" };
       }
       return { authorised: false, outcome };

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,20 +53,28 @@ posture see `auraxis-platform/.context/`.
 - Mandatory gates currently cover account deletion and checkout
   finalization. Account deletion uses biometrics-only mode; checkout
   allows the OS credential fallback when the biometric prompt offers it.
+- Sensitive flows that pass `biometricsOnly: true` reject
+  `fallback_pin` and require a real biometric match.
 - Password change does not have an authenticated in-app flow yet. When
   that screen lands, it must call `useBiometricGate({ required: true })`
   before submitting the mutation.
 
+### CAPTCHA
+- Login and registration render the Cloudflare Turnstile challenge when
+  `EXPO_PUBLIC_TURNSTILE_SITE_KEY` is configured.
+- The auth service sends the resulting token as `captcha_token`, aligned
+  with the backend contract and web parity.
+
 ## Active scaffolding
 
-### SSL pinning (not yet enforcing)
+### SSL pinning (native pins pending)
 - `core/security/ssl-pinning.ts` exposes `resolveSslPinningPolicy()`
   and `isSslPinningEnforced()` reading from
   `EXPO_PUBLIC_SSL_PINNING_ENABLED` and
   `EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS`.
-- The flag stays **off** in current builds because production
-  certificate fingerprints are not yet pinned at the native layer
-  (Android `networkSecurityConfig`, iOS ATS dictionary).
+- Native scaffolding exists in `app.json` / `assets/network-security-config.xml`,
+  but production certificate fingerprints are not yet populated in the
+  native pin sets.
 - Two SHA-256 fingerprints are recommended (current + next) so a
   certificate roll never bricks installed clients.
 - Enabling for real lands together with a deploy that ties the
@@ -76,6 +84,8 @@ posture see `auraxis-platform/.context/`.
 
 - **Backend session and refresh contracts** — see `auraxis-api`.
 - **Frontend (web) security headers and CSP** — see `auraxis-web`.
-- **CAPTCHA on login / register** — Cloudflare Turnstile is active in
+- **CAPTCHA provider/key changes** — Cloudflare Turnstile is active in
   the auth forms; provider/key changes remain tracked in `#298`.
+- **Native SSL pin values and MITM smoke** — tracked in `#298` and the
+  SSL pinning rotation runbook.
 - **Penetration test cadence** — owned by platform `.context/`.

--- a/shared/types/generated/graphql.ts
+++ b/shared/types/generated/graphql.ts
@@ -45,6 +45,16 @@ export type AiInsightHistoryResultType = {
   total: Scalars['Int']['output'];
 };
 
+/** A single LLM-produced insight item, tagged by dimension. */
+export type AiInsightItemType = {
+  __typename?: 'AIInsightItemType';
+  dimension: Scalars['String']['output'];
+  evidence?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  message: Scalars['String']['output'];
+  title: Scalars['String']['output'];
+  type: Scalars['String']['output'];
+};
+
 export type AiInsightType = {
   __typename?: 'AIInsightType';
   content: Scalars['String']['output'];
@@ -171,6 +181,24 @@ export type BankImportPreviewType = {
   totalEntries: Scalars['Int']['output'];
 };
 
+export type BillCycleType = {
+  __typename?: 'BillCycleType';
+  dueDate: Scalars['String']['output'];
+  endDate: Scalars['String']['output'];
+  startDate: Scalars['String']['output'];
+  status: Scalars['String']['output'];
+};
+
+export type BillTransactionType = {
+  __typename?: 'BillTransactionType';
+  amount: Scalars['DecimalScalar']['output'];
+  dueDate?: Maybe<Scalars['String']['output']>;
+  id: Scalars['String']['output'];
+  status?: Maybe<Scalars['String']['output']>;
+  title: Scalars['String']['output'];
+  type?: Maybe<Scalars['String']['output']>;
+};
+
 /** An enumeration. */
 export type BillingCycle =
   | 'ANNUAL'
@@ -282,6 +310,47 @@ export type CreateTransactionMutation = {
   message: Scalars['String']['output'];
 };
 
+export type CreditCardBillType = {
+  __typename?: 'CreditCardBillType';
+  cycle: BillCycleType;
+  paidAmount: Scalars['DecimalScalar']['output'];
+  pendingAmount: Scalars['DecimalScalar']['output'];
+  totalAmount: Scalars['DecimalScalar']['output'];
+  transactions?: Maybe<Array<Maybe<BillTransactionType>>>;
+};
+
+export type CreditCardListType = {
+  __typename?: 'CreditCardListType';
+  creditCards?: Maybe<Array<Maybe<CreditCardType>>>;
+  total?: Maybe<Scalars['Int']['output']>;
+};
+
+export type CreditCardType = {
+  __typename?: 'CreditCardType';
+  bank?: Maybe<Scalars['String']['output']>;
+  benefits?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
+  brand?: Maybe<Scalars['String']['output']>;
+  closingDay?: Maybe<Scalars['Int']['output']>;
+  createdAt?: Maybe<Scalars['String']['output']>;
+  description?: Maybe<Scalars['String']['output']>;
+  dueDay?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['String']['output'];
+  lastFourDigits?: Maybe<Scalars['String']['output']>;
+  limitAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  name: Scalars['String']['output'];
+  updatedAt?: Maybe<Scalars['String']['output']>;
+  validityDate?: Maybe<Scalars['String']['output']>;
+};
+
+export type CreditCardUtilizationType = {
+  __typename?: 'CreditCardUtilizationType';
+  availableAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  committedAmount: Scalars['DecimalScalar']['output'];
+  cycle: BillCycleType;
+  limitAmount?: Maybe<Scalars['DecimalScalar']['output']>;
+  utilizationPct?: Maybe<Scalars['Float']['output']>;
+};
+
 export type DashboardCategoriesType = {
   __typename?: 'DashboardCategoriesType';
   expense: Array<Maybe<DashboardCategoryType>>;
@@ -390,6 +459,22 @@ export type FiscalDocumentType = {
   issuedAt: Scalars['String']['output'];
   status: Scalars['String']['output'];
   type: Scalars['String']['output'];
+};
+
+export type GenerateAiInsightPayload = {
+  __typename?: 'GenerateAiInsightPayload';
+  cached?: Maybe<Scalars['Boolean']['output']>;
+  contextVersion?: Maybe<Scalars['String']['output']>;
+  costUsd?: Maybe<Scalars['Float']['output']>;
+  items?: Maybe<Array<Maybe<AiInsightItemType>>>;
+  model?: Maybe<Scalars['String']['output']>;
+  ok: Scalars['Boolean']['output'];
+  periodEnd?: Maybe<Scalars['String']['output']>;
+  periodLabel?: Maybe<Scalars['String']['output']>;
+  periodStart?: Maybe<Scalars['String']['output']>;
+  periodType?: Maybe<Scalars['String']['output']>;
+  summary?: Maybe<Scalars['String']['output']>;
+  tokensUsed?: Maybe<Scalars['Int']['output']>;
 };
 
 export type GoalListPayloadType = {
@@ -690,6 +775,14 @@ export type Mutation = {
   /** @deprecated ADR-0002: use DELETE /wallet/{id} */
   deleteWalletEntry?: Maybe<DeleteWalletEntryMutation>;
   forgotPassword?: Maybe<AuthPayloadType>;
+  /**
+   * GraphQL parity for POST /ai/insights/generate.
+   *
+   * Reuses AIAdvisoryService — quota (2x/day Premium), entitlement gate and
+   * LGPD consent are enforced inside the service. GraphQL surface exposes the
+   * same payload shape so the frontend hub can render either path identically.
+   */
+  generateAiInsight?: Maybe<GenerateAiInsightPayload>;
   login?: Maybe<AuthPayloadType>;
   logout?: Maybe<LogoutMutation>;
   /** @deprecated ADR-0002: use PATCH /fiscal/receivables/{id}/receive */
@@ -930,6 +1023,12 @@ export type MutationDeleteWalletEntryArgs = {
 
 export type MutationForgotPasswordArgs = {
   email: Scalars['String']['input'];
+};
+
+
+export type MutationGenerateAiInsightArgs = {
+  anchorDate?: InputMaybe<Scalars['String']['input']>;
+  periodType: Scalars['String']['input'];
 };
 
 
@@ -1213,6 +1312,9 @@ export type Query = {
   budget?: Maybe<BudgetType>;
   budgetSummary?: Maybe<BudgetSummaryType>;
   budgets?: Maybe<BudgetListPayloadType>;
+  creditCardBill?: Maybe<CreditCardBillType>;
+  creditCardUtilization?: Maybe<CreditCardUtilizationType>;
+  creditCards?: Maybe<CreditCardListType>;
   dashboardOverview?: Maybe<TransactionDashboardPayloadType>;
   fiscalDocuments?: Maybe<FiscalDocumentListType>;
   goal?: Maybe<GoalTypeObject>;
@@ -1261,6 +1363,17 @@ export type QueryAiInsightHistoryArgs = {
 
 export type QueryBudgetArgs = {
   budgetId: Scalars['UUID']['input'];
+};
+
+
+export type QueryCreditCardBillArgs = {
+  cardId: Scalars['UUID']['input'];
+  month: Scalars['String']['input'];
+};
+
+
+export type QueryCreditCardUtilizationArgs = {
+  cardId: Scalars['UUID']['input'];
 };
 
 


### PR DESCRIPTION
## Summary
- Reject `fallback_pin` when a sensitive flow requests `biometricsOnly: true`.
- Add coverage for the strict biometric-only contract.
- Refresh mobile security posture docs for biometric gates, CAPTCHA, and pending native SSL pins.
- Regenerate GraphQL types so `codegen:check` passes against the current schema.

Closes #426
Refs #298

## Tests
- `npm test -- --runTestsByPath core/security/use-biometric-gate.test.ts --runInBand`
- `npm run lint -- --max-warnings=0 core/security/use-biometric-gate.ts core/security/use-biometric-gate.test.ts`
- `bash scripts/clean-duplicate-files.sh`
- `npm run typecheck`
- `npm run quality-check`
- `git push` pre-push checks: policy, contracts, typecheck, coverage

## Notes
- Native SSL pin values and MITM smoke stay open in #298; this PR does not touch `app.json` or `eas.json`.