### PR TITLE
feat(release): eas.json EAS Update + store-release.yml tag trigger (APP-CI-01)

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,11 @@
+coverage/
+reports/
+__tests__/
+__mocks__/
+e2e/
+.maestro/
+docs/
+.stryker-tmp/
+.context/
+.expo/
+.husky/

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -1,4 +1,4 @@
-name: Store Release (Manual)
+name: Store Release (Manual + Tag)
 
 on:
   workflow_dispatch:
@@ -28,6 +28,9 @@ on:
         options:
           - "false"
           - "true"
+  push:
+    tags:
+      - "v*"
 
 jobs:
   build-and-submit:
@@ -63,11 +66,42 @@ jobs:
           eas-version: 16.13.0
           token: ${{ secrets.EXPO_TOKEN }}
 
+      - name: Verify EAS context
+        run: |
+          set -euo pipefail
+          eas whoami
+          eas project:info
+
+      - name: Resolve build parameters
+        id: params
+        env:
+          DISPATCH_PLATFORM: ${{ inputs.platform }}
+          DISPATCH_PROFILE: ${{ inputs.profile }}
+          DISPATCH_AUTO_SUBMIT: ${{ inputs.auto_submit }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            # Tag push (v*) -> full production release on both platforms with auto-submit
+            platform="all"
+            profile="production"
+            auto_submit="true"
+          else
+            platform="${DISPATCH_PLATFORM:-all}"
+            profile="${DISPATCH_PROFILE:-production}"
+            auto_submit="${DISPATCH_AUTO_SUBMIT:-false}"
+          fi
+          {
+            echo "platform=$platform"
+            echo "profile=$profile"
+            echo "auto_submit=$auto_submit"
+          } >> "$GITHUB_OUTPUT"
+          echo "Resolved trigger=${{ github.event_name }} platform=$platform profile=$profile auto_submit=$auto_submit"
+
       - name: Trigger build/submission
         env:
-          BUILD_PLATFORM: ${{ inputs.platform }}
-          BUILD_PROFILE: ${{ inputs.profile }}
-          AUTO_SUBMIT: ${{ inputs.auto_submit }}
+          PLATFORM: ${{ steps.params.outputs.platform }}
+          PROFILE: ${{ steps.params.outputs.profile }}
+          AUTO_SUBMIT: ${{ steps.params.outputs.auto_submit }}
         run: |
           set -euo pipefail
 
@@ -77,7 +111,7 @@ jobs:
           fi
 
           eas build \
-            --platform "$BUILD_PLATFORM" \
-            --profile "$BUILD_PROFILE" \
+            --platform "$PLATFORM" \
+            --profile "$PROFILE" \
             --non-interactive \
             $extra_args

--- a/app.json
+++ b/app.json
@@ -3,6 +3,13 @@
     "name": "auraxis-app",
     "slug": "auraxis-app",
     "version": "1.0.0",
+    "runtimeVersion": {
+      "policy": "appVersion"
+    },
+    "updates": {
+      "url": "https://u.expo.dev/f775e10b-89c3-4bb9-8af1-5073e68ac2ce",
+      "fallbackToCacheTimeout": 0
+    },
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "auraxisapp",
@@ -13,6 +20,9 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.sensoriumit.auraxis",
       "buildNumber": "1",
+      "config": {
+        "usesNonExemptEncryption": false
+      },
       "infoPlist": {
         "NSAppTransportSecurity": {
           "NSAllowsArbitraryLoads": false,

--- a/credentials/.gitignore
+++ b/credentials/.gitignore
@@ -1,0 +1,5 @@
+*.p8
+*.json
+*.keystore
+*.jks
+!.gitignore

--- a/eas.json
+++ b/eas.json
@@ -6,10 +6,16 @@
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "channel": "development",
+      "ios": {
+        "simulator": false
+      }
     },
     "preview": {
       "distribution": "internal",
+      "channel": "preview",
+      "autoIncrement": true,
       "android": {
         "buildType": "apk"
       },
@@ -19,6 +25,8 @@
     },
     "production": {
       "distribution": "store",
+      "channel": "production",
+      "autoIncrement": true,
       "android": {
         "buildType": "app-bundle"
       }
@@ -27,10 +35,16 @@
   "submit": {
     "production": {
       "android": {
-        "track": "internal"
+        "serviceAccountKeyPath": "@secret:GOOGLE_SERVICE_ACCOUNT",
+        "track": "internal",
+        "releaseStatus": "draft"
       },
       "ios": {
-        "ascAppId": "${ASC_APP_ID}"
+        "ascAppId": "${ASC_APP_ID}",
+        "appleTeamId": "${APPLE_TEAM_ID}",
+        "ascApiKeyPath": "@secret:ASC_API_KEY_FILE",
+        "ascApiKeyId": "${ASC_API_KEY_ID}",
+        "ascApiKeyIssuerId": "${ASC_API_KEY_ISSUER_ID}"
       }
     }
   }


### PR DESCRIPTION
## Summary

- Adiciona `channel` (EAS Update) e `autoIncrement` aos profiles do `eas.json`; completa submit profile production iOS (ASC API key) + Android (service account, track internal, releaseStatus draft)
- Patches em `app.json`: `runtimeVersion.policy=appVersion`, `updates.url` EAS Update, `ios.config.usesNonExemptEncryption=false`
- Cria `.easignore` (exclui coverage, tests, docs, etc do upload pro EAS Build) e `credentials/.gitignore` (diretório versionado, *.p8/*.json ignorados)
- Adiciona trigger `push: tags: ['v*']` ao `.github/workflows/store-release.yml` (release-please drive), step `eas whoami && eas project:info` pre-build, e resolve params do trigger

Implementação da Fase 1+3 do plano canônico
(`~/.claude/plans/preparar-builds-para-android-ios-mutable-pine.md`).

## Test plan

- [x] `node scripts/check-runtime-release-governance.cjs` → OK
- [x] `npm run policy:check` → 9/9 PASS
- [x] JSON valid: `app.json` + `eas.json` (node JSON.parse)
- [x] Diff stat: 0 mudanças em `.ts/.tsx` (TS errors em main não introduzidos por esta PR)
- [ ] Após merge + Italo entregar credenciais da Fase 0: `eas secret:create` dos 6 secrets (ASC_APP_ID, ASC_API_KEY_FILE, ASC_API_KEY_ID, ASC_API_KEY_ISSUER_ID, APPLE_TEAM_ID, GOOGLE_SERVICE_ACCOUNT)
- [ ] Smoke test via workflow_dispatch com platform=ios, profile=preview, auto_submit=false
- [ ] Smoke test via workflow_dispatch com platform=android, profile=preview, auto_submit=false
- [ ] Validar tag trigger criando tag draft `v1.0.1-test` (depois deletar)

## Out of scope (issues separadas)

- App Store Connect criar app + ASC API key → #437 (APP-TF-01) + #438 (APP-TF-02)
- Google Play Console + service account → #455 (APP-PS-01) + #456 (APP-PS-02)
- Primeiro build real + smoke → #441 (APP-TF-05) + #457 (APP-PS-05)
- Privacy Policy URL hospedada → italofelipe/auraxis-web#933
- Runbooks docs/wiki cross-platform → italofelipe/auraxis-platform#777

## Riscos conhecidos

- **EAS Update sem migration**: `runtimeVersion.policy=appVersion` significa que cada bump de `version` (1.x.y) é uma boundary de OTA. Builds antigos não recebem updates de novas versões — comportamento correto, mas vale lembrar ao bumpar version.
- **Bundle ID hardcoded** em `app.json` (`com.sensoriumit.auraxis`) precisa matchar o que for registrado em App Store Connect (#437) e Play Console (#455).
- **`releaseStatus: draft`** no Android impede release automático — Italo precisa promover manualmente no Play Console UI pra Internal Testing aparecer pros testers. Após pipeline estável, pode-se trocar pra `completed`.

## Restrição operacional documentada

Free tier EAS Build: 30 builds/mês. Política: builds production só via tag git (release-please drive), preview on-demand via workflow_dispatch. Dev day-to-day usa Expo Go / dev client local.

Closes #454