### PR TITLE
fix: require biometric-only checkout gate

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -51,13 +51,14 @@ posture see `auraxis-platform/.context/`.
   reports unsupported / not-enrolled, the toggle disables itself with
   helper copy explaining why.
 - Mandatory gates currently cover account deletion and checkout
-  finalization. Account deletion uses biometrics-only mode; checkout
-  allows the OS credential fallback when the biometric prompt offers it.
+  finalization. Both pass `biometricsOnly: true`, so the OS credential
+  fallback cannot authorize these sensitive actions.
 - Sensitive flows that pass `biometricsOnly: true` reject
   `fallback_pin` and require a real biometric match.
 - Password change does not have an authenticated in-app flow yet. When
-  that screen lands, it must call `useBiometricGate({ required: true })`
-  before submitting the mutation.
+  that screen lands, it must call
+  `useBiometricGate({ required: true, biometricsOnly: true })` before
+  submitting the mutation.
 
 ### CAPTCHA
 - Login and registration render the Cloudflare Turnstile challenge when

--- a/features/subscription/hooks/use-checkout-flow.test.tsx
+++ b/features/subscription/hooks/use-checkout-flow.test.tsx
@@ -90,6 +90,7 @@ describe("useCheckoutFlow success states", () => {
     expect(biometricGate).toHaveBeenCalledWith({
       promptMessage: "Confirme para finalizar checkout",
       required: true,
+      biometricsOnly: true,
     });
     expect(mutateAsync).toHaveBeenCalledWith({ planSlug: "premium-monthly" });
     expect(openCheckout).toHaveBeenCalled();
@@ -152,6 +153,7 @@ describe("useCheckoutFlow biometric gate", () => {
     expect(biometricGate).toHaveBeenCalledWith({
       promptMessage: "Confirme para finalizar checkout",
       required: true,
+      biometricsOnly: true,
     });
     expect(mutateAsync).not.toHaveBeenCalled();
     expect(openCheckout).not.toHaveBeenCalled();

--- a/features/subscription/hooks/use-checkout-flow.ts
+++ b/features/subscription/hooks/use-checkout-flow.ts
@@ -84,6 +84,7 @@ export function useCheckoutFlow(
     const gate = await requestBiometricGate({
       promptMessage: "Confirme para finalizar checkout",
       required: true,
+      biometricsOnly: true,
     });
     if (!gate.authorised) {
       return { outcome: "locked", session: null };


### PR DESCRIPTION
## Summary

- Requires `biometricsOnly: true` for the checkout biometric gate so OS credential fallback cannot authorize subscription checkout startup.
- Updates checkout hook tests to lock the strict sensitive-flow contract.
- Updates `docs/security.md` so account deletion, checkout, and future authenticated password-change flows all require biometric-only gates.

## Scope notes

- Refs #298, but does not close it yet.
- No `app.json` or `eas.json` changes.
- Native SSL pin values and MITM smoke remain pending because they require real current + backup SPKI fingerprints and explicit approval before changing native config.
- Screenshots: not applicable; this is a runtime security gate change.

## Tests

- RED: `npm test -- --runTestsByPath features/subscription/hooks/use-checkout-flow.test.tsx --runInBand` failed until checkout passed `biometricsOnly: true`.
- GREEN: `npm test -- --runTestsByPath features/subscription/hooks/use-checkout-flow.test.tsx --runInBand`
- `npm run lint -- --max-warnings=0 features/subscription/hooks/use-checkout-flow.ts features/subscription/hooks/use-checkout-flow.test.tsx`
- `git diff --check`
- `npm run quality-check`
- Pre-push hooks: policy, contracts, typecheck, coverage

## Remaining #298 work

- Populate native SSL pinning with current + backup SPKI fingerprints in native config.
- Run preview/release MITM smoke after native pins are populated.
