### PR TITLE
feat(testing): a11y assertions + visual baseline via Maestro (R2/2.2)

### DIFF
--- a/.github/workflows/maestro-schedule.yml
+++ b/.github/workflows/maestro-schedule.yml
@@ -39,11 +39,23 @@ jobs:
           # Wait for simulator to be ready
           sleep 30
 
-      - name: Run Maestro flows
+      - name: Run Maestro flows (smoke)
         run: |
           maestro test .maestro/01_login.yaml
           maestro test .maestro/02_dashboard_overview.yaml
           maestro test .maestro/05_logout.yaml
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '120000'
+        continue-on-error: true
+
+      - name: Run Maestro a11y assertions
+        run: maestro test .maestro/a11y_checks.yaml
+        env:
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: '120000'
+        continue-on-error: true
+
+      - name: Run Maestro visual baseline (screenshots)
+        run: maestro test .maestro/visual_baseline.yaml
         env:
           MAESTRO_DRIVER_STARTUP_TIMEOUT: '120000'
         continue-on-error: true

--- a/.maestro/a11y_checks.yaml
+++ b/.maestro/a11y_checks.yaml
@@ -1,0 +1,40 @@
+appId: com.sensoriumit.auraxis
+name: A11y assertions on critical flows
+tags:
+  - a11y
+---
+# Critical-path a11y assertions: every interactive primary CTA on the 3 most
+# trafficked screens must be reachable by its visible label OR accessibilityLabel.
+# This is the minimum bar — pair with manual screen reader review per release.
+#
+# Initial implementation uses visible labels (Portuguese pt-BR). Follow-up issue
+# will add explicit testID/accessibilityLabel props to make the assertions
+# language-agnostic and screen-reader friendly.
+#
+# Run isolated: `maestro test .maestro/a11y_checks.yaml`
+
+- launchApp:
+    clearState: true
+
+# ── 1. Login screen — primary form a11y ─────────────────────────────────────
+- assertVisible: "E-mail"
+- assertVisible: "Senha"
+- assertVisible: "Entrar"
+
+- tapOn: "E-mail"
+- inputText: "test@auraxis.com.br"
+- tapOn: "Senha"
+- inputText: "TestPass123!"
+- tapOn: "Entrar"
+
+# ── 2. Dashboard — primary nav reachable ────────────────────────────────────
+- assertVisible: "Dashboard"
+
+# ── 3. Tools tab — navigation a11y ──────────────────────────────────────────
+- tapOn: "Ferramentas"
+- assertVisible: "Ferramentas"
+
+# Future-state (when testIDs land — tracked in follow-up):
+#   - assertVisible: { id: "login-submit-button" }
+#   - assertVisible: { id: "tab-dashboard" }
+#   - assertVisible: { id: "kpi-net-worth" }

--- a/.maestro/visual_baseline.yaml
+++ b/.maestro/visual_baseline.yaml
@@ -1,0 +1,34 @@
+appId: com.sensoriumit.auraxis
+name: Visual baseline (3 key screens)
+tags:
+  - visual
+---
+# Captures screenshots of the 3 most user-facing screens. Maestro Cloud
+# (when configured) diffs against the baseline of the latest passing main
+# build and fails the run on visual drift.
+#
+# Locally: `maestro test .maestro/visual_baseline.yaml` writes screenshots
+# under `~/.maestro/tests/<run-id>/`. CI uploads them as an artifact so they
+# can be inspected on the PR.
+
+- launchApp:
+    clearState: true
+
+# Login screen baseline
+- takeScreenshot: visual_01_login
+
+# Authenticate
+- tapOn: "E-mail"
+- inputText: "test@auraxis.com.br"
+- tapOn: "Senha"
+- inputText: "TestPass123!"
+- tapOn: "Entrar"
+- assertVisible: "Dashboard"
+
+# Dashboard baseline
+- takeScreenshot: visual_02_dashboard
+
+# Tools tab baseline
+- tapOn: "Ferramentas"
+- assertVisible: "Ferramentas"
+- takeScreenshot: visual_03_tools

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "test:mutation:features": "stryker run --mutate 'features/**/*.ts'",
     "ci:local": "bash scripts/run_ci_like_actions_local.sh",
     "e2e": "maestro test .maestro/",
-    "e2e:login": "maestro test .maestro/01_login.yaml"
+    "e2e:login": "maestro test .maestro/01_login.yaml",
+    "e2e:a11y": "maestro test .maestro/a11y_checks.yaml",
+    "e2e:visual": "maestro test .maestro/visual_baseline.yaml"
   },
   "dependencies": {
     "@expo-google-fonts/playfair-display": "^0.4.2",


### PR DESCRIPTION
## Summary

Fase 2.2 do plano Housekeeping Round 2. Stryker mutation testing **já existe** no app (`stryker.config.mjs` + `test:mutation*`). Adiciona o que faltava: a11y + visual regression.

### `.maestro/a11y_checks.yaml`

Asserções de a11y em 3 telas críticas (login, dashboard, ferramentas) validando que CTAs primárias são reachable. Versão inicial usa visible labels pt-BR; **testIDs explícitos são follow-up issue separada**.

### `.maestro/visual_baseline.yaml`

Captura screenshots baseline. Maestro Cloud diffa quando configurado; sem Cloud, CI uploada como artifact (`actions/upload-artifact@v4`) já configurado no workflow existente.

### package.json scripts

- `npm run e2e:a11y` → maestro test a11y_checks.yaml
- `npm run e2e:visual` → maestro test visual_baseline.yaml

### Workflow

`.github/workflows/maestro-schedule.yml` estende para rodar a11y + visual depois do smoke trio. `continue-on-error: true` (não-bloqueante até calibragem) — tighten para hard fail é follow-up após baseline estável de 1-2 semanas.

## Test plan

- [x] 2 flows YAML válidos (syntax check)
- [x] Workflow YAML válido
- [x] npm scripts apontam para os flows corretos
- [x] Stryker confirmado já em uso

## Follow-up

- Issue separada: adicionar `testID` props nos componentes críticos (login-email-input, tab-dashboard, etc) — torna asserções language-agnostic e melhora screen reader UX
- Tighten Maestro a11y/visual de `continue-on-error: true` para hard fail após 1-2 semanas estável

## Closes

Closes #448