### PR TITLE
feat: add contextual AI insights hub

### DIFF
--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -27,6 +27,7 @@ const HIDDEN_TAB_NAMES: readonly string[] = [
   "contas",
   "cartoes",
   "orcamentos",
+  "insights",
   "foco",
   "onboarding",
   "simulador-meta",

--- a/app/(private)/insights.tsx
+++ b/app/(private)/insights.tsx
@@ -1,0 +1,7 @@
+import type { ReactElement } from "react";
+
+import { AiInsightsScreen } from "@/features/insights/screens/ai-insights-screen";
+
+export default function InsightsRoute(): ReactElement {
+  return <AiInsightsScreen />;
+}

--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -89,6 +89,16 @@
       "status": "enabled-prod",
       "description": "Controla o hub mobile de cartoes com fatura, utilizacao e metadados estendidos.",
       "repositories": ["auraxis-app", "auraxis-api", "auraxis-web"]
+    },
+    {
+      "key": "app.insights.contextual",
+      "owner": "platform",
+      "createdAt": "2026-05-19",
+      "removeBy": "2026-12-31",
+      "type": "release",
+      "status": "enabled-prod",
+      "description": "Controla o hub mobile de insights de IA e a filtragem contextual por dimensao.",
+      "repositories": ["auraxis-app", "auraxis-api", "auraxis-web"]
     }
   ]
 }

--- a/contracts/known-openapi-gaps.json
+++ b/contracts/known-openapi-gaps.json
@@ -43,6 +43,8 @@
     "GET /credit-cards/{credit_card_id}/utilization",
     "GET /v1/insights/latest",
     "POST /v1/insights/{insight_id}/read",
+    "POST /ai/insights/generate",
+    "GET /ai/insights/history",
     "POST /v2/import/detect",
     "POST /v2/import/preview",
     "POST /v2/import/confirm"

--- a/core/navigation/routes.test.ts
+++ b/core/navigation/routes.test.ts
@@ -29,5 +29,6 @@ describe("app routes", () => {
 
   it("keeps static private routes as direct href strings", () => {
     expect(appRoutes.private.dashboard).toBe("/dashboard");
+    expect(appRoutes.private.insights).toBe("/insights");
   });
 });

