### PR TITLE
feat(app): add iOS Privacy Manifest (iOS 17+) for App Store submission

### DIFF
--- a/app.json
+++ b/app.json
@@ -32,6 +32,114 @@
             }
           }
         }
+      },
+      "privacyManifests": {
+        "NSPrivacyTracking": false,
+        "NSPrivacyTrackingDomains": [],
+        "NSPrivacyCollectedDataTypes": [
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeEmailAddress",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality",
+              "NSPrivacyCollectedDataTypePurposeAccountManagement"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeName",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAccountManagement"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeUserID",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality",
+              "NSPrivacyCollectedDataTypePurposeAccountManagement"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeOtherFinancialInfo",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeOtherUserContent",
+            "NSPrivacyCollectedDataTypeLinked": true,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeCrashData",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypePerformanceData",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeOtherDiagnosticData",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeDeviceID",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality",
+              "NSPrivacyCollectedDataTypePurposeAnalytics"
+            ]
+          },
+          {
+            "NSPrivacyCollectedDataType": "NSPrivacyCollectedDataTypeProductInteraction",
+            "NSPrivacyCollectedDataTypeLinked": false,
+            "NSPrivacyCollectedDataTypeTracking": false,
+            "NSPrivacyCollectedDataTypePurposes": [
+              "NSPrivacyCollectedDataTypePurposeAnalytics",
+              "NSPrivacyCollectedDataTypePurposeAppFunctionality"
+            ]
+          }
+        ],
+        "NSPrivacyAccessedAPITypes": [
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
+            "NSPrivacyAccessedAPITypeReasons": ["C617.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
+            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
+          },
+          {
+            "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
+            "NSPrivacyAccessedAPITypeReasons": ["E174.1"]
+          }
+        ]
       }
     },
     "android": {


### PR DESCRIPTION
## Summary

Adiciona \`expo.ios.privacyManifests\` ao \`app.json\` cobrindo 10 categorias de dados coletados e 4 required-reason APIs. Sem esse manifest, App Store Review rejeita builds (Apple deprecation Spring 2024).

Closes #439

## Conteúdo do manifest

### NSPrivacyTracking: false
Auraxis NÃO combina dados do usuário com dados de terceiros para advertising. \`NSPrivacyTrackingDomains: []\`.

### NSPrivacyCollectedDataTypes (10 categorias)

| Categoria | Linked | Tracking | Purpose |
|:----------|:-------|:---------|:--------|
| Email Address | ✅ | ❌ | App Functionality + Account |
| Name | ✅ | ❌ | Account Management |
| User ID | ✅ | ❌ | App Functionality + Account |
| Other Financial Info | ✅ | ❌ | App Functionality |
| Other User Content | ✅ | ❌ | App Functionality |
| Crash Data | ❌ | ❌ | App Functionality (Sentry) |
| Performance Data | ❌ | ❌ | App Functionality (Sentry) |
| Other Diagnostic Data | ❌ | ❌ | App Functionality (Sentry) |
| Device ID | ❌ | ❌ | App Functionality + Analytics |
| Product Interaction | ❌ | ❌ | Analytics + App Functionality (PostHog) |

### NSPrivacyAccessedAPITypes (4 required-reason APIs)

| API | Reason Code | Uso |
|:----|:------------|:----|
| File Timestamp | C617.1 | sync to original file path for user-initiated |
| User Defaults | CA92.1 | access info from same app |
| System Boot Time | 35F9.1 | measure time elapsed |
| Disk Space | E174.1 | display info to user about available space |

Estas APIs são usadas internamente por Sentry SDK, expo-secure-store, AsyncStorage, expo-notifications e Hermes engine.

## Test plan

- [x] JSON válido (\`python3 -c 'json.load(open(app.json))'\`)
- [ ] EAS Build local gera \`PrivacyInfo.xcprivacy\` no bundle:
  \`\`\`bash
  eas build --profile preview --platform ios --local
  unzip -l <build>.ipa | grep PrivacyInfo
  \`\`\`
- [ ] Submit para TestFlight não rejeita com erro de privacy manifest
- [ ] CI verde (lint + typecheck + tests + coverage)

## Referências

- Apple deprecation notice: https://developer.apple.com/news/?id=3d8a9yyh
- Required reason API codes: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api
- Data type identifiers: https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_data_use_in_privacy_manifests
- Tracker (epic): #436
- Companion legal: italofelipe/auraxis-platform#750