### PR TITLE
fix: enable native SSL pinning

### DIFF
--- a/__tests__/config/native-ssl-pinning.test.ts
+++ b/__tests__/config/native-ssl-pinning.test.ts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import appConfig from "@/app.json";
+
+const API_HOST = "api.auraxis.com.br";
+const PIN_CURRENT = "6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=";
+const PIN_BACKUP = "y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=";
+const ANDROID_PIN_EXPIRATION = "2026-08-01";
+
+const extractSpkiPins = (
+  identities: readonly Record<string, unknown>[] | undefined,
+): readonly string[] => {
+  return (identities ?? [])
+    .map((identity) => identity["SPKI-SHA256-BASE64"])
+    .filter((value): value is string => typeof value === "string");
+};
+
+describe("native SSL pinning config", () => {
+  it("pins the iOS API host with a current leaf and backup CA SPKI", () => {
+    const ats = appConfig.expo.ios.infoPlist.NSAppTransportSecurity;
+    const pinnedDomain = ats.NSPinnedDomains[API_HOST];
+
+    expect(ats.NSAllowsArbitraryLoads).toBe(false);
+    expect(pinnedDomain.NSIncludesSubdomains).toBe(false);
+    expect(extractSpkiPins(pinnedDomain.NSPinnedLeafIdentities)).toEqual([
+      PIN_CURRENT,
+    ]);
+    expect(extractSpkiPins(pinnedDomain.NSPinnedCAIdentities)).toEqual([
+      PIN_BACKUP,
+    ]);
+  });
+
+  it("pins the Android API host with the same current and backup SPKI", () => {
+    const xml = fs.readFileSync(
+      path.join(process.cwd(), "assets/network-security-config.xml"),
+      "utf8",
+    );
+
+    expect(xml).toContain("<domain>api.auraxis.com.br</domain>");
+    expect(xml).toContain(
+      `<pin-set expiration="${ANDROID_PIN_EXPIRATION}">`,
+    );
+    expect(xml).toContain(`<pin digest="SHA-256">${PIN_CURRENT}</pin>`);
+    expect(xml).toContain(`<pin digest="SHA-256">${PIN_BACKUP}</pin>`);
+    expect(xml).toContain("<base-config cleartextTrafficPermitted=\"false\">");
+    expect(xml).toContain("<certificates src=\"system\" />");
+  });
+});