--- a/core/navigation/routes.ts
+++ b/core/navigation/routes.ts
@@ -42,6 +42,7 @@ export const appRoutes = {
     accounts: "/contas",
     creditCards: "/cartoes",
     budgets: "/orcamentos",
+    insights: "/insights",
     focus: "/foco",
     onboarding: "/onboarding",
     goalSimulator: "/simulador-meta",
@@ -320,6 +321,13 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
   {
     key: "budgets",
     path: appRoutes.private.budgets,
+    access: "private",
+    tabVisible: false,
+    supportsHostedCheckoutReturn: false,
+  },
+  {
+    key: "insights",
+    path: appRoutes.private.insights,
     access: "private",
     tabVisible: false,
     supportsHostedCheckoutReturn: false,

--- a/core/query/query-keys.ts
+++ b/core/query/query-keys.ts
@@ -10,6 +10,10 @@ export const queryKeys = {
   insights: {
     root: ["insights"] as const,
     latest: () => ["insights", "latest"] as const,
+    current: () => ["insights", "current"] as const,
+    historyRoot: () => ["insights", "history"] as const,
+    history: (page: number, perPage: number) =>
+      ["insights", "history", page, perPage] as const,
   },
   import: {
     root: ["import"] as const,

--- a/features/budgets/screens/budgets-screen.tsx
+++ b/features/budgets/screens/budgets-screen.tsx
@@ -1,13 +1,16 @@
 import type { ReactElement } from "react";
 
+import { useRouter } from "expo-router";
 import { Paragraph, XStack, YStack } from "tamagui";
 
+import { appRoutes } from "@/core/navigation/routes";
 import { BudgetForm } from "@/features/budgets/components/budget-form";
 import type { Budget } from "@/features/budgets/contracts";
 import {
   useBudgetsScreenController,
   type BudgetsScreenController,
 } from "@/features/budgets/hooks/use-budgets-screen-controller";
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
@@ -19,6 +22,7 @@ import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
 export function BudgetsScreen(): ReactElement {
   const controller = useBudgetsScreenController();
+  const router = useRouter();
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -42,6 +46,10 @@ export function BudgetsScreen(): ReactElement {
   return (
     <AppScreen>
       <SummaryCard controller={controller} />
+      <AiInsightSurface
+        dimension="budgets"
+        onOpenHub={() => router.push(appRoutes.private.insights)}
+      />
       <BudgetsListCard controller={controller} />
     </AppScreen>
   );

--- a/features/credit-cards/screens/credit-cards-screen.tsx
+++ b/features/credit-cards/screens/credit-cards-screen.tsx
@@ -3,13 +3,14 @@ import type { ReactElement } from "react";
 import { useRouter } from "expo-router";
 import { YStack } from "tamagui";
 
-import { buildCreditCardBillPath } from "@/core/navigation/routes";
+import { appRoutes, buildCreditCardBillPath } from "@/core/navigation/routes";
 import { CreditCardCard } from "@/features/credit-cards/components/credit-card-card";
 import { CreditCardForm } from "@/features/credit-cards/components/credit-card-form";
 import {
   useCreditCardsScreenController,
   type CreditCardsScreenController,
 } from "@/features/credit-cards/hooks/use-credit-cards-screen-controller";
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
 import { AppButton } from "@/shared/components/app-button";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
@@ -42,6 +43,10 @@ export function CreditCardsScreen(): ReactElement {
   return (
     <AppScreen>
       <SummaryCard controller={controller} />
+      <AiInsightSurface
+        dimension="credit_cards"
+        onOpenHub={() => router.push(appRoutes.private.insights)}
+      />
       <CreditCardsListSection
         controller={controller}
         onViewBill={(creditCardId) => {

--- a/features/goals/screens/goals-screen.tsx
+++ b/features/goals/screens/goals-screen.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "expo-router";
 import { RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
-import { buildGoalScenarioPath } from "@/core/navigation/routes";
+import { appRoutes, buildGoalScenarioPath } from "@/core/navigation/routes";
 import { queryKeys } from "@/core/query/query-keys";
 import { GoalForm } from "@/features/goals/components/goal-form";
 import { GoalPlanCard } from "@/features/goals/components/goal-plan-card";
@@ -14,6 +14,7 @@ import {
   useGoalsScreenController,
   type GoalsScreenController,
 } from "@/features/goals/hooks/use-goals-screen-controller";
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
 import type { GoalProgressView } from "@/features/goals/services/goal-progress-calculator";
 import { AppButton } from "@/shared/components/app-button";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
@@ -60,6 +61,7 @@ function ListSeparator(): ReactElement {
  */
 export function GoalsScreen(): ReactElement {
   const controller = useGoalsScreenController();
+  const router = useRouter();
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -81,6 +83,10 @@ export function GoalsScreen(): ReactElement {
   return (
     <AppScreen scrollable={false}>
       <SummaryCard controller={controller} />
+      <AiInsightSurface
+        dimension="goals"
+        onOpenHub={() => router.push(appRoutes.private.insights)}
+      />
       <YStack flex={1}>
         <GoalsListCard controller={controller} />
       </YStack>

--- a/features/insights/components/__snapshots__/insight-hub.test.tsx.snap
+++ b/features/insights/components/__snapshots__/insight-hub.test.tsx.snap
@@ -1,0 +1,1671 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
+<View
+  style={
+    {
+      "flexDirection": "column",
+      "gap": 16,
+    }
+  }
+>
+  <View
+    style={
+      {
+        "backgroundColor": "$surfaceCardLight",
+        "borderBottomColor": "$borderMutedLight",
+        "borderBottomLeftRadius": 14,
+        "borderBottomRightRadius": 14,
+        "borderBottomWidth": 1,
+        "borderLeftColor": "$borderMutedLight",
+        "borderLeftWidth": 1,
+        "borderRightColor": "$borderMutedLight",
+        "borderRightWidth": 1,
+        "borderStyle": "solid",
+        "borderTopColor": "$borderMutedLight",
+        "borderTopLeftRadius": 14,
+        "borderTopRightRadius": 14,
+        "borderTopWidth": 1,
+        "flexDirection": "column",
+        "gap": 8,
+        "paddingBottom": 16,
+        "paddingLeft": 16,
+        "paddingRight": 16,
+        "paddingTop": 16,
+      }
+    }
+  >
+    <Text
+      role="heading"
+      style={
+        {
+          "color": "$textPrimaryLight",
+          "fontFamily": "PlayfairDisplay_700Bold",
+          "fontSize": 20,
+          "lineHeight": 36,
+          "marginBottom": 0,
+          "marginLeft": 0,
+          "marginRight": 0,
+          "marginTop": 0,
+        }
+      }
+      suppressHighlighting={true}
+    >
+      Insights de IA
+    </Text>
+    <Text
+      style={
+        {
+          "color": "$textMutedLight",
+          "fontFamily": "Raleway_400Regular",
+          "fontSize": 14,
+          "lineHeight": 20,
+        }
+      }
+      suppressHighlighting={true}
+    >
+      Analise global
+    </Text>
+    <View
+      style={
+        {
+          "flexDirection": "column",
+          "gap": 12,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 12,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "flexDirection": "column",
+              "gap": 8,
+            }
+          }
+          testID="ai-insight-transparency-granted"
+        >
+          <Text
+            style={
+              {
+                "alignSelf": "flex-start",
+                "backgroundColor": "$brandPrimaryLight",
+                "borderBottomColor": "$borderMutedLight",
+                "borderBottomLeftRadius": 28,
+                "borderBottomRightRadius": 28,
+                "borderBottomWidth": 1,
+                "borderLeftColor": "$borderMutedLight",
+                "borderLeftWidth": 1,
+                "borderRightColor": "$borderMutedLight",
+                "borderRightWidth": 1,
+                "borderStyle": "solid",
+                "borderTopColor": "$borderMutedLight",
+                "borderTopLeftRadius": 28,
+                "borderTopRightRadius": 28,
+                "borderTopWidth": 1,
+                "color": "$brandPrimaryForegroundLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 13,
+                "lineHeight": 18,
+                "paddingBottom": 4,
+                "paddingLeft": 8,
+                "paddingRight": 8,
+                "paddingTop": 4,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            IA informativa
+          </Text>
+          <Text
+            style={
+              {
+                "color": "$textMutedLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Seus dados financeiros nao sao usados para treinar modelos. A IA usa apenas os registros do Auraxis para preparar esta leitura.
+          </Text>
+          <Text
+            style={
+              {
+                "color": "$textMutedLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Este conteudo informativo e nao substitui aconselhamento financeiro individualizado.
+          </Text>
+        </View>
+        <View
+          style={
+            {
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+              "gap": 8,
+            }
+          }
+        >
+          <View
+            accessibilityRole="button"
+            accessibilityState={
+              {
+                "disabled": false,
+              }
+            }
+            accessible={true}
+            focusVisibleStyle={
+              {
+                "outlineColor": "$brandPrimaryLight",
+                "outlineStyle": "solid",
+                "outlineWidth": 2,
+              }
+            }
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            role="button"
+            style={
+              {
+                "alignItems": "center",
+                "backgroundColor": "$brandPrimaryLight",
+                "borderBottomColor": "transparent",
+                "borderBottomLeftRadius": 10,
+                "borderBottomRightRadius": 10,
+                "borderBottomWidth": 1,
+                "borderLeftColor": "transparent",
+                "borderLeftWidth": 1,
+                "borderRightColor": "transparent",
+                "borderRightWidth": 1,
+                "borderStyle": "solid",
+                "borderTopColor": "transparent",
+                "borderTopLeftRadius": 10,
+                "borderTopRightRadius": 10,
+                "borderTopWidth": 1,
+                "cursor": "pointer",
+                "flex": 1,
+                "flexDirection": "row",
+                "flexWrap": "nowrap",
+                "justifyContent": "center",
+              }
+            }
+            tabIndex={0}
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                  "justifyContent": "center",
+                }
+              }
+            >
+              <Text />
+              <Text
+                style={
+                  {
+                    "color": "$brandPrimaryForegroundLight",
+                    "fontFamily": "Raleway_600SemiBold",
+                    "fontSize": 15,
+                    "lineHeight": 22,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                Gerar insights
+              </Text>
+            </View>
+          </View>
+        </View>
+        <Text
+          style={
+            {
+              "color": "$textMutedLight",
+              "fontFamily": "Raleway_400Regular",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          1
+           de 2 insights restantes hoje
+        </Text>
+        <View
+          style={
+            {
+              "flexDirection": "column",
+              "gap": 8,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "backgroundColor": "$surfaceCardLight",
+                "borderBottomColor": "$borderMutedLight",
+                "borderBottomLeftRadius": 14,
+                "borderBottomRightRadius": 14,
+                "borderBottomWidth": 1,
+                "borderLeftColor": "$borderMutedLight",
+                "borderLeftWidth": 1,
+                "borderRightColor": "$borderMutedLight",
+                "borderRightWidth": 1,
+                "borderStyle": "solid",
+                "borderTopColor": "$borderMutedLight",
+                "borderTopLeftRadius": 14,
+                "borderTopRightRadius": 14,
+                "borderTopWidth": 1,
+                "flexDirection": "column",
+                "gap": 8,
+                "paddingBottom": 12,
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 12,
+              }
+            }
+            testID="insight-card-general"
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <Text />
+              <Text
+                style={
+                  {
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "$surfaceRaisedLight",
+                    "borderBottomColor": "$borderMutedLight",
+                    "borderBottomLeftRadius": 28,
+                    "borderBottomRightRadius": 28,
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "$borderMutedLight",
+                    "borderRightWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "$borderMutedLight",
+                    "borderTopLeftRadius": 28,
+                    "borderTopRightRadius": 28,
+                    "borderTopWidth": 1,
+                    "color": "$textPrimaryLight",
+                    "fontFamily": "Raleway_400Regular",
+                    "fontSize": 13,
+                    "lineHeight": 18,
+                    "paddingBottom": 4,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 4,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                saude_financeira
+              </Text>
+            </View>
+            <Text
+              style={
+                {
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Resumo global
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "$textMutedLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              O caixa segue positivo.
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "$surfaceCardLight",
+                "borderBottomColor": "$borderMutedLight",
+                "borderBottomLeftRadius": 14,
+                "borderBottomRightRadius": 14,
+                "borderBottomWidth": 1,
+                "borderLeftColor": "$borderMutedLight",
+                "borderLeftWidth": 1,
+                "borderRightColor": "$borderMutedLight",
+                "borderRightWidth": 1,
+                "borderStyle": "solid",
+                "borderTopColor": "$borderMutedLight",
+                "borderTopLeftRadius": 14,
+                "borderTopRightRadius": 14,
+                "borderTopWidth": 1,
+                "flexDirection": "column",
+                "gap": 8,
+                "paddingBottom": 12,
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 12,
+              }
+            }
+            testID="insight-card-transactions"
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <Text />
+              <Text
+                style={
+                  {
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "$surfaceRaisedLight",
+                    "borderBottomColor": "$borderMutedLight",
+                    "borderBottomLeftRadius": 28,
+                    "borderBottomRightRadius": 28,
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "$borderMutedLight",
+                    "borderRightWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "$borderMutedLight",
+                    "borderTopLeftRadius": 28,
+                    "borderTopRightRadius": 28,
+                    "borderTopWidth": 1,
+                    "color": "$textPrimaryLight",
+                    "fontFamily": "Raleway_400Regular",
+                    "fontSize": 13,
+                    "lineHeight": 18,
+                    "paddingBottom": 4,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 4,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                padrao_gasto
+              </Text>
+            </View>
+            <Text
+              style={
+                {
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Padrao em transacoes
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "$textMutedLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Despesas pequenas se repetiram.
+            </Text>
+          </View>
+          <View
+            style={
+              {
+                "backgroundColor": "$surfaceCardLight",
+                "borderBottomColor": "$borderMutedLight",
+                "borderBottomLeftRadius": 14,
+                "borderBottomRightRadius": 14,
+                "borderBottomWidth": 1,
+                "borderLeftColor": "$borderMutedLight",
+                "borderLeftWidth": 1,
+                "borderRightColor": "$borderMutedLight",
+                "borderRightWidth": 1,
+                "borderStyle": "solid",
+                "borderTopColor": "$borderMutedLight",
+                "borderTopLeftRadius": 14,
+                "borderTopRightRadius": 14,
+                "borderTopWidth": 1,
+                "flexDirection": "column",
+                "gap": 8,
+                "paddingBottom": 12,
+                "paddingLeft": 12,
+                "paddingRight": 12,
+                "paddingTop": 12,
+              }
+            }
+            testID="insight-card-goals"
+          >
+            <View
+              style={
+                {
+                  "alignItems": "center",
+                  "flexDirection": "row",
+                  "gap": 8,
+                }
+              }
+            >
+              <Text />
+              <Text
+                style={
+                  {
+                    "alignSelf": "flex-start",
+                    "backgroundColor": "$surfaceRaisedLight",
+                    "borderBottomColor": "$borderMutedLight",
+                    "borderBottomLeftRadius": 28,
+                    "borderBottomRightRadius": 28,
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "$borderMutedLight",
+                    "borderRightWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "$borderMutedLight",
+                    "borderTopLeftRadius": 28,
+                    "borderTopRightRadius": 28,
+                    "borderTopWidth": 1,
+                    "color": "$textPrimaryLight",
+                    "fontFamily": "Raleway_400Regular",
+                    "fontSize": 13,
+                    "lineHeight": 18,
+                    "paddingBottom": 4,
+                    "paddingLeft": 8,
+                    "paddingRight": 8,
+                    "paddingTop": 4,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                alerta_meta
+              </Text>
+            </View>
+            <Text
+              style={
+                {
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Meta em atencao
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "$textMutedLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              A reserva ficou abaixo do ritmo planejado.
+            </Text>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flexDirection": "column",
+        "gap": 12,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "flex": 1,
+            "flexDirection": "column",
+            "gap": 4,
+          }
+        }
+      >
+        <Text
+          role="heading"
+          style={
+            {
+              "color": "$textPrimaryLight",
+              "fontFamily": "PlayfairDisplay_700Bold",
+              "fontSize": 20,
+              "lineHeight": 36,
+              "marginBottom": 0,
+              "marginLeft": 0,
+              "marginRight": 0,
+              "marginTop": 0,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Insight atual
+        </Text>
+        <Text
+          style={
+            {
+              "color": "$textMutedLight",
+              "fontFamily": "Raleway_400Regular",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          2026-05-19
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "column",
+          "gap": 12,
+        }
+      }
+      testID="insight-group-general"
+    >
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "$textPrimaryLight",
+              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "fontSize": 20,
+              "lineHeight": 28,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Visao geral
+        </Text>
+        <Text
+          style={
+            {
+              "color": "$textMutedLight",
+              "fontFamily": "Raleway_400Regular",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          1
+           insight
+        </Text>
+      </View>
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 8,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "backgroundColor": "$surfaceCardLight",
+              "borderBottomColor": "$borderMutedLight",
+              "borderBottomLeftRadius": 14,
+              "borderBottomRightRadius": 14,
+              "borderBottomWidth": 1,
+              "borderLeftColor": "$borderMutedLight",
+              "borderLeftWidth": 1,
+              "borderRightColor": "$borderMutedLight",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "borderTopColor": "$borderMutedLight",
+              "borderTopLeftRadius": 14,
+              "borderTopRightRadius": 14,
+              "borderTopWidth": 1,
+              "flexDirection": "column",
+              "gap": 8,
+              "paddingBottom": 12,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 12,
+            }
+          }
+          testID="insight-card-general"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 8,
+              }
+            }
+          >
+            <Text />
+            <Text
+              style={
+                {
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "$surfaceRaisedLight",
+                  "borderBottomColor": "$borderMutedLight",
+                  "borderBottomLeftRadius": 28,
+                  "borderBottomRightRadius": 28,
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "$borderMutedLight",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "$borderMutedLight",
+                  "borderRightWidth": 1,
+                  "borderStyle": "solid",
+                  "borderTopColor": "$borderMutedLight",
+                  "borderTopLeftRadius": 28,
+                  "borderTopRightRadius": 28,
+                  "borderTopWidth": 1,
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 13,
+                  "lineHeight": 18,
+                  "paddingBottom": 4,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 4,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              saude_financeira
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "$textPrimaryLight",
+                "fontFamily": "PlayfairDisplay_600SemiBold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Resumo global
+          </Text>
+          <Text
+            style={
+              {
+                "color": "$textMutedLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            O caixa segue positivo.
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "column",
+          "gap": 12,
+        }
+      }
+      testID="insight-group-transactions"
+    >
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "$textPrimaryLight",
+              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "fontSize": 20,
+              "lineHeight": 28,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Transacoes
+        </Text>
+        <Text
+          style={
+            {
+              "color": "$textMutedLight",
+              "fontFamily": "Raleway_400Regular",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          1
+           insight
+        </Text>
+      </View>
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 8,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "backgroundColor": "$surfaceCardLight",
+              "borderBottomColor": "$borderMutedLight",
+              "borderBottomLeftRadius": 14,
+              "borderBottomRightRadius": 14,
+              "borderBottomWidth": 1,
+              "borderLeftColor": "$borderMutedLight",
+              "borderLeftWidth": 1,
+              "borderRightColor": "$borderMutedLight",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "borderTopColor": "$borderMutedLight",
+              "borderTopLeftRadius": 14,
+              "borderTopRightRadius": 14,
+              "borderTopWidth": 1,
+              "flexDirection": "column",
+              "gap": 8,
+              "paddingBottom": 12,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 12,
+            }
+          }
+          testID="insight-card-transactions"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 8,
+              }
+            }
+          >
+            <Text />
+            <Text
+              style={
+                {
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "$surfaceRaisedLight",
+                  "borderBottomColor": "$borderMutedLight",
+                  "borderBottomLeftRadius": 28,
+                  "borderBottomRightRadius": 28,
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "$borderMutedLight",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "$borderMutedLight",
+                  "borderRightWidth": 1,
+                  "borderStyle": "solid",
+                  "borderTopColor": "$borderMutedLight",
+                  "borderTopLeftRadius": 28,
+                  "borderTopRightRadius": 28,
+                  "borderTopWidth": 1,
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 13,
+                  "lineHeight": 18,
+                  "paddingBottom": 4,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 4,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              padrao_gasto
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "$textPrimaryLight",
+                "fontFamily": "PlayfairDisplay_600SemiBold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Padrao em transacoes
+          </Text>
+          <Text
+            style={
+              {
+                "color": "$textMutedLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Despesas pequenas se repetiram.
+          </Text>
+        </View>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "column",
+          "gap": 12,
+        }
+      }
+      testID="insight-group-goals"
+    >
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 4,
+          }
+        }
+      >
+        <Text
+          style={
+            {
+              "color": "$textPrimaryLight",
+              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "fontSize": 20,
+              "lineHeight": 28,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Metas
+        </Text>
+        <Text
+          style={
+            {
+              "color": "$textMutedLight",
+              "fontFamily": "Raleway_400Regular",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          1
+           insight
+        </Text>
+      </View>
+      <View
+        style={
+          {
+            "flexDirection": "column",
+            "gap": 8,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "backgroundColor": "$surfaceCardLight",
+              "borderBottomColor": "$borderMutedLight",
+              "borderBottomLeftRadius": 14,
+              "borderBottomRightRadius": 14,
+              "borderBottomWidth": 1,
+              "borderLeftColor": "$borderMutedLight",
+              "borderLeftWidth": 1,
+              "borderRightColor": "$borderMutedLight",
+              "borderRightWidth": 1,
+              "borderStyle": "solid",
+              "borderTopColor": "$borderMutedLight",
+              "borderTopLeftRadius": 14,
+              "borderTopRightRadius": 14,
+              "borderTopWidth": 1,
+              "flexDirection": "column",
+              "gap": 8,
+              "paddingBottom": 12,
+              "paddingLeft": 12,
+              "paddingRight": 12,
+              "paddingTop": 12,
+            }
+          }
+          testID="insight-card-goals"
+        >
+          <View
+            style={
+              {
+                "alignItems": "center",
+                "flexDirection": "row",
+                "gap": 8,
+              }
+            }
+          >
+            <Text />
+            <Text
+              style={
+                {
+                  "alignSelf": "flex-start",
+                  "backgroundColor": "$surfaceRaisedLight",
+                  "borderBottomColor": "$borderMutedLight",
+                  "borderBottomLeftRadius": 28,
+                  "borderBottomRightRadius": 28,
+                  "borderBottomWidth": 1,
+                  "borderLeftColor": "$borderMutedLight",
+                  "borderLeftWidth": 1,
+                  "borderRightColor": "$borderMutedLight",
+                  "borderRightWidth": 1,
+                  "borderStyle": "solid",
+                  "borderTopColor": "$borderMutedLight",
+                  "borderTopLeftRadius": 28,
+                  "borderTopRightRadius": 28,
+                  "borderTopWidth": 1,
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 13,
+                  "lineHeight": 18,
+                  "paddingBottom": 4,
+                  "paddingLeft": 8,
+                  "paddingRight": 8,
+                  "paddingTop": 4,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              alerta_meta
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "$textPrimaryLight",
+                "fontFamily": "PlayfairDisplay_600SemiBold",
+                "fontSize": 16,
+                "lineHeight": 24,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Meta em atencao
+          </Text>
+          <Text
+            style={
+              {
+                "color": "$textMutedLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            A reserva ficou abaixo do ritmo planejado.
+          </Text>
+        </View>
+      </View>
+    </View>
+  </View>
+  <View
+    style={
+      {
+        "flexDirection": "column",
+        "gap": 12,
+      }
+    }
+  >
+    <View
+      style={
+        {
+          "alignItems": "flex-start",
+          "flexDirection": "row",
+          "gap": 12,
+          "justifyContent": "space-between",
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "flex": 1,
+            "flexDirection": "column",
+            "gap": 4,
+          }
+        }
+      >
+        <Text
+          role="heading"
+          style={
+            {
+              "color": "$textPrimaryLight",
+              "fontFamily": "PlayfairDisplay_700Bold",
+              "fontSize": 20,
+              "lineHeight": 36,
+              "marginBottom": 0,
+              "marginLeft": 0,
+              "marginRight": 0,
+              "marginTop": 0,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Historico
+        </Text>
+        <Text
+          style={
+            {
+              "color": "$textMutedLight",
+              "fontFamily": "Raleway_400Regular",
+              "fontSize": 14,
+              "lineHeight": 20,
+            }
+          }
+          suppressHighlighting={true}
+        >
+          Registros salvos pela geracao de IA.
+        </Text>
+      </View>
+    </View>
+    <View
+      style={
+        {
+          "flexDirection": "column",
+          "gap": 12,
+        }
+      }
+    >
+      <View
+        style={
+          {
+            "borderBottomColor": "$borderMutedLight",
+            "borderBottomWidth": 1,
+            "borderStyle": "solid",
+            "flexDirection": "column",
+            "gap": 12,
+            "paddingBottom": 12,
+            "paddingTop": 12,
+          }
+        }
+      >
+        <View
+          style={
+            {
+              "flexDirection": "column",
+              "gap": 12,
+            }
+          }
+        >
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "gap": 4,
+              }
+            }
+          >
+            <Text
+              style={
+                {
+                  "color": "$textPrimaryLight",
+                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "fontSize": 16,
+                  "lineHeight": 24,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              Resumo global do periodo
+            </Text>
+            <Text
+              style={
+                {
+                  "color": "$textMutedLight",
+                  "fontFamily": "Raleway_400Regular",
+                  "fontSize": 14,
+                  "lineHeight": 20,
+                }
+              }
+              suppressHighlighting={true}
+            >
+              2026-05-19 · daily
+            </Text>
+          </View>
+          <Text
+            style={
+              {
+                "color": "$textMutedLight",
+                "fontFamily": "Raleway_400Regular",
+                "fontSize": 14,
+                "lineHeight": 20,
+              }
+            }
+            suppressHighlighting={true}
+          >
+            Periodo equilibrado
+          </Text>
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "gap": 12,
+              }
+            }
+            testID="insight-group-general"
+          >
+            <View
+              style={
+                {
+                  "flexDirection": "column",
+                  "gap": 4,
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "$textPrimaryLight",
+                    "fontFamily": "PlayfairDisplay_600SemiBold",
+                    "fontSize": 20,
+                    "lineHeight": 28,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                Visao geral
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "$textMutedLight",
+                    "fontFamily": "Raleway_400Regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                1
+                 insight
+              </Text>
+            </View>
+            <View
+              style={
+                {
+                  "flexDirection": "column",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "$surfaceCardLight",
+                    "borderBottomColor": "$borderMutedLight",
+                    "borderBottomLeftRadius": 14,
+                    "borderBottomRightRadius": 14,
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "$borderMutedLight",
+                    "borderRightWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "$borderMutedLight",
+                    "borderTopLeftRadius": 14,
+                    "borderTopRightRadius": 14,
+                    "borderTopWidth": 1,
+                    "flexDirection": "column",
+                    "gap": 8,
+                    "paddingBottom": 12,
+                    "paddingLeft": 12,
+                    "paddingRight": 12,
+                    "paddingTop": 12,
+                  }
+                }
+                testID="insight-card-general"
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 8,
+                    }
+                  }
+                >
+                  <Text />
+                  <Text
+                    style={
+                      {
+                        "alignSelf": "flex-start",
+                        "backgroundColor": "$surfaceRaisedLight",
+                        "borderBottomColor": "$borderMutedLight",
+                        "borderBottomLeftRadius": 28,
+                        "borderBottomRightRadius": 28,
+                        "borderBottomWidth": 1,
+                        "borderLeftColor": "$borderMutedLight",
+                        "borderLeftWidth": 1,
+                        "borderRightColor": "$borderMutedLight",
+                        "borderRightWidth": 1,
+                        "borderStyle": "solid",
+                        "borderTopColor": "$borderMutedLight",
+                        "borderTopLeftRadius": 28,
+                        "borderTopRightRadius": 28,
+                        "borderTopWidth": 1,
+                        "color": "$textPrimaryLight",
+                        "fontFamily": "Raleway_400Regular",
+                        "fontSize": 13,
+                        "lineHeight": 18,
+                        "paddingBottom": 4,
+                        "paddingLeft": 8,
+                        "paddingRight": 8,
+                        "paddingTop": 4,
+                      }
+                    }
+                    suppressHighlighting={true}
+                  >
+                    saude_financeira
+                  </Text>
+                </View>
+                <Text
+                  style={
+                    {
+                      "color": "$textPrimaryLight",
+                      "fontFamily": "PlayfairDisplay_600SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 24,
+                    }
+                  }
+                  suppressHighlighting={true}
+                >
+                  Resumo global
+                </Text>
+                <Text
+                  style={
+                    {
+                      "color": "$textMutedLight",
+                      "fontFamily": "Raleway_400Regular",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                    }
+                  }
+                  suppressHighlighting={true}
+                >
+                  O caixa segue positivo.
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "gap": 12,
+              }
+            }
+            testID="insight-group-transactions"
+          >
+            <View
+              style={
+                {
+                  "flexDirection": "column",
+                  "gap": 4,
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "$textPrimaryLight",
+                    "fontFamily": "PlayfairDisplay_600SemiBold",
+                    "fontSize": 20,
+                    "lineHeight": 28,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                Transacoes
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "$textMutedLight",
+                    "fontFamily": "Raleway_400Regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                1
+                 insight
+              </Text>
+            </View>
+            <View
+              style={
+                {
+                  "flexDirection": "column",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "$surfaceCardLight",
+                    "borderBottomColor": "$borderMutedLight",
+                    "borderBottomLeftRadius": 14,
+                    "borderBottomRightRadius": 14,
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "$borderMutedLight",
+                    "borderRightWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "$borderMutedLight",
+                    "borderTopLeftRadius": 14,
+                    "borderTopRightRadius": 14,
+                    "borderTopWidth": 1,
+                    "flexDirection": "column",
+                    "gap": 8,
+                    "paddingBottom": 12,
+                    "paddingLeft": 12,
+                    "paddingRight": 12,
+                    "paddingTop": 12,
+                  }
+                }
+                testID="insight-card-transactions"
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 8,
+                    }
+                  }
+                >
+                  <Text />
+                  <Text
+                    style={
+                      {
+                        "alignSelf": "flex-start",
+                        "backgroundColor": "$surfaceRaisedLight",
+                        "borderBottomColor": "$borderMutedLight",
+                        "borderBottomLeftRadius": 28,
+                        "borderBottomRightRadius": 28,
+                        "borderBottomWidth": 1,
+                        "borderLeftColor": "$borderMutedLight",
+                        "borderLeftWidth": 1,
+                        "borderRightColor": "$borderMutedLight",
+                        "borderRightWidth": 1,
+                        "borderStyle": "solid",
+                        "borderTopColor": "$borderMutedLight",
+                        "borderTopLeftRadius": 28,
+                        "borderTopRightRadius": 28,
+                        "borderTopWidth": 1,
+                        "color": "$textPrimaryLight",
+                        "fontFamily": "Raleway_400Regular",
+                        "fontSize": 13,
+                        "lineHeight": 18,
+                        "paddingBottom": 4,
+                        "paddingLeft": 8,
+                        "paddingRight": 8,
+                        "paddingTop": 4,
+                      }
+                    }
+                    suppressHighlighting={true}
+                  >
+                    padrao_gasto
+                  </Text>
+                </View>
+                <Text
+                  style={
+                    {
+                      "color": "$textPrimaryLight",
+                      "fontFamily": "PlayfairDisplay_600SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 24,
+                    }
+                  }
+                  suppressHighlighting={true}
+                >
+                  Padrao em transacoes
+                </Text>
+                <Text
+                  style={
+                    {
+                      "color": "$textMutedLight",
+                      "fontFamily": "Raleway_400Regular",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                    }
+                  }
+                  suppressHighlighting={true}
+                >
+                  Despesas pequenas se repetiram.
+                </Text>
+              </View>
+            </View>
+          </View>
+          <View
+            style={
+              {
+                "flexDirection": "column",
+                "gap": 12,
+              }
+            }
+            testID="insight-group-goals"
+          >
+            <View
+              style={
+                {
+                  "flexDirection": "column",
+                  "gap": 4,
+                }
+              }
+            >
+              <Text
+                style={
+                  {
+                    "color": "$textPrimaryLight",
+                    "fontFamily": "PlayfairDisplay_600SemiBold",
+                    "fontSize": 20,
+                    "lineHeight": 28,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                Metas
+              </Text>
+              <Text
+                style={
+                  {
+                    "color": "$textMutedLight",
+                    "fontFamily": "Raleway_400Regular",
+                    "fontSize": 14,
+                    "lineHeight": 20,
+                  }
+                }
+                suppressHighlighting={true}
+              >
+                1
+                 insight
+              </Text>
+            </View>
+            <View
+              style={
+                {
+                  "flexDirection": "column",
+                  "gap": 8,
+                }
+              }
+            >
+              <View
+                style={
+                  {
+                    "backgroundColor": "$surfaceCardLight",
+                    "borderBottomColor": "$borderMutedLight",
+                    "borderBottomLeftRadius": 14,
+                    "borderBottomRightRadius": 14,
+                    "borderBottomWidth": 1,
+                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftWidth": 1,
+                    "borderRightColor": "$borderMutedLight",
+                    "borderRightWidth": 1,
+                    "borderStyle": "solid",
+                    "borderTopColor": "$borderMutedLight",
+                    "borderTopLeftRadius": 14,
+                    "borderTopRightRadius": 14,
+                    "borderTopWidth": 1,
+                    "flexDirection": "column",
+                    "gap": 8,
+                    "paddingBottom": 12,
+                    "paddingLeft": 12,
+                    "paddingRight": 12,
+                    "paddingTop": 12,
+                  }
+                }
+                testID="insight-card-goals"
+              >
+                <View
+                  style={
+                    {
+                      "alignItems": "center",
+                      "flexDirection": "row",
+                      "gap": 8,
+                    }
+                  }
+                >
+                  <Text />
+                  <Text
+                    style={
+                      {
+                        "alignSelf": "flex-start",
+                        "backgroundColor": "$surfaceRaisedLight",
+                        "borderBottomColor": "$borderMutedLight",
+                        "borderBottomLeftRadius": 28,
+                        "borderBottomRightRadius": 28,
+                        "borderBottomWidth": 1,
+                        "borderLeftColor": "$borderMutedLight",
+                        "borderLeftWidth": 1,
+                        "borderRightColor": "$borderMutedLight",
+                        "borderRightWidth": 1,
+                        "borderStyle": "solid",
+                        "borderTopColor": "$borderMutedLight",
+                        "borderTopLeftRadius": 28,
+                        "borderTopRightRadius": 28,
+                        "borderTopWidth": 1,
+                        "color": "$textPrimaryLight",
+                        "fontFamily": "Raleway_400Regular",
+                        "fontSize": 13,
+                        "lineHeight": 18,
+                        "paddingBottom": 4,
+                        "paddingLeft": 8,
+                        "paddingRight": 8,
+                        "paddingTop": 4,
+                      }
+                    }
+                    suppressHighlighting={true}
+                  >
+                    alerta_meta
+                  </Text>
+                </View>
+                <Text
+                  style={
+                    {
+                      "color": "$textPrimaryLight",
+                      "fontFamily": "PlayfairDisplay_600SemiBold",
+                      "fontSize": 16,
+                      "lineHeight": 24,
+                    }
+                  }
+                  suppressHighlighting={true}
+                >
+                  Meta em atencao
+                </Text>
+                <Text
+                  style={
+                    {
+                      "color": "$textMutedLight",
+                      "fontFamily": "Raleway_400Regular",
+                      "fontSize": 14,
+                      "lineHeight": 20,
+                    }
+                  }
+                  suppressHighlighting={true}
+                >
+                  A reserva ficou abaixo do ritmo planejado.
+                </Text>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</View>
+`;

--- a/features/insights/components/ai-insight-loading-modal.tsx
+++ b/features/insights/components/ai-insight-loading-modal.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from "react";
+
+import { Modal } from "react-native";
+import { YStack } from "tamagui";
+
+import { AsyncStateNotice } from "@/shared/components/async-state-notice";
+
+export interface AiInsightLoadingModalProps {
+  readonly visible: boolean;
+}
+
+export function AiInsightLoadingModal({
+  visible,
+}: AiInsightLoadingModalProps): ReactElement {
+  return (
+    <Modal visible={visible} transparent animationType="fade">
+      <YStack
+        flex={1}
+        alignItems="center"
+        justifyContent="center"
+        padding="$4"
+        backgroundColor="rgba(0,0,0,0.42)"
+      >
+        <AsyncStateNotice
+          kind="loading"
+          title="Gerando insights"
+          description="A IA esta cruzando seu contexto financeiro mais recente."
+        />
+      </YStack>
+    </Modal>
+  );
+}

--- a/features/insights/components/ai-insight-surface.test.tsx
+++ b/features/insights/components/ai-insight-surface.test.tsx
@@ -1,0 +1,145 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { ApiError } from "@/core/http/api-error";
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import type { UserInsight } from "@/features/insights/contracts";
+import type { AiInsightsController } from "@/features/insights/hooks/use-ai-insights-controller";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+const mockUseFeatureAccess = jest.fn();
+const mockUseAiInsightConsent = jest.fn();
+
+jest.mock("@/features/entitlements/hooks/use-feature-access", () => ({
+  useFeatureAccess: (...args: readonly unknown[]) => mockUseFeatureAccess(...args),
+}));
+
+jest.mock("@/features/insights/hooks/use-ai-insight-consent", () => ({
+  useAiInsightConsent: (...args: readonly unknown[]) => mockUseAiInsightConsent(...args),
+}));
+
+const insightFixture: UserInsight = {
+  id: "ins-1",
+  content: "Resumo global",
+  keyMetric: "Resumo global",
+  items: [
+    {
+      type: "saude_financeira",
+      dimension: "general",
+      title: "Resumo global",
+      message: "O caixa segue positivo.",
+    },
+    {
+      type: "padrao_gasto",
+      dimension: "transactions",
+      title: "Padrao em transacoes",
+      message: "Despesas pequenas se repetiram.",
+    },
+    {
+      type: "alerta_orcamento",
+      dimension: "budgets",
+      title: "Orcamento em alerta",
+      message: "Mercado chegou a 91%.",
+    },
+  ],
+  summary: null,
+  periodType: "daily",
+  periodLabel: "2026-05-19",
+  periodStart: "2026-05-19",
+  periodEnd: "2026-05-19",
+  status: "delivered",
+  generatedAt: "2026-05-19",
+  readAt: null,
+  metadata: {
+    model: "gpt-4o-mini",
+    tokensUsed: 420,
+    costUsd: 0.000063,
+    cached: false,
+    contextVersion: "financial_insight_snapshot.v1",
+  },
+};
+
+const createController = (
+  override: Partial<AiInsightsController> = {},
+): AiInsightsController => ({
+  currentInsight: insightFixture,
+  visibleItems: insightFixture.items.slice(0, 2),
+  dimensionGroups: [],
+  history: [insightFixture],
+  historyQuery: {} as AiInsightsController["historyQuery"],
+  isGenerating: false,
+  generateError: null,
+  generateErrorTitle: null,
+  callsRemaining: 1,
+  hasGeneratedInsight: true,
+  shouldShowContextualEmptyState: false,
+  generate: jest.fn(),
+  dismissGenerateError: jest.fn(),
+  ...override,
+});
+
+describe("AiInsightSurface", () => {
+  beforeEach(() => {
+    mockUseFeatureAccess.mockReturnValue({ hasAccess: true, isLoading: false });
+    mockUseAiInsightConsent.mockReturnValue({
+      hasConsent: true,
+      isHydrated: true,
+      grantConsent: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("mostra apenas itens general e da dimensao contextual", () => {
+    const { getByText, queryByText } = render(
+      <TestProviders>
+        <AiInsightSurface
+          dimension="transactions"
+          controller={createController()}
+        />
+      </TestProviders>,
+    );
+
+    expect(getByText("Resumo global")).toBeTruthy();
+    expect(getByText("Padrao em transacoes")).toBeTruthy();
+    expect(queryByText("Orcamento em alerta")).toBeNull();
+  });
+
+  it("dispara geracao daily pelo botao da superficie", () => {
+    const generate = jest.fn().mockResolvedValue(undefined);
+    const { getByText } = render(
+      <TestProviders>
+        <AiInsightSurface
+          dimension="transactions"
+          controller={createController({ generate })}
+        />
+      </TestProviders>,
+    );
+
+    fireEvent.press(getByText("Gerar insights"));
+
+    expect(generate).toHaveBeenCalledWith({ periodType: "daily" });
+  });
+
+  it("mostra mensagem amigavel para quota 429", () => {
+    const quotaError = new ApiError({
+      message: "Daily limit exceeded",
+      status: 429,
+      code: "AI_DAILY_LIMIT_EXCEEDED",
+    });
+    const { getByText } = render(
+      <TestProviders>
+        <AiInsightSurface
+          dimension="transactions"
+          controller={createController({
+            generateError: quotaError,
+            generateErrorTitle: "Voce atingiu o limite de 2 insights/dia",
+          })}
+        />
+      </TestProviders>,
+    );
+
+    expect(getByText("Voce atingiu o limite de 2 insights/dia")).toBeTruthy();
+  });
+});

--- a/features/insights/components/ai-insight-surface.tsx
+++ b/features/insights/components/ai-insight-surface.tsx
@@ -1,0 +1,222 @@
+import type { ComponentProps, ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { ApiError } from "@/core/http/api-error";
+import { AiInsightLoadingModal } from "@/features/insights/components/ai-insight-loading-modal";
+import { AiInsightTransparencyNotice } from "@/features/insights/components/ai-insight-transparency-notice";
+import { InsightCard } from "@/features/insights/components/insight-card";
+import type { InsightDimension } from "@/features/insights/contracts";
+import { useAiInsightConsent } from "@/features/insights/hooks/use-ai-insight-consent";
+import {
+  type AiInsightsController,
+  useAiInsightsController,
+} from "@/features/insights/hooks/use-ai-insights-controller";
+import { getInsightDimensionLabel } from "@/features/insights/hooks/use-insights-by-dimension";
+import { AI_INSIGHTS_CONTEXTUAL_FEATURE_FLAG_KEY } from "@/features/insights/insights-config";
+import { useFeatureAccess } from "@/features/entitlements/hooks/use-feature-access";
+import { UpgradeCta } from "@/features/subscription/components/upgrade-cta";
+import { AppButton } from "@/shared/components/app-button";
+import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { isFeatureEnabled } from "@/shared/feature-flags";
+
+export interface AiInsightSurfaceProps {
+  readonly dimension?: InsightDimension;
+  readonly controller?: AiInsightsController;
+  readonly onOpenHub?: () => void;
+}
+
+type MaterialCommunityIconName = ComponentProps<typeof MaterialCommunityIcons>["name"];
+
+const buttonIconProps = {
+  name: "lightbulb-on-outline" as MaterialCommunityIconName,
+  size: 18,
+  color: "white",
+} as const;
+
+const isAiConsentRequiredError = (error: ApiError | null): boolean => {
+  return error?.code === "AI_CONSENT_REQUIRED";
+};
+
+const resolveErrorTitle = (
+  error: ApiError | null,
+  quotaTitle: string | null,
+): string => {
+  if (quotaTitle) {
+    return quotaTitle;
+  }
+  if (isAiConsentRequiredError(error)) {
+    return "Autorize o uso de IA para gerar insights";
+  }
+  return "Nao foi possivel gerar insights";
+};
+
+export function AiInsightSurface({
+  dimension,
+  controller: providedController,
+  onOpenHub,
+}: AiInsightSurfaceProps): ReactElement | null {
+  if (providedController) {
+    return (
+      <AiInsightSurfaceRoot
+        dimension={dimension}
+        controller={providedController}
+        onOpenHub={onOpenHub}
+      />
+    );
+  }
+
+  return <AiInsightSurfaceWithHook dimension={dimension} onOpenHub={onOpenHub} />;
+}
+
+function AiInsightSurfaceWithHook({
+  dimension,
+  onOpenHub,
+}: Pick<AiInsightSurfaceProps, "dimension" | "onOpenHub">): ReactElement | null {
+  const controller = useAiInsightsController({ dimension });
+  return (
+    <AiInsightSurfaceRoot
+      dimension={dimension}
+      controller={controller}
+      onOpenHub={onOpenHub}
+    />
+  );
+}
+
+function AiInsightSurfaceRoot({
+  dimension,
+  controller,
+  onOpenHub,
+}: Required<Pick<AiInsightSurfaceProps, "controller">> &
+  Pick<AiInsightSurfaceProps, "dimension" | "onOpenHub">): ReactElement | null {
+  const featureEnabled = isFeatureEnabled(AI_INSIGHTS_CONTEXTUAL_FEATURE_FLAG_KEY);
+  const access = useFeatureAccess("advanced_simulations", featureEnabled);
+  const consent = useAiInsightConsent({ enabled: featureEnabled });
+
+  if (!featureEnabled) {
+    return null;
+  }
+
+  return (
+    <AppSurfaceCard
+      title="Insights de IA"
+      description={dimension ? getInsightDimensionLabel(dimension) : "Analise global"}
+    >
+      <YStack gap="$3">
+        {access.isLoading ? (
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+            Conferindo acesso Premium
+          </Paragraph>
+        ) : access.hasAccess ? (
+          <InsightSurfaceContent
+            controller={controller}
+            consent={consent}
+            onOpenHub={onOpenHub}
+          />
+        ) : (
+          <UpgradeCta />
+        )}
+      </YStack>
+    </AppSurfaceCard>
+  );
+}
+
+interface InsightSurfaceContentProps {
+  readonly controller: AiInsightsController;
+  readonly consent: ReturnType<typeof useAiInsightConsent>;
+  readonly onOpenHub?: () => void;
+}
+
+function InsightSurfaceContent({
+  controller,
+  consent,
+  onOpenHub,
+}: InsightSurfaceContentProps): ReactElement {
+  const canGenerate = consent.isHydrated && consent.hasConsent && !controller.isGenerating;
+
+  return (
+    <YStack gap="$3">
+      <AiInsightTransparencyNotice
+        hasConsent={consent.hasConsent}
+        isHydrated={consent.isHydrated}
+        onGrantConsent={consent.grantConsent}
+      />
+      <XStack gap="$2" flexWrap="wrap">
+        <AppButton
+          flex={1}
+          disabled={!canGenerate}
+          onPress={() => {
+            void controller.generate({ periodType: "daily" });
+          }}
+        >
+          <XStack alignItems="center" justifyContent="center" gap="$2">
+            <MaterialCommunityIcons {...buttonIconProps} />
+            <Paragraph color="$actionPrimaryForeground" fontFamily="$body" fontWeight="$6">
+              Gerar insights
+            </Paragraph>
+          </XStack>
+        </AppButton>
+        {onOpenHub ? (
+          <AppButton tone="secondary" onPress={onOpenHub}>
+            Ver hub
+          </AppButton>
+        ) : null}
+      </XStack>
+      {controller.callsRemaining !== null ? (
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+          {controller.callsRemaining} de 2 insights restantes hoje
+        </Paragraph>
+      ) : null}
+      <InsightSurfaceFeedback controller={controller} />
+      <AiInsightLoadingModal visible={controller.isGenerating} />
+    </YStack>
+  );
+}
+
+function InsightSurfaceFeedback({
+  controller,
+}: {
+  readonly controller: AiInsightsController;
+}): ReactElement | null {
+  if (controller.generateError) {
+    return (
+      <AppErrorNotice
+        error={controller.generateError}
+        fallbackTitle={resolveErrorTitle(
+          controller.generateError,
+          controller.generateErrorTitle,
+        )}
+        fallbackDescription="Tente novamente mais tarde ou abra o hub para ver o historico."
+        actionLabel="Dispensar"
+        onAction={controller.dismissGenerateError}
+      />
+    );
+  }
+
+  if (controller.visibleItems.length > 0) {
+    return (
+      <YStack gap="$2">
+        {controller.visibleItems.map((item) => (
+          <InsightCard key={`${item.dimension}-${item.type}-${item.title}`} item={item} />
+        ))}
+      </YStack>
+    );
+  }
+
+  if (controller.shouldShowContextualEmptyState) {
+    return (
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+        Nenhum insight especifico para esta area no periodo atual. A visao completa
+        continua disponivel em Insights.
+      </Paragraph>
+    );
+  }
+
+  return (
+    <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+      Gere uma leitura com IA para cruzar seus dados financeiros mais recentes.
+    </Paragraph>
+  );
+}

--- a/features/insights/components/insight-card.tsx
+++ b/features/insights/components/insight-card.tsx
@@ -1,0 +1,64 @@
+import type { ComponentProps, ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import type { InsightItem } from "@/features/insights/contracts";
+import { AppBadge } from "@/shared/components/app-badge";
+
+export interface InsightCardProps {
+  readonly item: InsightItem;
+}
+
+type MaterialCommunityIconName = ComponentProps<typeof MaterialCommunityIcons>["name"];
+
+const ICON_BY_TYPE: Record<string, MaterialCommunityIconName> = {
+  gasto_elevado: "trending-up",
+  oportunidade_economia: "piggy-bank-outline",
+  saude_financeira: "heart-pulse",
+  alerta_orcamento: "alert-outline",
+  padrao_gasto: "chart-bar",
+  alerta_meta: "flag-outline",
+  progresso_meta: "flag-checkered",
+  planejamento_meta: "map-clock-outline",
+  orcamento_ultrapassado: "alert-circle-outline",
+  saude_orcamento_mensal: "finance",
+  conquista_meta: "trophy-outline",
+  savings_rate_gap: "cash-clock",
+};
+
+const resolveIcon = (type: string): MaterialCommunityIconName => {
+  return ICON_BY_TYPE[type] ?? "lightbulb-on-outline";
+};
+
+export function InsightCard({ item }: InsightCardProps): ReactElement {
+  return (
+    <YStack
+      gap="$2"
+      padding="$3"
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderRadius="$2"
+      borderWidth={1}
+      testID={`insight-card-${item.dimension ?? "general"}`}
+    >
+      <XStack alignItems="center" gap="$2">
+        <MaterialCommunityIcons name={resolveIcon(item.type)} size={18} />
+        <AppBadge>{item.type}</AppBadge>
+      </XStack>
+      <Paragraph color="$color" fontFamily="$heading" fontSize="$5">
+        {item.title}
+      </Paragraph>
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+        {item.message}
+      </Paragraph>
+      {item.evidence && item.evidence.length > 0 ? (
+        <XStack gap="$2" flexWrap="wrap">
+          {item.evidence.map((evidence) => (
+            <AppBadge key={evidence}>{evidence}</AppBadge>
+          ))}
+        </XStack>
+      ) : null}
+    </YStack>
+  );
+}

--- a/features/insights/components/insight-dimension-group.tsx
+++ b/features/insights/components/insight-dimension-group.tsx
@@ -1,0 +1,32 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, YStack } from "tamagui";
+
+import { InsightCard } from "@/features/insights/components/insight-card";
+import type { InsightDimensionGroup as InsightDimensionGroupModel } from "@/features/insights/hooks/use-insights-by-dimension";
+
+export interface InsightDimensionGroupProps {
+  readonly group: InsightDimensionGroupModel;
+}
+
+export function InsightDimensionGroup({
+  group,
+}: InsightDimensionGroupProps): ReactElement {
+  return (
+    <YStack gap="$3" testID={`insight-group-${group.dimension}`}>
+      <YStack gap="$1">
+        <Paragraph color="$color" fontFamily="$heading" fontSize="$6">
+          {group.label}
+        </Paragraph>
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+          {group.items.length} insight{group.items.length === 1 ? "" : "s"}
+        </Paragraph>
+      </YStack>
+      <YStack gap="$2">
+        {group.items.map((item) => (
+          <InsightCard key={`${group.dimension}-${item.type}-${item.title}`} item={item} />
+        ))}
+      </YStack>
+    </YStack>
+  );
+}

--- a/features/insights/components/insight-hub.test.tsx
+++ b/features/insights/components/insight-hub.test.tsx
@@ -1,0 +1,114 @@
+import { render } from "@testing-library/react-native";
+
+import { InsightHub } from "@/features/insights/components/insight-hub";
+import type { UserInsight } from "@/features/insights/contracts";
+import type { AiInsightsController } from "@/features/insights/hooks/use-ai-insights-controller";
+import { groupInsightItemsByDimension } from "@/features/insights/hooks/use-insights-by-dimension";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+const mockUseFeatureAccess = jest.fn();
+const mockUseAiInsightConsent = jest.fn();
+
+jest.mock("@/features/entitlements/hooks/use-feature-access", () => ({
+  useFeatureAccess: (...args: readonly unknown[]) => mockUseFeatureAccess(...args),
+}));
+
+jest.mock("@/features/insights/hooks/use-ai-insight-consent", () => ({
+  useAiInsightConsent: (...args: readonly unknown[]) => mockUseAiInsightConsent(...args),
+}));
+
+const insightFixture: UserInsight = {
+  id: "ins-1",
+  content: "Resumo global",
+  keyMetric: "Resumo global do periodo",
+  items: [
+    {
+      type: "saude_financeira",
+      dimension: "general",
+      title: "Resumo global",
+      message: "O caixa segue positivo.",
+    },
+    {
+      type: "padrao_gasto",
+      dimension: "transactions",
+      title: "Padrao em transacoes",
+      message: "Despesas pequenas se repetiram.",
+    },
+    {
+      type: "alerta_meta",
+      dimension: "goals",
+      title: "Meta em atencao",
+      message: "A reserva ficou abaixo do ritmo planejado.",
+    },
+  ],
+  summary: { headline: "Periodo equilibrado" },
+  periodType: "daily",
+  periodLabel: "2026-05-19",
+  periodStart: "2026-05-19",
+  periodEnd: "2026-05-19",
+  status: "delivered",
+  generatedAt: "2026-05-19",
+  readAt: null,
+  metadata: {
+    model: "gpt-4o-mini",
+    tokensUsed: 420,
+    costUsd: 0.000063,
+    cached: false,
+    contextVersion: "financial_insight_snapshot.v1",
+  },
+};
+
+const historyQuery = {
+  data: {
+    items: [insightFixture],
+    page: 1,
+    perPage: 20,
+    total: 1,
+  },
+  error: null,
+  isPending: false,
+  isError: false,
+  isFetching: false,
+  refetch: jest.fn(),
+} as unknown as AiInsightsController["historyQuery"];
+
+const controller: AiInsightsController = {
+  currentInsight: insightFixture,
+  visibleItems: insightFixture.items,
+  dimensionGroups: groupInsightItemsByDimension(insightFixture.items),
+  history: [insightFixture],
+  historyQuery,
+  isGenerating: false,
+  generateError: null,
+  generateErrorTitle: null,
+  callsRemaining: 1,
+  hasGeneratedInsight: true,
+  shouldShowContextualEmptyState: false,
+  generate: jest.fn(),
+  dismissGenerateError: jest.fn(),
+};
+
+describe("InsightHub", () => {
+  beforeEach(() => {
+    mockUseFeatureAccess.mockReturnValue({ hasAccess: true, isLoading: false });
+    mockUseAiInsightConsent.mockReturnValue({
+      hasConsent: true,
+      isHydrated: true,
+      grantConsent: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("agrupa o insight atual por dimensao", () => {
+    const tree = render(
+      <TestProviders>
+        <InsightHub controller={controller} />
+      </TestProviders>,
+    ).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/features/insights/components/insight-hub.tsx
+++ b/features/insights/components/insight-hub.tsx
@@ -1,0 +1,130 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, YStack } from "tamagui";
+
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import { InsightDimensionGroup } from "@/features/insights/components/insight-dimension-group";
+import type {
+  AiInsightsController,
+} from "@/features/insights/hooks/use-ai-insights-controller";
+import { groupInsightItemsByDimension } from "@/features/insights/hooks/use-insights-by-dimension";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
+import { AppQueryState } from "@/shared/components/app-query-state";
+import { AppSectionHeader } from "@/shared/components/app-section-header";
+
+export interface InsightHubProps {
+  readonly controller: AiInsightsController;
+}
+
+export function InsightHub({ controller }: InsightHubProps): ReactElement {
+  return (
+    <YStack gap="$4">
+      <AiInsightSurface controller={controller} />
+      <CurrentInsightSection controller={controller} />
+      <HistorySection controller={controller} />
+    </YStack>
+  );
+}
+
+function CurrentInsightSection({
+  controller,
+}: InsightHubProps): ReactElement | null {
+  if (!controller.currentInsight || controller.dimensionGroups.length === 0) {
+    return null;
+  }
+
+  return (
+    <YStack gap="$3">
+      <AppSectionHeader
+        title="Insight atual"
+        description={controller.currentInsight.periodLabel}
+      />
+      {controller.dimensionGroups.map((group) => (
+        <InsightDimensionGroup key={group.dimension} group={group} />
+      ))}
+    </YStack>
+  );
+}
+
+function HistorySection({ controller }: InsightHubProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      <AppSectionHeader
+        title="Historico"
+        description="Registros salvos pela geracao de IA."
+      />
+      <AppQueryState
+        query={controller.historyQuery}
+        options={{
+          loading: {
+            title: "Carregando insights",
+            description: "Buscando o historico salvo.",
+          },
+          empty: {
+            title: "Nenhum insight gerado",
+            description: "Gere a primeira leitura para criar seu historico.",
+          },
+          error: {
+            fallbackTitle: "Nao foi possivel carregar insights",
+            fallbackDescription: "Tente novamente em instantes.",
+          },
+          isEmpty: () => controller.history.length === 0,
+        }}
+        emptyComponent={
+          <AppEmptyState
+            illustration="insights"
+            title="Sem insights salvos"
+            description="Gere uma leitura para acompanhar seu historico por periodo."
+          />
+        }
+      >
+        {() => (
+          <YStack gap="$3">
+            {controller.history.map((insight) => (
+              <HistoryInsightCard
+                key={insight.id}
+                insight={insight}
+              />
+            ))}
+          </YStack>
+        )}
+      </AppQueryState>
+    </YStack>
+  );
+}
+
+function HistoryInsightCard({
+  insight,
+}: {
+  readonly insight: AiInsightsController["history"][number];
+}): ReactElement {
+  const groups = groupInsightItemsByDimension(insight.items);
+
+  return (
+    <YStack
+      gap="$3"
+      paddingVertical="$3"
+      borderBottomColor="$borderColor"
+      borderBottomWidth={1}
+    >
+      <YStack gap="$3">
+        <YStack gap="$1">
+          <Paragraph color="$color" fontFamily="$heading" fontSize="$5">
+            {insight.keyMetric}
+          </Paragraph>
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+            {`${insight.periodLabel} · ${insight.periodType}`}
+          </Paragraph>
+        </YStack>
+        {insight.summary?.headline ? (
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+            {String(insight.summary.headline)}
+          </Paragraph>
+        ) : null}
+        {groups.map((group) => (
+          <InsightDimensionGroup key={`${insight.id}-${group.dimension}`} group={group} />
+        ))}
+      </YStack>
+    </YStack>
+  );
+}

--- a/features/insights/contracts.ts
+++ b/features/insights/contracts.ts
@@ -1,8 +1,16 @@
 export type InsightStatus = "pending" | "delivered" | "read";
 export type InsightPeriodType = "daily" | "weekly" | "monthly" | "recap";
+export type InsightGenerationPeriodType = "daily" | "weekly" | "monthly";
+export type InsightDimension =
+  | "general"
+  | "transactions"
+  | "credit_cards"
+  | "goals"
+  | "budgets";
 
 export interface InsightItem {
   readonly type: string;
+  readonly dimension?: InsightDimension;
   readonly title: string;
   readonly message: string;
   readonly evidence?: readonly string[];
@@ -36,4 +44,26 @@ export interface UserInsight {
 
 export interface LatestInsightResponse {
   readonly insight: UserInsight | null;
+}
+
+export interface GenerateInsightCommand {
+  readonly periodType: InsightGenerationPeriodType;
+  readonly anchorDate?: string;
+}
+
+export interface GeneratedInsightResponse {
+  readonly insight: UserInsight;
+  readonly callsRemaining: number | null;
+}
+
+export interface InsightHistoryQuery {
+  readonly page?: number;
+  readonly perPage?: number;
+}
+
+export interface InsightHistoryResponse {
+  readonly items: readonly UserInsight[];
+  readonly page: number;
+  readonly perPage: number;
+  readonly total: number;
 }

--- a/features/insights/hooks/use-ai-insights-controller.ts
+++ b/features/insights/hooks/use-ai-insights-controller.ts
@@ -1,0 +1,123 @@
+import { useCallback, useMemo } from "react";
+
+import { useQuery } from "@tanstack/react-query";
+
+import { ApiError } from "@/core/http/api-error";
+import { queryKeys } from "@/core/query/query-keys";
+import type {
+  GenerateInsightCommand,
+  InsightDimension,
+  InsightHistoryResponse,
+  InsightItem,
+  UserInsight,
+} from "@/features/insights/contracts";
+import { useGenerateInsightMutation } from "@/features/insights/hooks/use-generate-insight-mutation";
+import { useInsightsHistoryQuery } from "@/features/insights/hooks/use-insights-history-query";
+import {
+  filterInsightItemsByDimension,
+  groupInsightItemsByDimension,
+  type InsightDimensionGroup,
+} from "@/features/insights/hooks/use-insights-by-dimension";
+
+export interface AiInsightsControllerOptions {
+  readonly dimension?: InsightDimension;
+  readonly page?: number;
+  readonly perPage?: number;
+}
+
+export interface AiInsightsController {
+  readonly currentInsight: UserInsight | null;
+  readonly visibleItems: readonly InsightItem[];
+  readonly dimensionGroups: readonly InsightDimensionGroup[];
+  readonly history: readonly UserInsight[];
+  readonly historyQuery: ReturnType<typeof useInsightsHistoryQuery>;
+  readonly isGenerating: boolean;
+  readonly generateError: ApiError | null;
+  readonly generateErrorTitle: string | null;
+  readonly callsRemaining: number | null;
+  readonly hasGeneratedInsight: boolean;
+  readonly shouldShowContextualEmptyState: boolean;
+  readonly generate: (command?: GenerateInsightCommand) => Promise<void>;
+  readonly dismissGenerateError: () => void;
+}
+
+const DEFAULT_HISTORY: InsightHistoryResponse = {
+  items: [],
+  page: 1,
+  perPage: 20,
+  total: 0,
+};
+
+const isQuotaError = (error: ApiError | null): boolean => {
+  return error?.status === 429;
+};
+
+const useCurrentInsightQuery = () => {
+  return useQuery<UserInsight | null>({
+    queryKey: queryKeys.insights.current(),
+    queryFn: async () => null,
+    enabled: false,
+    initialData: null,
+  });
+};
+
+const resolveVisibleItems = (
+  items: readonly InsightItem[],
+  dimension: InsightDimension | undefined,
+): readonly InsightItem[] => {
+  return dimension ? filterInsightItemsByDimension(items, dimension) : items;
+};
+
+export const useAiInsightsController = (
+  options: AiInsightsControllerOptions = {},
+): AiInsightsController => {
+  const historyQuery = useInsightsHistoryQuery({
+    page: options.page ?? 1,
+    perPage: options.perPage ?? 20,
+  });
+  const currentQuery = useCurrentInsightQuery();
+  const generateMutation = useGenerateInsightMutation();
+  const historyData = historyQuery.data ?? DEFAULT_HISTORY;
+  const currentInsight = currentQuery.data ?? historyData.items[0] ?? null;
+  const allItems = currentInsight?.items ?? [];
+  const visibleItems = useMemo(
+    () => resolveVisibleItems(allItems, options.dimension),
+    [allItems, options.dimension],
+  );
+  const dimensionGroups = useMemo(
+    () => groupInsightItemsByDimension(allItems),
+    [allItems],
+  );
+  const generateError = generateMutation.error ?? null;
+
+  const generate = useCallback(
+    async (command?: GenerateInsightCommand): Promise<void> => {
+      try {
+        await generateMutation.mutateAsync(command);
+      } catch {
+        // The mutation error is exposed via generateError for inline feedback.
+      }
+    },
+    [generateMutation],
+  );
+
+  return {
+    currentInsight,
+    visibleItems,
+    dimensionGroups,
+    history: historyData.items,
+    historyQuery,
+    isGenerating: generateMutation.isPending,
+    generateError,
+    generateErrorTitle: isQuotaError(generateError)
+      ? "Voce atingiu o limite de 2 insights/dia"
+      : null,
+    callsRemaining: generateMutation.data?.callsRemaining ?? null,
+    hasGeneratedInsight: allItems.length > 0,
+    shouldShowContextualEmptyState: Boolean(
+      options.dimension && allItems.length > 0 && visibleItems.length === 0,
+    ),
+    generate,
+    dismissGenerateError: generateMutation.reset,
+  };
+};

--- a/features/insights/hooks/use-generate-insight-mutation.test.tsx
+++ b/features/insights/hooks/use-generate-insight-mutation.test.tsx
@@ -1,0 +1,76 @@
+import { act, renderHook, waitFor } from "@testing-library/react-native";
+
+import type {
+  GeneratedInsightResponse,
+  UserInsight,
+} from "@/features/insights/contracts";
+import { useGenerateInsightMutation } from "@/features/insights/hooks/use-generate-insight-mutation";
+import { insightService } from "@/features/insights/services/insight-service";
+import { createTestQueryClient } from "@/shared/testing/test-query-client";
+import { createTestHookWrapper } from "@/shared/testing/test-providers";
+
+jest.mock("@/features/insights/services/insight-service", () => ({
+  insightService: {
+    generate: jest.fn(),
+  },
+}));
+
+const mockedInsightService = jest.mocked(insightService);
+
+const insightFixture: UserInsight = {
+  id: "ins-1",
+  content: "Resumo global",
+  keyMetric: "Resumo global",
+  items: [
+    {
+      type: "saude_financeira",
+      dimension: "general",
+      title: "Resumo global",
+      message: "O caixa segue positivo.",
+    },
+  ],
+  summary: null,
+  periodType: "daily",
+  periodLabel: "2026-05-19",
+  periodStart: "2026-05-19",
+  periodEnd: "2026-05-19",
+  status: "delivered",
+  generatedAt: "2026-05-19",
+  readAt: null,
+  metadata: {
+    model: "gpt-4o-mini",
+    tokensUsed: 420,
+    costUsd: 0.000063,
+    cached: false,
+    contextVersion: "financial_insight_snapshot.v1",
+  },
+};
+
+const generatedFixture: GeneratedInsightResponse = {
+  insight: insightFixture,
+  callsRemaining: 1,
+};
+
+describe("useGenerateInsightMutation", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("gera insight e publica a mesma record no cache compartilhado", async () => {
+    mockedInsightService.generate.mockResolvedValue(generatedFixture);
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestHookWrapper({ queryClient });
+
+    const { result } = renderHook(() => useGenerateInsightMutation(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({ periodType: "daily" });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(mockedInsightService.generate).toHaveBeenCalledWith({ periodType: "daily" });
+    expect(queryClient.getQueryData(["insights", "current"])).toEqual(insightFixture);
+  });
+});

--- a/features/insights/hooks/use-generate-insight-mutation.ts
+++ b/features/insights/hooks/use-generate-insight-mutation.ts
@@ -1,0 +1,58 @@
+import { useQueryClient } from "@tanstack/react-query";
+
+import { createApiMutation } from "@/core/query/create-api-mutation";
+import { queryKeys } from "@/core/query/query-keys";
+import type {
+  GeneratedInsightResponse,
+  GenerateInsightCommand,
+  InsightHistoryResponse,
+} from "@/features/insights/contracts";
+import { insightService } from "@/features/insights/services/insight-service";
+
+const DEFAULT_COMMAND: GenerateInsightCommand = {
+  periodType: "daily",
+};
+
+const prependGeneratedInsight = (
+  previous: InsightHistoryResponse | undefined,
+  generated: GeneratedInsightResponse,
+): InsightHistoryResponse | undefined => {
+  if (!previous) {
+    return previous;
+  }
+
+  const withoutDuplicate = previous.items.filter(
+    (item) => item.id !== generated.insight.id,
+  );
+
+  return {
+    ...previous,
+    items: [generated.insight, ...withoutDuplicate],
+    total: Math.max(previous.total, withoutDuplicate.length + 1),
+  };
+};
+
+export const useGenerateInsightMutation = () => {
+  const queryClient = useQueryClient();
+
+  return createApiMutation<
+    GeneratedInsightResponse,
+    GenerateInsightCommand | undefined
+  >(
+    (command) => insightService.generate(command ?? DEFAULT_COMMAND),
+    {
+      onSuccess: async (generated) => {
+        queryClient.setQueryData(queryKeys.insights.current(), generated.insight);
+        queryClient.setQueryData<InsightHistoryResponse>(
+          queryKeys.insights.history(1, 20),
+          (previous) => prependGeneratedInsight(previous, generated),
+        );
+        await Promise.all([
+          queryClient.invalidateQueries({ queryKey: queryKeys.insights.historyRoot() }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.overview() }),
+          queryClient.invalidateQueries({ queryKey: queryKeys.insights.latest() }),
+        ]);
+      },
+    },
+  );
+};

--- a/features/insights/hooks/use-insights-by-dimension.test.ts
+++ b/features/insights/hooks/use-insights-by-dimension.test.ts
@@ -1,0 +1,58 @@
+import {
+  filterInsightItemsByDimension,
+  groupInsightItemsByDimension,
+} from "@/features/insights/hooks/use-insights-by-dimension";
+import type { InsightItem } from "@/features/insights/contracts";
+
+const items: readonly InsightItem[] = [
+  {
+    type: "saude_financeira",
+    dimension: "general",
+    title: "Resumo global",
+    message: "O caixa segue positivo.",
+  },
+  {
+    type: "padrao_gasto",
+    dimension: "transactions",
+    title: "Padrao em transacoes",
+    message: "Despesas pequenas se repetiram.",
+  },
+  {
+    type: "alerta_orcamento",
+    dimension: "budgets",
+    title: "Orcamento em alerta",
+    message: "Mercado chegou a 91%.",
+  },
+  {
+    type: "legacy",
+    title: "Legado sem dimensao",
+    message: "Deve entrar na visao geral.",
+  },
+];
+
+describe("insight dimension helpers", () => {
+  it("filtra contexto com itens general e da propria dimensao", () => {
+    expect(filterInsightItemsByDimension(items, "transactions")).toEqual([
+      expect.objectContaining({ title: "Resumo global", dimension: "general" }),
+      expect.objectContaining({
+        title: "Padrao em transacoes",
+        dimension: "transactions",
+      }),
+      expect.objectContaining({
+        title: "Legado sem dimensao",
+        dimension: "general",
+      }),
+    ]);
+  });
+
+  it("agrupa na ordem canonica omitindo dimensoes vazias", () => {
+    const groups = groupInsightItemsByDimension(items);
+
+    expect(groups.map((group) => group.dimension)).toEqual([
+      "general",
+      "transactions",
+      "budgets",
+    ]);
+    expect(groups[0]?.items).toHaveLength(2);
+  });
+});

--- a/features/insights/hooks/use-insights-by-dimension.ts
+++ b/features/insights/hooks/use-insights-by-dimension.ts
@@ -1,0 +1,76 @@
+import { useMemo } from "react";
+
+import type {
+  InsightDimension,
+  InsightItem,
+} from "@/features/insights/contracts";
+
+export interface InsightDimensionGroup {
+  readonly dimension: InsightDimension;
+  readonly label: string;
+  readonly items: readonly InsightItem[];
+}
+
+export const INSIGHT_DIMENSION_ORDER: readonly InsightDimension[] = [
+  "general",
+  "transactions",
+  "credit_cards",
+  "goals",
+  "budgets",
+];
+
+const INSIGHT_DIMENSION_LABELS: Record<InsightDimension, string> = {
+  general: "Visao geral",
+  transactions: "Transacoes",
+  credit_cards: "Cartoes",
+  goals: "Metas",
+  budgets: "Orcamentos",
+};
+
+export const getInsightDimensionLabel = (dimension: InsightDimension): string => {
+  return INSIGHT_DIMENSION_LABELS[dimension];
+};
+
+export const normalizeInsightDimension = (
+  dimension: InsightItem["dimension"],
+): InsightDimension => {
+  return INSIGHT_DIMENSION_ORDER.includes(dimension as InsightDimension)
+    ? (dimension as InsightDimension)
+    : "general";
+};
+
+export const normalizeInsightItemDimension = (item: InsightItem): InsightItem => ({
+  ...item,
+  dimension: normalizeInsightDimension(item.dimension),
+});
+
+export const filterInsightItemsByDimension = (
+  items: readonly InsightItem[],
+  dimension: InsightDimension,
+): readonly InsightItem[] => {
+  return items
+    .map(normalizeInsightItemDimension)
+    .filter((item) => item.dimension === "general" || item.dimension === dimension);
+};
+
+export const groupInsightItemsByDimension = (
+  items: readonly InsightItem[],
+): readonly InsightDimensionGroup[] => {
+  const normalized = items.map(normalizeInsightItemDimension);
+
+  return INSIGHT_DIMENSION_ORDER.map((dimension) => ({
+    dimension,
+    label: getInsightDimensionLabel(dimension),
+    items: normalized.filter((item) => item.dimension === dimension),
+  })).filter((group) => group.items.length > 0);
+};
+
+export const useInsightsByDimension = (
+  items: readonly InsightItem[],
+  dimension: InsightDimension,
+): readonly InsightItem[] => {
+  return useMemo(
+    () => filterInsightItemsByDimension(items, dimension),
+    [dimension, items],
+  );
+};

--- a/features/insights/hooks/use-insights-history-query.test.tsx
+++ b/features/insights/hooks/use-insights-history-query.test.tsx
@@ -1,0 +1,48 @@
+import { renderHook, waitFor } from "@testing-library/react-native";
+
+import type { InsightHistoryResponse } from "@/features/insights/contracts";
+import { useInsightsHistoryQuery } from "@/features/insights/hooks/use-insights-history-query";
+import { insightService } from "@/features/insights/services/insight-service";
+import { createTestQueryClient } from "@/shared/testing/test-query-client";
+import { createTestHookWrapper } from "@/shared/testing/test-providers";
+
+jest.mock("@/features/insights/services/insight-service", () => ({
+  insightService: {
+    history: jest.fn(),
+  },
+}));
+
+const mockedInsightService = jest.mocked(insightService);
+
+const historyFixture: InsightHistoryResponse = {
+  items: [],
+  page: 2,
+  perPage: 10,
+  total: 0,
+};
+
+describe("useInsightsHistoryQuery", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("carrega historico com paginacao canonica", async () => {
+    mockedInsightService.history.mockResolvedValue(historyFixture);
+    const queryClient = createTestQueryClient();
+    const wrapper = createTestHookWrapper({ queryClient });
+
+    const { result } = renderHook(
+      () => useInsightsHistoryQuery({ page: 2, perPage: 10 }),
+      { wrapper },
+    );
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual(historyFixture);
+    });
+
+    expect(mockedInsightService.history).toHaveBeenCalledWith({
+      page: 2,
+      perPage: 10,
+    });
+  });
+});

--- a/features/insights/hooks/use-insights-history-query.ts
+++ b/features/insights/hooks/use-insights-history-query.ts
@@ -1,0 +1,19 @@
+import { createApiQuery } from "@/core/query/create-api-query";
+import { queryKeys } from "@/core/query/query-keys";
+import type {
+  InsightHistoryQuery,
+  InsightHistoryResponse,
+} from "@/features/insights/contracts";
+import { insightService } from "@/features/insights/services/insight-service";
+
+export const useInsightsHistoryQuery = (
+  query: InsightHistoryQuery = {},
+) => {
+  const page = query.page ?? 1;
+  const perPage = query.perPage ?? 20;
+
+  return createApiQuery<InsightHistoryResponse>(
+    queryKeys.insights.history(page, perPage),
+    () => insightService.history({ page, perPage }),
+  );
+};

--- a/features/insights/insights-config.ts
+++ b/features/insights/insights-config.ts
@@ -1,0 +1,1 @@
+export const AI_INSIGHTS_CONTEXTUAL_FEATURE_FLAG_KEY = "app.insights.contextual";

--- a/features/insights/screens/ai-insights-screen.tsx
+++ b/features/insights/screens/ai-insights-screen.tsx
@@ -1,0 +1,15 @@
+import type { ReactElement } from "react";
+
+import { InsightHub } from "@/features/insights/components/insight-hub";
+import { useAiInsightsController } from "@/features/insights/hooks/use-ai-insights-controller";
+import { AppScreen } from "@/shared/components/app-screen";
+
+export function AiInsightsScreen(): ReactElement {
+  const controller = useAiInsightsController();
+
+  return (
+    <AppScreen>
+      <InsightHub controller={controller} />
+    </AppScreen>
+  );
+}

--- a/features/insights/services/insight-service.test.ts
+++ b/features/insights/services/insight-service.test.ts
@@ -39,6 +39,7 @@ describe("insightService", () => {
       items: [
         {
           type: "weekly_summary",
+          dimension: "general",
           title: "Voce economizou R$ 320 nesta semana",
           message: "Voce reduziu gastos variaveis sem cortar lazer.",
         },
@@ -73,6 +74,7 @@ describe("insightService", () => {
             items: [
               {
                 type: "weekly_cashflow",
+                dimension: "transactions",
                 title: "Fluxo de caixa",
                 message: "As entradas superaram as saidas em R$ 420.",
                 evidence: ["current_period.net_balance"],
@@ -108,6 +110,7 @@ describe("insightService", () => {
       items: [
         {
           type: "weekly_cashflow",
+          dimension: "transactions",
           title: "Fluxo de caixa",
           message: "As entradas superaram as saidas em R$ 420.",
           evidence: ["current_period.net_balance"],
@@ -152,5 +155,118 @@ describe("insightService", () => {
     await service.markAsRead("ins-1");
 
     expect(client.post).toHaveBeenCalledWith("/v1/insights/ins-1/read");
+  });
+
+  it("gera insight period-aware com dimensoes e cabecalho de quota", async () => {
+    const client = createClient();
+    client.post.mockResolvedValue({
+      headers: { "x-ai-calls-remaining": "1" },
+      data: {
+        data: {
+          summary: "Resumo do periodo.",
+          context_hash: "hash-1",
+          context_version: "financial_insight_snapshot.v1",
+          period_type: "daily",
+          period_label: "2026-05-19",
+          period_start: "2026-05-19",
+          period_end: "2026-05-19",
+          model: "gpt-4o-mini",
+          tokens_used: 420,
+          cost_usd: 0.000063,
+          cached: false,
+          items: [
+            {
+              type: "saude_financeira",
+              dimension: "general",
+              title: "Saldo positivo",
+              message: "Voce terminou o periodo com saldo positivo.",
+              evidence: ["current_period.paid.balance"],
+            },
+          ],
+        },
+      },
+    });
+
+    const service = createInsightService(client as unknown as AxiosInstance);
+    const result = await service.generate({
+      periodType: "daily",
+      anchorDate: "2026-05-19",
+    });
+
+    expect(client.post).toHaveBeenCalledWith("/ai/insights/generate", {
+      period_type: "daily",
+      anchor_date: "2026-05-19",
+    });
+    expect(result.callsRemaining).toBe(1);
+    expect(result.insight).toMatchObject({
+      id: "hash-1",
+      keyMetric: "Resumo do periodo.",
+      periodType: "daily",
+      periodLabel: "2026-05-19",
+      metadata: {
+        model: "gpt-4o-mini",
+        tokensUsed: 420,
+        costUsd: 0.000063,
+        cached: false,
+        contextVersion: "financial_insight_snapshot.v1",
+      },
+      items: [
+        {
+          type: "saude_financeira",
+          dimension: "general",
+          title: "Saldo positivo",
+          message: "Voce terminou o periodo com saldo positivo.",
+          evidence: ["current_period.paid.balance"],
+        },
+      ],
+    });
+  });
+
+  it("carrega historico com fallback general para item legado sem dimension", async () => {
+    const client = createClient();
+    client.get.mockResolvedValue({
+      data: {
+        data: {
+          items: [
+            {
+              id: "hist-1",
+              content: JSON.stringify({
+                summary: "Resumo legado",
+                items: [
+                  {
+                    type: "padrao_gasto",
+                    title: "Padrao recorrente",
+                    message: "Compras pequenas se repetiram no periodo.",
+                  },
+                ],
+              }),
+              insight_type: "daily",
+              period_label: "2026-05-19",
+              period_start: "2026-05-19",
+              period_end: "2026-05-19",
+              created_at: "2026-05-19T10:00:00.000Z",
+            },
+          ],
+          page: 1,
+          per_page: 20,
+          total: 1,
+        },
+      },
+    });
+
+    const service = createInsightService(client as unknown as AxiosInstance);
+    const result = await service.history({ page: 1, perPage: 20 });
+
+    expect(client.get).toHaveBeenCalledWith("/ai/insights/history", {
+      params: { page: 1, per_page: 20 },
+    });
+    expect(result.items[0]?.items).toEqual([
+      {
+        type: "padrao_gasto",
+        dimension: "general",
+        title: "Padrao recorrente",
+        message: "Compras pequenas se repetiram no periodo.",
+      },
+    ]);
   });
 });

--- a/features/insights/services/insight-service.ts
+++ b/features/insights/services/insight-service.ts
@@ -4,7 +4,13 @@ import { ApiError } from "@/core/http/api-error";
 import { unwrapEnvelopeData } from "@/core/http/contracts";
 import { httpClient } from "@/core/http/http-client";
 import type {
+  GeneratedInsightResponse,
+  GenerateInsightCommand,
+  InsightDimension,
+  InsightHistoryQuery,
+  InsightHistoryResponse,
   InsightItem,
+  InsightGenerationPeriodType,
   InsightPeriodType,
   InsightStatus,
   InsightSummary,
@@ -19,19 +25,45 @@ interface UserInsightPayload {
   readonly key_metric?: string | null;
   readonly items?: unknown;
   readonly summary?: unknown;
+  readonly insight_type?: string | null;
   readonly period_type?: string | null;
   readonly period_label?: string | null;
-  readonly period_start: string;
-  readonly period_end: string;
-  readonly status: string;
+  readonly period_start?: string | null;
+  readonly period_end?: string | null;
+  readonly status?: string | null;
   readonly generated_at?: string | null;
   readonly created_at?: string | null;
-  readonly read_at: string | null;
+  readonly read_at?: string | null;
   readonly model?: string | null;
   readonly tokens_used?: number | null;
   readonly cost_usd?: number | null;
   readonly cached?: boolean | null;
   readonly context_version?: string | null;
+  readonly context_schema_version?: string | null;
+}
+
+interface GeneratedInsightPayload {
+  readonly summary?: string | null;
+  readonly items?: unknown;
+  readonly period_type?: string | null;
+  readonly period_label?: string | null;
+  readonly period_start?: string | null;
+  readonly period_end?: string | null;
+  readonly context_version?: string | null;
+  readonly context_hash?: string | null;
+  readonly model?: string | null;
+  readonly tokens_used?: number | null;
+  readonly cost_usd?: number | null;
+  readonly cached?: boolean | null;
+  readonly generated_at?: string | null;
+  readonly created_at?: string | null;
+}
+
+interface InsightHistoryPayload {
+  readonly items?: unknown;
+  readonly page?: number | null;
+  readonly per_page?: number | null;
+  readonly total?: number | null;
 }
 
 const DEFAULT_INSIGHT_TYPE = "weekly_summary";
@@ -40,6 +72,18 @@ const DEFAULT_KEY_METRIC = "Insight financeiro atualizado";
 const DEFAULT_CONTENT = "Seu insight financeiro esta disponivel para leitura.";
 const INSIGHT_STATUSES = new Set<InsightStatus>(["pending", "delivered", "read"]);
 const PERIOD_TYPES = new Set<InsightPeriodType>(["daily", "weekly", "monthly", "recap"]);
+const GENERATION_PERIOD_TYPES = new Set<InsightGenerationPeriodType>([
+  "daily",
+  "weekly",
+  "monthly",
+]);
+const INSIGHT_DIMENSIONS = new Set<InsightDimension>([
+  "general",
+  "transactions",
+  "credit_cards",
+  "goals",
+  "budgets",
+]);
 
 const pickString = (value: unknown, fallback = ""): string => {
   return typeof value === "string" && value.trim().length > 0 ? value : fallback;
@@ -57,11 +101,23 @@ const pickBoolean = (value: unknown): boolean | null => {
   return typeof value === "boolean" ? value : null;
 };
 
+const pickPositiveNumber = (value: unknown, fallback: number): number => {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+};
+
+const pickNonNegativeNumber = (value: unknown, fallback: number): number => {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : fallback;
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> => {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 };
 
-const mapStatus = (status: string): InsightStatus => {
+const mapStatus = (status: string | null | undefined): InsightStatus => {
   return INSIGHT_STATUSES.has(status as InsightStatus) ? (status as InsightStatus) : "delivered";
 };
 
@@ -71,8 +127,22 @@ const mapPeriodType = (periodType: string | null | undefined): InsightPeriodType
     : DEFAULT_PERIOD_TYPE;
 };
 
+const mapGenerationPeriodType = (
+  periodType: string | null | undefined,
+): InsightGenerationPeriodType => {
+  return GENERATION_PERIOD_TYPES.has(periodType as InsightGenerationPeriodType)
+    ? (periodType as InsightGenerationPeriodType)
+    : "daily";
+};
+
 const mapSummary = (summary: unknown): InsightSummary | null => {
-  return isRecord(summary) ? summary : null;
+  if (isRecord(summary)) {
+    return summary;
+  }
+  if (typeof summary === "string" && summary.trim().length > 0) {
+    return { headline: summary };
+  }
+  return null;
 };
 
 const mapEvidence = (evidence: unknown): readonly string[] | undefined => {
@@ -84,6 +154,12 @@ const mapEvidence = (evidence: unknown): readonly string[] | undefined => {
     (entry): entry is string => typeof entry === "string" && entry.trim().length > 0,
   );
   return values.length > 0 ? values : undefined;
+};
+
+const mapDimension = (dimension: unknown): InsightDimension => {
+  return INSIGHT_DIMENSIONS.has(dimension as InsightDimension)
+    ? (dimension as InsightDimension)
+    : "general";
 };
 
 const mapInsightItem = (value: unknown): InsightItem | null => {
@@ -100,25 +176,53 @@ const mapInsightItem = (value: unknown): InsightItem | null => {
   }
 
   const evidence = mapEvidence(value.evidence);
-  return evidence ? { type, title, message, evidence } : { type, title, message };
+  const base = { type, dimension: mapDimension(value.dimension), title, message };
+  return evidence ? { ...base, evidence } : base;
+};
+
+const stripMarkdownJsonFence = (content: string): string => {
+  const trimmed = content.trim();
+  if (!trimmed.startsWith("```")) {
+    return trimmed;
+  }
+
+  const openingLineEnd = trimmed.indexOf("\n");
+  const closingFenceStart = trimmed.lastIndexOf("```");
+  if (openingLineEnd === -1 || closingFenceStart <= openingLineEnd) {
+    return trimmed;
+  }
+
+  const language = trimmed.slice(3, openingLineEnd).trim().toLowerCase();
+  if (language && language !== "json") {
+    return trimmed;
+  }
+
+  return trimmed.slice(openingLineEnd + 1, closingFenceStart).trim();
+};
+
+const mapInsightItemsArray = (items: unknown): readonly InsightItem[] => {
+  return Array.isArray(items)
+    ? items.map(mapInsightItem).filter((item): item is InsightItem => item !== null)
+    : [];
 };
 
 const parseContentItems = (content: string): readonly InsightItem[] => {
   try {
-    const parsed = JSON.parse(content) as unknown;
-    if (!Array.isArray(parsed)) {
-      return [];
+    const parsed = JSON.parse(stripMarkdownJsonFence(content)) as unknown;
+    if (Array.isArray(parsed)) {
+      return mapInsightItemsArray(parsed);
     }
-    return parsed.map(mapInsightItem).filter((item): item is InsightItem => item !== null);
+    if (isRecord(parsed)) {
+      return mapInsightItemsArray(parsed.items);
+    }
+    return [];
   } catch {
     return [];
   }
 };
 
 const mapInsightItems = (payload: UserInsightPayload, content: string): readonly InsightItem[] => {
-  const directItems = Array.isArray(payload.items)
-    ? payload.items.map(mapInsightItem).filter((item): item is InsightItem => item !== null)
-    : [];
+  const directItems = mapInsightItemsArray(payload.items);
   if (directItems.length > 0) {
     return directItems;
   }
@@ -131,6 +235,7 @@ const mapInsightItems = (payload: UserInsightPayload, content: string): readonly
   return [
     {
       type: DEFAULT_INSIGHT_TYPE,
+      dimension: "general",
       title: pickString(payload.key_metric, DEFAULT_KEY_METRIC),
       message: content || DEFAULT_CONTENT,
     },
@@ -153,6 +258,13 @@ const resolvePeriodLabel = (payload: UserInsightPayload): string => {
   return start && end ? `${start} a ${end}` : "Semana atual";
 };
 
+const resolveContextVersion = (payload: UserInsightPayload): string | null => {
+  return (
+    pickNullableString(payload.context_version) ??
+    pickNullableString(payload.context_schema_version)
+  );
+};
+
 const mapInsight = (payload: UserInsightPayload): UserInsight => {
   const content = pickString(payload.content);
   const summary = mapSummary(payload.summary);
@@ -170,13 +282,58 @@ const mapInsight = (payload: UserInsightPayload): UserInsight => {
     keyMetric,
     items,
     summary,
-    periodType: mapPeriodType(payload.period_type),
+    periodType: mapPeriodType(payload.period_type ?? payload.insight_type),
     periodLabel: resolvePeriodLabel(payload),
-    periodStart: payload.period_start,
-    periodEnd: payload.period_end,
+    periodStart: pickString(payload.period_start),
+    periodEnd: pickString(payload.period_end),
     status: mapStatus(payload.status),
     generatedAt: pickString(payload.generated_at, pickString(payload.created_at)),
-    readAt: payload.read_at,
+    readAt: pickNullableString(payload.read_at),
+    metadata: {
+      model: pickNullableString(payload.model),
+      tokensUsed: pickNumber(payload.tokens_used),
+      costUsd: pickNumber(payload.cost_usd),
+      cached: pickBoolean(payload.cached),
+      contextVersion: resolveContextVersion(payload),
+    },
+  };
+};
+
+const mapGeneratedPayload = (payload: GeneratedInsightPayload): UserInsight => {
+  const periodType = mapGenerationPeriodType(payload.period_type);
+  const periodLabel = pickString(payload.period_label, "Periodo atual");
+  const summary = mapSummary(payload.summary);
+  const items = mapInsightItemsArray(payload.items);
+  const content = pickString(payload.summary, items[0]?.message ?? DEFAULT_CONTENT);
+
+  return {
+    id: pickString(payload.context_hash, `${periodType}-${periodLabel}`),
+    content,
+    keyMetric:
+      getSummaryHeadline(summary) ||
+      items[0]?.title ||
+      DEFAULT_KEY_METRIC,
+    items: items.length > 0
+      ? items
+      : [
+          {
+            type: DEFAULT_INSIGHT_TYPE,
+            dimension: "general",
+            title: DEFAULT_KEY_METRIC,
+            message: content,
+          },
+        ],
+    summary,
+    periodType,
+    periodLabel,
+    periodStart: pickString(payload.period_start),
+    periodEnd: pickString(payload.period_end),
+    status: "delivered",
+    generatedAt: pickString(
+      payload.generated_at,
+      pickString(payload.created_at, pickString(payload.period_end)),
+    ),
+    readAt: null,
     metadata: {
       model: pickNullableString(payload.model),
       tokensUsed: pickNumber(payload.tokens_used),
@@ -187,12 +344,70 @@ const mapInsight = (payload: UserInsightPayload): UserInsight => {
   };
 };
 
+const mapHistoryPayload = (
+  payload: InsightHistoryPayload,
+  query: Required<InsightHistoryQuery>,
+): InsightHistoryResponse => {
+  const items = Array.isArray(payload.items)
+    ? payload.items
+        .filter(isRecord)
+        .map((item) => mapInsight(item as unknown as UserInsightPayload))
+    : [];
+
+  return {
+    items,
+    page: pickPositiveNumber(payload.page, query.page),
+    perPage: pickPositiveNumber(payload.per_page, query.perPage),
+    total: pickNonNegativeNumber(payload.total, items.length),
+  };
+};
+
+const parseCallsRemaining = (value: unknown): number | null => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+};
+
 const isNotFoundError = (error: unknown): boolean => {
   return error instanceof ApiError && error.status === 404;
 };
 
 export const createInsightService = (client: AxiosInstance) => {
   return {
+    generate: async (
+      command: GenerateInsightCommand,
+    ): Promise<GeneratedInsightResponse> => {
+      const response = await client.post(apiContractMap.aiInsightGenerate.path, {
+        period_type: command.periodType,
+        ...(command.anchorDate ? { anchor_date: command.anchorDate } : {}),
+      });
+      const payload = unwrapEnvelopeData<GeneratedInsightPayload>(response.data);
+      return {
+        insight: mapGeneratedPayload(payload),
+        callsRemaining: parseCallsRemaining(response.headers?.["x-ai-calls-remaining"]),
+      };
+    },
+    history: async (
+      query: InsightHistoryQuery = {},
+    ): Promise<InsightHistoryResponse> => {
+      const resolvedQuery = {
+        page: query.page ?? 1,
+        perPage: query.perPage ?? 20,
+      };
+      const response = await client.get(apiContractMap.aiInsightHistory.path, {
+        params: {
+          page: resolvedQuery.page,
+          per_page: resolvedQuery.perPage,
+        },
+      });
+      const payload = unwrapEnvelopeData<InsightHistoryPayload>(response.data);
+      return mapHistoryPayload(payload, resolvedQuery);
+    },
     getLatest: async (): Promise<UserInsight | null> => {
       try {
         const response = await client.get(apiContractMap.insightsLatest.path);

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -8,6 +8,7 @@ import { Paragraph, XStack, YStack } from "tamagui";
 import { appRoutes } from "@/core/navigation/routes";
 import { queryKeys } from "@/core/query/query-keys";
 import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
 import { FinancialCalendar } from "@/features/transactions/components/financial-calendar";
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
 import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
@@ -60,6 +61,7 @@ const TRANSACTIONS_REFRESH_KEYS = [
  */
 export function TransactionsScreen(): ReactElement {
   const controller = useTransactionsScreenController();
+  const router = useRouter();
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -83,6 +85,10 @@ export function TransactionsScreen(): ReactElement {
   return (
     <AppScreen scrollable={false}>
       <FilterHeader controller={controller} />
+      <AiInsightSurface
+        dimension="transactions"
+        onOpenHub={() => router.push(appRoutes.private.insights)}
+      />
       <YStack flex={1}>
         {controller.viewMode === "calendar" ? (
           <FinancialCalendar transactions={controller.transactions} />

--- a/shared/components/app-empty-state.tsx
+++ b/shared/components/app-empty-state.tsx
@@ -13,6 +13,7 @@ export type AppEmptyStateIllustration =
   | "wallet"
   | "alerts"
   | "budgets"
+  | "insights"
   | "fiscal"
   | "shared"
   | "simulations"
@@ -27,6 +28,7 @@ const ICON_BY_ILLUSTRATION: Record<
   wallet: "chart-line",
   alerts: "bell-outline",
   budgets: "piggy-bank-outline",
+  insights: "lightbulb-on-outline",
   fiscal: "file-document-outline",
   shared: "account-multiple-outline",
   simulations: "calculator-variant-outline",

--- a/shared/contracts/api-contract-map.ts
+++ b/shared/contracts/api-contract-map.ts
@@ -84,7 +84,13 @@ import type {
   ImportPreview,
   ImportPreviewCommand,
 } from "@/features/import/contracts";
-import type { LatestInsightResponse } from "@/features/insights/contracts";
+import type {
+  GeneratedInsightResponse,
+  GenerateInsightCommand,
+  InsightHistoryQuery,
+  InsightHistoryResponse,
+  LatestInsightResponse,
+} from "@/features/insights/contracts";
 import type {
   PushSubscriptionCommand,
   PushSubscriptionRecord,
@@ -393,6 +399,27 @@ export const apiContractMap = {
   >({
     method: "POST",
     path: "/v1/insights/{insight_id}/read",
+    authRequired: true,
+  }),
+  aiInsightGenerate: defineApiContract<
+    "POST",
+    "/ai/insights/generate",
+    GenerateInsightCommand,
+    GeneratedInsightResponse
+  >({
+    method: "POST",
+    path: "/ai/insights/generate",
+    authRequired: true,
+  }),
+  aiInsightHistory: defineApiContract<
+    "GET",
+    "/ai/insights/history",
+    never,
+    InsightHistoryResponse,
+    InsightHistoryQuery
+  >({
+    method: "GET",
+    path: "/ai/insights/history",
     authRequired: true,
   }),
   importDetect: defineApiContract<

--- a/shared/contracts/api-endpoint-catalog.ts
+++ b/shared/contracts/api-endpoint-catalog.ts
@@ -28,6 +28,8 @@ export const apiEndpointCatalog = {
   insights: [
     "GET /v1/insights/latest",
     "POST /v1/insights/{insight_id}/read",
+    "POST /ai/insights/generate",
+    "GET /ai/insights/history",
   ],
   imports: [
     "POST /v2/import/detect",


### PR DESCRIPTION
## Descrição

Implementa o hub mobile de AI Insights em `/insights`, adiciona suporte REST para geração/histórico period-aware e inclui superfícies contextuais em transações, cartões, metas e orçamentos. Os filtros contextuais mostram insights da dimensão da página junto com itens `general`, e payloads legados sem `dimension` caem para `general`.

Closes #420

## Tipo de mudança

- [x] Feature nova
- [ ] Bug fix
- [ ] Refactor
- [ ] Documentação / infraestrutura
- [ ] Outros: ___

## Checklist de qualidade

- [x] `npm run quality-check` passou localmente
- [x] Coverage **não** regrediu abaixo de 85%
- [x] Testes unitários criados/atualizados para o código novo
- [x] Screen controllers e services têm teste escrito (TDD)

## Checklist de dependências nativas

- [x] **Não adicionei dependência nativa** — OU —
- [ ] Adicionei dependência nativa via `npx expo install <dep>` (não npm install) E documentei a necessidade de novo build nativo no corpo do PR

## Checklist de feature flags

- [ ] **Não criei feature nova** — OU —
- [x] Feature nova está atrás de flag em `shared/feature-flags/` e `config/feature-flags.json`

## Checklist de contratos

- [ ] Nenhum endpoint novo consumido — OU —
- [x] `npm run contracts:check` passou com o novo endpoint

## Screenshots / evidência (se UI)

- `npm run quality-check`
- Focused feature tests: service mapping, dimension filtering, generation mutation, history query, `AiInsightSurface`, `InsightHub` snapshot and route registry.
- Screenshot nativo não capturado neste ambiente; a evidência visual automatizada é o snapshot RN do `InsightHub`.