--- a/app.json
+++ b/app.json
@@ -17,9 +17,18 @@
         "NSAppTransportSecurity": {
           "NSAllowsArbitraryLoads": false,
           "NSPinnedDomains": {
-            "auraxis.com.br": {
-              "NSIncludesSubdomains": true,
-              "NSPinnedCAIdentities": []
+            "api.auraxis.com.br": {
+              "NSIncludesSubdomains": false,
+              "NSPinnedLeafIdentities": [
+                {
+                  "SPKI-SHA256-BASE64": "6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI="
+                }
+              ],
+              "NSPinnedCAIdentities": [
+                {
+                  "SPKI-SHA256-BASE64": "y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU="
+                }
+              ]
             }
           }
         }

--- a/assets/network-security-config.xml
+++ b/assets/network-security-config.xml
@@ -2,19 +2,21 @@
 <!--
   Auraxis app — Android network security config.
 
-  Baseline today (PR #346):
+  Baseline:
   - Cleartext traffic blocked by default. The whole app must speak HTTPS.
   - System trust anchors only. No user-installed CAs honored.
-  - <pin-set> deliberately omitted until ops populates production SPKI
-    hashes (Apr/2026). See docs/runtime.md "SSL pinning" for the
-    rotation playbook and sample structure to drop in.
-
-  Once SPKI hashes are populated, this file gains a <domain-config>
-  block listing auraxis.com.br + its api/cdn subdomains under a
-  <pin-set> with two pins (current + backup) and an explicit
-  expiration date.
+  - api.auraxis.com.br is pinned with the current leaf SPKI and the
+    Let's Encrypt E7 intermediate SPKI as the operational backup pin.
+    See docs/runbooks/ssl-pinning-rotation.md before rotating.
 -->
 <network-security-config>
+    <domain-config>
+        <domain>api.auraxis.com.br</domain>
+        <pin-set expiration="2026-08-01">
+            <pin digest="SHA-256">6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=</pin>
+            <pin digest="SHA-256">y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=</pin>
+        </pin-set>
+    </domain-config>
     <base-config cleartextTrafficPermitted="false">
         <trust-anchors>
             <certificates src="system" />

--- a/core/security/ssl-pinning.test.ts
+++ b/core/security/ssl-pinning.test.ts
@@ -36,7 +36,7 @@ describe("ssl-pinning policy", () => {
     expect(isSslPinningEnforced()).toBe(false);
   });
 
-  it("requires both flag and fingerprints to enforce", () => {
+  it("requires both flag and two distinct fingerprints to enforce", () => {
     setEnv("true", "sha256/AAA===,sha256/BBB===");
     const policy = resolveSslPinningPolicy();
     expect(policy.enabled).toBe(true);
@@ -46,12 +46,20 @@ describe("ssl-pinning policy", () => {
     ]);
   });
 
+  it("ignores a single or duplicated fingerprint", () => {
+    setEnv("true", "sha256/AAA===");
+    expect(isSslPinningEnforced()).toBe(false);
+
+    setEnv("true", "sha256/AAA===,sha256/AAA===");
+    expect(isSslPinningEnforced()).toBe(false);
+  });
+
   it("treats truthy variants of the flag as enabled", () => {
-    setEnv("1", "sha256/AAA===");
+    setEnv("1", "sha256/AAA===,sha256/BBB===");
     expect(isSslPinningEnforced()).toBe(true);
-    setEnv("on", "sha256/AAA===");
+    setEnv("on", "sha256/AAA===,sha256/BBB===");
     expect(isSslPinningEnforced()).toBe(true);
-    setEnv("TRUE", "sha256/AAA===");
+    setEnv("TRUE", "sha256/AAA===,sha256/BBB===");
     expect(isSslPinningEnforced()).toBe(true);
   });
 
@@ -69,12 +77,6 @@ describe("verifyCanonicalRequest", () => {
     expect(verifyCanonicalRequest("https://api.auraxis.com.br/foo")).toEqual({
       kind: "ok",
     });
-    expect(verifyCanonicalRequest("https://auraxis.com.br/")).toEqual({
-      kind: "ok",
-    });
-    expect(verifyCanonicalRequest("https://cdn.auraxis.com.br/avatar.png")).toEqual({
-      kind: "ok",
-    });
   });
 
   it("bloqueia esquemas nao-HTTPS", () => {
@@ -86,6 +88,16 @@ describe("verifyCanonicalRequest", () => {
 
   it("bloqueia hosts nao-canonicos", () => {
     expect(verifyCanonicalRequest("https://api.attacker.com/foo")).toEqual({
+      kind: "blocked",
+      reason: "non_canonical_host",
+    });
+    expect(verifyCanonicalRequest("https://auraxis.com.br/")).toEqual({
+      kind: "blocked",
+      reason: "non_canonical_host",
+    });
+    expect(
+      verifyCanonicalRequest("https://cdn.auraxis.com.br/avatar.png"),
+    ).toEqual({
       kind: "blocked",
       reason: "non_canonical_host",
     });

--- a/core/security/ssl-pinning.ts
+++ b/core/security/ssl-pinning.ts
@@ -14,7 +14,7 @@
  *
  * 2. **Defensive (this module)** — runtime predicates the HTTP layer
  *    can call to ensure outbound requests target the canonical
- *    `*.auraxis.com.br` envelope and use HTTPS. This catches developer
+ *    `api.auraxis.com.br` host and use HTTPS. This catches developer
  *    errors (typos, dev-only bypass URLs, http://) before they reach
  *    the network — a small belt-and-braces step on top of the native
  *    layer.
@@ -39,8 +39,8 @@ interface RawEnvSnapshot {
   readonly fingerprints: string | undefined;
 }
 
-const CANONICAL_HOST_SUFFIX = ".auraxis.com.br";
-const ROOT_HOST = "auraxis.com.br";
+const API_HOST = "api.auraxis.com.br";
+const REQUIRED_PIN_COUNT = 2;
 
 const readEnv = (): RawEnvSnapshot => {
   return {
@@ -61,10 +61,12 @@ const parseFingerprints = (raw: string | undefined): readonly string[] => {
   if (!raw) {
     return [];
   }
-  return raw
+  const fingerprints = raw
     .split(",")
     .map((item) => item.trim())
     .filter((item) => item.length > 0);
+
+  return Array.from(new Set(fingerprints));
 };
 
 export interface SslPinningPolicy {
@@ -86,7 +88,7 @@ export const resolveSslPinningPolicy = (): SslPinningPolicy => {
   const fingerprints = parseFingerprints(env.fingerprints);
 
   return {
-    enabled: enabled && fingerprints.length > 0,
+    enabled: enabled && fingerprints.length >= REQUIRED_PIN_COUNT,
     expectedFingerprints: fingerprints,
   };
 };
@@ -111,14 +113,12 @@ export type BlockedReason =
 
 const isCanonicalHost = (hostname: string): boolean => {
   const normalized = hostname.trim().toLowerCase();
-  return (
-    normalized === ROOT_HOST || normalized.endsWith(CANONICAL_HOST_SUFFIX)
-  );
+  return normalized === API_HOST;
 };
 
 /**
  * Validates that an outbound request URL targets the canonical
- * `*.auraxis.com.br` envelope and uses HTTPS. Returns a discriminated
+ * `api.auraxis.com.br` host and uses HTTPS. Returns a discriminated
  * verdict so callers (HTTP client interceptor, fetch wrapper) can
  * react appropriately — typically blocking the request and reporting
  * to telemetry.

--- a/core/telemetry/logging-policy.ts
+++ b/core/telemetry/logging-policy.ts
@@ -164,7 +164,7 @@ export const APP_EVENT_LOGGING_POLICY = Object.freeze({
     ["method", "path", "status", "code"],
   ),
   "network.canonical_request_violation": warnAndErrorWarnPolicy(
-    "Request iniciado fora do envelope canônico *.auraxis.com.br ou sem HTTPS — pinning nativo deve bloquear; sinal de bug em config.",
+    "Request iniciado fora do host canônico api.auraxis.com.br ou sem HTTPS — pinning nativo deve bloquear; sinal de bug em config.",
     ["method", "reason"],
   ),
   "auth.session_established": devOnlyInfoPolicy(

--- a/docs/runbooks/ssl-pinning-rotation.md
+++ b/docs/runbooks/ssl-pinning-rotation.md
@@ -2,16 +2,22 @@
 
 ## Quando executar
 
-- A cada 90 dias (alinhado ao ACM auto-renew dos certs `*.auraxis.com.br`).
-- Imediatamente quando ACM rotacionar inesperadamente um cert.
+- A cada 90 dias (alinhado ao ciclo de renovação do cert
+  `api.auraxis.com.br`).
+- Imediatamente quando o provedor TLS rotacionar inesperadamente um cert.
 - Antes de qualquer release que altere a infra de TLS (mudança de provider,
   região, distribuição CDN).
 
 ## Pre-requisitos
 
 - `openssl` na máquina local (≥1.1.1).
-- Acesso SSH/CLI à máquina que tem o cert atual da `auraxis.com.br`,
+- Acesso SSH/CLI à máquina que tem o cert atual da API,
   ou uso direto do endpoint público (handshake remoto).
+- Pins atuais extraídos em 2026-05-19:
+  - Leaf `api.auraxis.com.br`:
+    `sha256/6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=`
+  - Backup CA/intermediário `Let's Encrypt E7`:
+    `sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=`
 
 ## Passos
 
@@ -32,15 +38,18 @@ PIN_CURRENT=$(openssl x509 -in /tmp/api-cert.pem -pubkey -noout \
 echo "Pin atual: sha256/${PIN_CURRENT}"
 ```
 
-Repetir para `cdn.auraxis.com.br` e qualquer outro subdomínio servindo
-tráfego TLS direto.
+Repetir para `cdn.auraxis.com.br` e qualquer outro subdomínio somente
+quando ele passar a servir tráfego TLS direto pelo app. Em 2026-05-19,
+`cdn.auraxis.com.br` não respondeu handshake público, então a build
+pina apenas `api.auraxis.com.br`.
 
 ### 2. Gerar pin backup (próximo cert)
 
 O backup pin deve apontar para a **próxima** chave que a CA vai assinar.
 Duas opções:
 
-**Opção A — Pin do CA intermediário** (mais resiliente, menos seguro):
+**Opção A — Pin do CA intermediário** (atual nesta build; mais
+resiliente, menos seguro):
 
 ```bash
 openssl s_client -connect api.auraxis.com.br:443 -showcerts </dev/null 2>/dev/null \
@@ -64,8 +73,8 @@ PIN_BACKUP=$(openssl rsa -in /tmp/backup-key.pem -pubout -outform der 2>/dev/nul
 echo "Pin backup: sha256/${PIN_BACKUP}"
 ```
 
-Recomendado: opção B, com a chave guardada em AWS Secrets Manager
-(`auraxis/ssl-pinning/backup-key`).
+Recomendado para a próxima rotação: migrar para a opção B, com a chave
+guardada em AWS Secrets Manager (`auraxis/ssl-pinning/backup-key`).
 
 ### 3. Atualizar `app.json` (iOS)
 
@@ -75,10 +84,12 @@ Recomendado: opção B, com a chave guardada em AWS Secrets Manager
     "NSAppTransportSecurity": {
       "NSAllowsArbitraryLoads": false,
       "NSPinnedDomains": {
-        "auraxis.com.br": {
-          "NSIncludesSubdomains": true,
+        "api.auraxis.com.br": {
+          "NSIncludesSubdomains": false,
+          "NSPinnedLeafIdentities": [
+            { "SPKI-SHA256-BASE64": "<PIN_CURRENT>" }
+          ],
           "NSPinnedCAIdentities": [
-            { "SPKI-SHA256-BASE64": "<PIN_CURRENT>" },
             { "SPKI-SHA256-BASE64": "<PIN_BACKUP>" }
           ]
         }
@@ -93,10 +104,10 @@ Recomendado: opção B, com a chave guardada em AWS Secrets Manager
 ```xml
 <network-security-config>
     <domain-config>
-        <domain includeSubdomains="true">auraxis.com.br</domain>
+        <domain>api.auraxis.com.br</domain>
         <pin-set expiration="2026-08-01">
-            <pin digest="SHA-256"><!-- PIN_CURRENT --></pin>
-            <pin digest="SHA-256"><!-- PIN_BACKUP --></pin>
+            <pin digest="SHA-256"><!-- PIN_CURRENT without sha256/ --></pin>
+            <pin digest="SHA-256"><!-- PIN_BACKUP without sha256/ --></pin>
         </pin-set>
     </domain-config>
     <base-config cleartextTrafficPermitted="false">

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -224,18 +224,26 @@ Pinning é aplicado em duas camadas:
 "NSAppTransportSecurity": {
   "NSAllowsArbitraryLoads": false,
   "NSPinnedDomains": {
-    "auraxis.com.br": {
-      "NSIncludesSubdomains": true,
-      "NSPinnedCAIdentities": []  // populado por ops antes de promover a prod
+    "api.auraxis.com.br": {
+      "NSIncludesSubdomains": false,
+      "NSPinnedLeafIdentities": [
+        { "SPKI-SHA256-BASE64": "6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=" }
+      ],
+      "NSPinnedCAIdentities": [
+        { "SPKI-SHA256-BASE64": "y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=" }
+      ]
     }
   }
 }
 ```
 
 **Android** — `app.json` aponta `expo.android.networkSecurityConfig` para
-`assets/network-security-config.xml`. Hoje o XML aplica baseline (cleartext
-bloqueado, system trust apenas). O bloco `<domain-config>` com `<pin-set>`
-entra quando ops popular as hashes SPKI.
+`assets/network-security-config.xml`. O XML aplica cleartext bloqueado,
+system trust apenas, e `<pin-set>` para `api.auraxis.com.br` com:
+
+- leaf atual: `sha256/6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=`
+- backup CA/intermediário Let's Encrypt E7:
+  `sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=`
 
 ### 2. Defensivo (JS, este módulo)
 
@@ -243,7 +251,7 @@ entra quando ops popular as hashes SPKI.
 toda chamada outbound:
 
 - Usa `https://` (rejeita `http://`).
-- Tem hostname dentro de `*.auraxis.com.br` (rejeita typos, dev-only
+- Tem hostname `api.auraxis.com.br` (rejeita typos, dev-only
   bypass URLs, exfil para hosts arbitrários).
 
 Retorna `{ kind: "ok" }` ou `{ kind: "blocked", reason: ... }`. O HTTP
@@ -253,7 +261,7 @@ belt-and-braces sobre o pinning nativo.
 ### Geração e rotação dos pins SPKI
 
 ```bash
-# 1. Baixar o cert público da raiz canônica
+# 1. Baixar o cert público da API canônica
 openssl s_client -connect api.auraxis.com.br:443 -servername api.auraxis.com.br \
   </dev/null 2>/dev/null | openssl x509 -outform PEM > /tmp/api-cert.pem
 
@@ -269,11 +277,12 @@ openssl x509 -in /tmp/api-cert.pem -pubkey -noout \
 
 **Política de pins:**
 
-- Sempre dois pins: **atual** + **backup** (próximo). Nunca um só, ou um
-  pin roll forçaria atualização da app store antes do cert vencer.
+- Sempre dois pins distintos. A build atual usa leaf
+  `api.auraxis.com.br` + CA/intermediário Let's Encrypt E7 porque ainda
+  não há chave offline de próxima rotação registrada em vault.
 - Validade dos pins documentada no XML/Info.plist com expiração explícita
   no XML Android (`<pin-set expiration="YYYY-MM-DD">`).
-- Rotação a cada 90 dias (alinhado ao ACM auto-renew).
+- Rotação a cada 90 dias (alinhada ao ciclo do provedor TLS).
 
 ### Smoke tests pós-build (manuais)
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -66,20 +66,22 @@ posture see `auraxis-platform/.context/`.
 - The auth service sends the resulting token as `captcha_token`, aligned
   with the backend contract and web parity.
 
-## Active scaffolding
+## Native/runtime controls
 
-### SSL pinning (native pins pending)
+### SSL pinning (native pins active)
 - `core/security/ssl-pinning.ts` exposes `resolveSslPinningPolicy()`
   and `isSslPinningEnforced()` reading from
   `EXPO_PUBLIC_SSL_PINNING_ENABLED` and
   `EXPO_PUBLIC_SSL_PINNING_FINGERPRINTS`.
-- Native scaffolding exists in `app.json` / `assets/network-security-config.xml`,
-  but production certificate fingerprints are not yet populated in the
-  native pin sets.
-- Two SHA-256 fingerprints are recommended (current + next) so a
-  certificate roll never bricks installed clients.
-- Enabling for real lands together with a deploy that ties the
-  fingerprint to the current ACM certificate. Tracked in `#298`.
+- Native pinning is configured for `api.auraxis.com.br` in `app.json`
+  and `assets/network-security-config.xml`.
+- Current production pins:
+  - Leaf `api.auraxis.com.br`: `sha256/6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=`
+  - Backup CA/intermediate `Let's Encrypt E7`: `sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=`
+- The runtime policy only reports `enabled=true` when the build exposes
+  at least two distinct fingerprints.
+- Before promoting beyond internal beta, run the MITM smoke in the SSL
+  pinning rotation runbook on both preview devices.
 
 ## Out of scope here (links)
 
@@ -87,6 +89,6 @@ posture see `auraxis-platform/.context/`.
 - **Frontend (web) security headers and CSP** — see `auraxis-web`.
 - **CAPTCHA provider/key changes** — Cloudflare Turnstile is active in
   the auth forms; provider/key changes remain tracked in `#298`.
-- **Native SSL pin values and MITM smoke** — tracked in `#298` and the
-  SSL pinning rotation runbook.
+- **MITM smoke** — tracked in `#298` and the SSL pinning rotation
+  runbook before promoting beyond internal beta.
 - **Penetration test cadence** — owned by platform `.context/`.


### PR DESCRIPTION
## Summary
- enable native SSL pinning for `api.auraxis.com.br` on iOS and Android
- pin the current leaf SPKI plus the Let's Encrypt E7 intermediate SPKI as the operational backup pin
- tighten JS/runtime SSL policy to require two distinct fingerprints and to treat only `api.auraxis.com.br` as the canonical API host
- add config tests and update the SSL pinning docs/runbook with the extracted pins and rotation notes

## Pins
- Current leaf: `sha256/6ZqZa5LRfTimLYEkGrZ9Pja4ku36AtNGVJ9NbD13GgI=`
- Backup CA/intermediate: `sha256/y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=`
- Extracted from the public `api.auraxis.com.br` TLS chain on 2026-05-19.

## Testing
- `npm test -- --runTestsByPath core/security/ssl-pinning.test.ts __tests__/config/native-ssl-pinning.test.ts --runInBand`
- `npm run quality-check`
- pre-push hook: policy, contracts, typecheck, coverage

## Release note
Manual MITM smoke on preview builds is still required before promoting internal beta beyond the current release checklist, because native TLS failure must be validated on real devices.

Screenshots: not applicable, native security/runtime config only.

Closes #298
