### PR TITLE
feat(transactions): cents-first money input + tz/NaN normalization (shared CurrencyInputField)

### DIFF
--- a/features/budgets/components/budget-form.tsx
+++ b/features/budgets/components/budget-form.tsx
@@ -18,6 +18,7 @@ import {
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
+import { CurrencyInputField } from "@/shared/forms/currency-input-field";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
 const PERIOD_OPTIONS: readonly { value: BudgetPeriod; label: string }[] = [
@@ -156,14 +157,13 @@ function BudgetFields({ control, errors }: BudgetFieldsProps): ReactElement {
         control={control}
         name="amount"
         render={({ field: { onChange, onBlur, value } }) => (
-          <AppInputField
+          <CurrencyInputField
             id="bud-amount"
             label="Limite"
-            placeholder="1500.00"
-            keyboardType="decimal-pad"
+            placeholder="0,00"
             value={value ?? ""}
             onBlur={onBlur}
-            onChangeText={onChange}
+            onChangeAmount={onChange}
             errorText={errors.amount?.message}
           />
         )}

--- a/features/credit-cards/components/credit-card-form.tsx
+++ b/features/credit-cards/components/credit-card-form.tsx
@@ -18,6 +18,7 @@ import {
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
+import { CurrencyInputField } from "@/shared/forms/currency-input-field";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
 const BRAND_OPTIONS: readonly { value: CreditCardBrand; label: string }[] = [
@@ -58,22 +59,6 @@ const buildDefaults = (initial: CreditCard | null): CreateCreditCardFormValues =
     benefits: [...initial.benefits],
     validityDate: initial.validityDate,
   };
-};
-
-const parseNumeric = (value: string): number | null => {
-  if (value.trim().length === 0) {
-    return null;
-  }
-  const normalized = value.replace(/\./g, "").replace(",", ".");
-  const parsed = Number.parseFloat(normalized);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-
-const formatNumeric = (value: number | null | undefined): string => {
-  if (value === null || value === undefined || !Number.isFinite(value)) {
-    return "";
-  }
-  return value.toString();
 };
 
 const parseInteger = (value: string): number | null => {
@@ -274,14 +259,13 @@ function LimitField({ control, errors }: CreditCardFieldsProps): ReactElement {
       control={control}
       name="limitAmount"
       render={({ field: { onChange, onBlur, value } }) => (
-        <AppInputField
+        <CurrencyInputField
           id="cc-limit"
           label="Limite"
           placeholder="0,00"
-          keyboardType="decimal-pad"
-          value={formatNumeric(value)}
+          value={value ? String(value) : ""}
           onBlur={onBlur}
-          onChangeText={(text) => onChange(parseNumeric(text))}
+          onChangeAmount={(amount) => onChange(amount === "" ? null : Number(amount))}
           errorText={errors.limitAmount?.message}
         />
       )}

--- a/features/goals/components/goal-form.tsx
+++ b/features/goals/components/goal-form.tsx
@@ -19,6 +19,7 @@ import {
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
+import { CurrencyInputField } from "@/shared/forms/currency-input-field";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 
 export interface GoalFormProps {
@@ -40,19 +41,6 @@ const goalToFormValues = (goal: GoalRecord | null | undefined): CreateGoalFormVa
     currentAmount: goal.currentAmount,
     targetDate: goal.targetDate,
   };
-};
-
-const parseNumeric = (value: string): number => {
-  const normalized = value.replace(/\./g, "").replace(",", ".");
-  const parsed = Number.parseFloat(normalized);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
-const formatNumeric = (value: number | null | undefined): string => {
-  if (value === null || value === undefined || !Number.isFinite(value)) {
-    return "";
-  }
-  return value.toString();
 };
 
 /**
@@ -142,14 +130,13 @@ function GoalFormFields({ control, errors }: GoalFormFieldsProps): ReactElement 
         control={control}
         name="targetAmount"
         render={({ field: { onChange, onBlur, value } }) => (
-          <AppInputField
+          <CurrencyInputField
             id="goal-target-amount"
             label="Valor alvo (R$)"
             placeholder="0,00"
-            keyboardType="decimal-pad"
-            value={formatNumeric(value)}
+            value={value ? String(value) : ""}
             onBlur={onBlur}
-            onChangeText={(text) => onChange(parseNumeric(text))}
+            onChangeAmount={(amount) => onChange(amount === "" ? 0 : Number(amount))}
             errorText={errors.targetAmount?.message}
           />
         )}
@@ -158,14 +145,13 @@ function GoalFormFields({ control, errors }: GoalFormFieldsProps): ReactElement 
         control={control}
         name="currentAmount"
         render={({ field: { onChange, onBlur, value } }) => (
-          <AppInputField
+          <CurrencyInputField
             id="goal-current-amount"
             label="Valor ja acumulado (R$)"
             placeholder="0,00"
-            keyboardType="decimal-pad"
-            value={formatNumeric(value)}
+            value={value ? String(value) : ""}
             onBlur={onBlur}
-            onChangeText={(text) => onChange(parseNumeric(text))}
+            onChangeAmount={(amount) => onChange(amount === "" ? 0 : Number(amount))}
             errorText={errors.currentAmount?.message}
           />
         )}

--- a/features/goals/components/goal-simulator-form.tsx
+++ b/features/goals/components/goal-simulator-form.tsx
@@ -18,6 +18,7 @@ import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { CurrencyInputField } from "@/shared/forms/currency-input-field";
 
 const DEFAULTS: SimulateGoalFormValues = {
   targetAmount: 0,
@@ -26,31 +27,6 @@ const DEFAULTS: SimulateGoalFormValues = {
   monthlyIncome: null,
   monthlyExpenses: null,
   monthlyContribution: null,
-};
-
-const parseNumeric = (value: string): number => {
-  if (value.trim().length === 0) {
-    return 0;
-  }
-  const normalized = value.replace(/\./g, "").replace(",", ".");
-  const parsed = Number.parseFloat(normalized);
-  return Number.isFinite(parsed) ? parsed : 0;
-};
-
-const parseOptional = (value: string): number | null => {
-  if (value.trim().length === 0) {
-    return null;
-  }
-  const normalized = value.replace(/\./g, "").replace(",", ".");
-  const parsed = Number.parseFloat(normalized);
-  return Number.isFinite(parsed) ? parsed : null;
-};
-
-const formatNumeric = (value: number | null | undefined): string => {
-  if (value === null || value === undefined || !Number.isFinite(value)) {
-    return "";
-  }
-  return value.toString();
 };
 
 export interface GoalSimulatorFormProps {
@@ -123,7 +99,7 @@ function SimulatorFields({
         name="targetAmount"
         id="sim-target"
         label="Valor alvo"
-        placeholder="100000"
+        placeholder="0,00"
       />
       <RequiredAmount
         control={control}
@@ -131,7 +107,7 @@ function SimulatorFields({
         name="currentAmount"
         id="sim-current"
         label="Valor atual"
-        placeholder="0"
+        placeholder="0,00"
       />
       <OptionalAmount
         control={control}
@@ -139,7 +115,7 @@ function SimulatorFields({
         name="monthlyIncome"
         id="sim-income"
         label="Renda mensal (opcional)"
-        placeholder="0"
+        placeholder="0,00"
       />
       <OptionalAmount
         control={control}
@@ -147,7 +123,7 @@ function SimulatorFields({
         name="monthlyExpenses"
         id="sim-expenses"
         label="Despesa mensal (opcional)"
-        placeholder="0"
+        placeholder="0,00"
       />
       <OptionalAmount
         control={control}
@@ -155,7 +131,7 @@ function SimulatorFields({
         name="monthlyContribution"
         id="sim-contribution"
         label="Contribuicao desejada (opcional)"
-        placeholder="0"
+        placeholder="0,00"
       />
       <Controller
         control={control}
@@ -197,14 +173,13 @@ function RequiredAmount({
       control={control}
       name={name}
       render={({ field: { onChange, onBlur, value } }) => (
-        <AppInputField
+        <CurrencyInputField
           id={id}
           label={label}
           placeholder={placeholder}
-          keyboardType="decimal-pad"
-          value={formatNumeric(value)}
+          value={value ? String(value) : ""}
           onBlur={onBlur}
-          onChangeText={(text) => onChange(parseNumeric(text))}
+          onChangeAmount={(amount) => onChange(amount === "" ? 0 : Number(amount))}
           errorText={errors[name]?.message}
         />
       )}
@@ -232,14 +207,13 @@ function OptionalAmount({
       control={control}
       name={name}
       render={({ field: { onChange, onBlur, value } }) => (
-        <AppInputField
+        <CurrencyInputField
           id={id}
           label={label}
           placeholder={placeholder}
-          keyboardType="decimal-pad"
-          value={formatNumeric(value)}
+          value={value ? String(value) : ""}
           onBlur={onBlur}
-          onChangeText={(text) => onChange(parseOptional(text))}
+          onChangeAmount={(amount) => onChange(amount === "" ? null : Number(amount))}
           errorText={errors[name]?.message}
         />
       )}

--- a/features/transactions/components/transaction-form.test.tsx
+++ b/features/transactions/components/transaction-form.test.tsx
@@ -74,7 +74,9 @@ describe("TransactionForm installments", () => {
     const { getByText, getByLabelText, onSubmit } = renderForm();
 
     fireEvent.changeText(getByLabelText("Titulo"), "Notebook");
-    fireEvent.changeText(getByLabelText("Valor (R$)"), "1200");
+    // Cents-first entry: digits shift in from the right, so R$ 1.200,00 is
+    // typed as "120000" (12000 cents → 1200,00).
+    fireEvent.changeText(getByLabelText("Valor (R$)"), "120000");
     fireEvent.changeText(getByLabelText("Data"), "2026-05-17");
     fireEvent.press(getByText("Nubank final 1234"));
     fireEvent(getByLabelText("Compra parcelada"), "onCheckedChange", true);

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -26,8 +26,10 @@ import { AppErrorNotice } from "@/shared/components/app-error-notice";
 import { AppInputField } from "@/shared/components/app-input-field";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { AppToggleRow } from "@/shared/components/app-toggle-row";
+import { CurrencyInputField } from "@/shared/forms/currency-input-field";
 import { isFeatureEnabled } from "@/shared/feature-flags";
-import { formatCurrency, formatShortDate } from "@/shared/utils/formatters";
+import { safeFormatCurrency } from "@/shared/utils/currency";
+import { formatShortDate } from "@/shared/utils/formatters";
 
 const transactionToFormValues = (
   transaction: TransactionRecord | null | undefined,
@@ -199,14 +201,13 @@ function TransactionFormFields({
         control={control}
         name="amount"
         render={({ field: { onChange, onBlur, value } }) => (
-          <AppInputField
+          <CurrencyInputField
             id="tx-amount"
             label="Valor (R$)"
             placeholder="0,00"
-            keyboardType="decimal-pad"
             value={value ?? ""}
             onBlur={onBlur}
-            onChangeText={onChange}
+            onChangeAmount={onChange}
             errorText={errors.amount?.message}
           />
         )}
@@ -586,7 +587,15 @@ const parseInstallmentCountInput = (text: string): number | null => {
 };
 
 const parseDueDateForPreview = (value: string): Date | null => {
-  const date = new Date(`${value}T00:00:00.000Z`);
+  // Build the date in the user's local timezone. Parsing `YYYY-MM-DD` with a
+  // trailing `Z` would anchor it to UTC midnight, which renders as the
+  // previous day for negative-offset zones (e.g. BRT, UTC-3).
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim());
+  if (!match) {
+    return null;
+  }
+  const [, year, month, day] = match;
+  const date = new Date(Number(year), Number(month) - 1, Number(day));
   return Number.isNaN(date.getTime()) ? null : date;
 };
 
@@ -598,5 +607,5 @@ const formatCreditCardLabel = (creditCard: CreditCard): string => {
 };
 
 const formatPreviewCurrency = (value: string): string => {
-  return formatCurrency(Number(value)).replace(/\u00A0/g, " ");
+  return safeFormatCurrency(value).replace(/\u00A0/g, " ");
 };

--- a/shared/forms/currency-input-field.test.tsx
+++ b/shared/forms/currency-input-field.test.tsx
@@ -1,0 +1,75 @@
+import { useState, type ReactElement } from "react";
+
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { CurrencyInputField } from "@/shared/forms/currency-input-field";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+const Harness = ({
+  onChange,
+  initial = "",
+}: {
+  readonly onChange?: (amount: string) => void;
+  readonly initial?: string;
+}): ReactElement => {
+  const [value, setValue] = useState(initial);
+  return (
+    <CurrencyInputField
+      id="amount"
+      label="Valor (R$)"
+      placeholder="0,00"
+      value={value}
+      onChangeAmount={(amount) => {
+        setValue(amount);
+        onChange?.(amount);
+      }}
+    />
+  );
+};
+
+describe("CurrencyInputField", () => {
+  it("renders the label and placeholder", () => {
+    const { getByText, getByPlaceholderText } = render(
+      <TestProviders>
+        <Harness />
+      </TestProviders>,
+    );
+
+    expect(getByText("Valor (R$)")).toBeTruthy();
+    expect(getByPlaceholderText("0,00")).toBeTruthy();
+  });
+
+  it("emits the canonical decimal string as the user types cents-first", () => {
+    const onChange = jest.fn();
+    const { getByPlaceholderText } = render(
+      <TestProviders>
+        <Harness onChange={onChange} />
+      </TestProviders>,
+    );
+
+    const input = getByPlaceholderText("0,00");
+    fireEvent.changeText(input, "5");
+    expect(onChange).toHaveBeenLastCalledWith("0.05");
+  });
+
+  it("shows the masked pt-BR amount for a canonical value", () => {
+    const { getByDisplayValue } = render(
+      <TestProviders>
+        <Harness initial="120.25" />
+      </TestProviders>,
+    );
+
+    expect(getByDisplayValue("120,25")).toBeTruthy();
+  });
+
+  it("renders an empty field (not NaN) for an empty value", () => {
+    const { getByPlaceholderText } = render(
+      <TestProviders>
+        <Harness initial="" />
+      </TestProviders>,
+    );
+
+    const input = getByPlaceholderText("0,00");
+    expect(input.props.value).toBe("");
+  });
+});

--- a/shared/forms/currency-input-field.tsx
+++ b/shared/forms/currency-input-field.tsx
@@ -1,0 +1,57 @@
+import { memo, useMemo, type ReactElement } from "react";
+
+import {
+  AppInputField,
+  type AppInputFieldProps,
+} from "@/shared/components/app-input-field";
+import {
+  centsInputToAmountString,
+  formatCurrencyInput,
+} from "@/shared/utils/currency";
+
+export interface CurrencyInputFieldProps
+  extends Omit<
+    AppInputFieldProps,
+    "value" | "onChangeText" | "keyboardType" | "inputMode"
+  > {
+  /** Canonical decimal string (e.g. `"120.25"`) or "" when empty. */
+  readonly value: string;
+  /** Emits the canonical decimal string on every keystroke. */
+  readonly onChangeAmount: (amount: string) => void;
+}
+
+/**
+ * Money field with Brazilian POS-style entry: each digit shifts the amount in
+ * cents (right-to-left), so typing `1,2,0,2,5` reads `0,01 → 0,12 → 1,20 →
+ * 12,02 → 120,25`. The visible text always mirrors the canonical value, and
+ * the field emits the decimal string the API/validators expect.
+ *
+ * @param props Field props plus `value`/`onChangeAmount`.
+ * @returns A controlled currency input.
+ */
+const CurrencyInputFieldComponent = ({
+  value,
+  onChangeAmount,
+  placeholder = "0,00",
+  ...rest
+}: CurrencyInputFieldProps): ReactElement => {
+  const display = useMemo(() => {
+    if (value.trim().length === 0) {
+      return "";
+    }
+    const numeric = Number(value);
+    return formatCurrencyInput(Number.isFinite(numeric) ? numeric : null);
+  }, [value]);
+
+  return (
+    <AppInputField
+      {...rest}
+      value={display}
+      placeholder={placeholder}
+      keyboardType="number-pad"
+      onChangeText={(text) => onChangeAmount(centsInputToAmountString(text))}
+    />
+  );
+};
+
+export const CurrencyInputField = memo(CurrencyInputFieldComponent);

--- a/shared/utils/currency.test.ts
+++ b/shared/utils/currency.test.ts
@@ -1,0 +1,67 @@
+import {
+  centsInputToAmountString,
+  formatCurrencyInput,
+  parseCurrencyCentsInput,
+  safeFormatCurrency,
+} from "@/shared/utils/currency";
+
+describe("parseCurrencyCentsInput", () => {
+  it("fills right-to-left as cents while typing 1,2,0,2,5", () => {
+    expect(parseCurrencyCentsInput("1")).toBe(0.01);
+    expect(parseCurrencyCentsInput("12")).toBe(0.12);
+    expect(parseCurrencyCentsInput("120")).toBe(1.2);
+    expect(parseCurrencyCentsInput("1202")).toBe(12.02);
+    expect(parseCurrencyCentsInput("12025")).toBe(120.25);
+  });
+
+  it("ignores non-digit characters (mask glyphs, separators)", () => {
+    expect(parseCurrencyCentsInput("R$ 120,25")).toBe(120.25);
+    expect(parseCurrencyCentsInput("1.202,50")).toBe(1202.5);
+  });
+
+  it("returns null when there are no digits", () => {
+    expect(parseCurrencyCentsInput("")).toBeNull();
+    expect(parseCurrencyCentsInput("R$")).toBeNull();
+    expect(parseCurrencyCentsInput("abc")).toBeNull();
+  });
+});
+
+describe("formatCurrencyInput", () => {
+  it("formats a number as pt-BR with two decimals and no symbol", () => {
+    expect(formatCurrencyInput(120.25)).toBe("120,25");
+    expect(formatCurrencyInput(1.2)).toBe("1,20");
+    expect(formatCurrencyInput(0.01)).toBe("0,01");
+  });
+
+  it("returns an empty string for null or non-finite values (no NaN)", () => {
+    expect(formatCurrencyInput(null)).toBe("");
+    expect(formatCurrencyInput(Number.NaN)).toBe("");
+    expect(formatCurrencyInput(Number.POSITIVE_INFINITY)).toBe("");
+  });
+});
+
+describe("centsInputToAmountString", () => {
+  it("produces the canonical decimal string the API expects", () => {
+    expect(centsInputToAmountString("12025")).toBe("120.25");
+    expect(centsInputToAmountString("120")).toBe("1.20");
+  });
+
+  it("returns an empty string when nothing parseable was typed", () => {
+    expect(centsInputToAmountString("")).toBe("");
+    expect(centsInputToAmountString("R$ ,")).toBe("");
+  });
+});
+
+describe("safeFormatCurrency", () => {
+  it("never renders NaN for empty/invalid input", () => {
+    expect(safeFormatCurrency("")).not.toContain("NaN");
+    expect(safeFormatCurrency(undefined)).not.toContain("NaN");
+    expect(safeFormatCurrency(null)).not.toContain("NaN");
+    expect(safeFormatCurrency("abc")).not.toContain("NaN");
+  });
+
+  it("formats finite numbers and numeric strings as BRL currency", () => {
+    expect(safeFormatCurrency(120.25)).toContain("120,25");
+    expect(safeFormatCurrency("120.25")).toContain("120,25");
+  });
+});

--- a/shared/utils/currency.ts
+++ b/shared/utils/currency.ts
@@ -1,0 +1,63 @@
+import { formatCurrency } from "@/shared/utils/formatters";
+
+const inputFormatter = new Intl.NumberFormat("pt-BR", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+/**
+ * Parses Brazilian POS-style currency entry: every typed digit shifts the
+ * amount in cents (right-to-left). Non-digit characters are ignored, so the
+ * masked display string round-trips safely.
+ *
+ * @param raw Raw text from the field (may include `R$`, separators, spaces).
+ * @returns Finite BRL amount, or `null` when no digits were typed.
+ */
+export const parseCurrencyCentsInput = (raw: string): number | null => {
+  const digits = raw.replace(/\D/g, "");
+  if (digits.length === 0) {
+    return null;
+  }
+  const value = Number(digits) / 100;
+  return Number.isFinite(value) ? value : null;
+};
+
+/**
+ * Formats a numeric amount for display inside the money input: pt-BR with two
+ * decimals and no currency symbol. NaN-safe — returns "" for null/non-finite.
+ *
+ * @param value Numeric amount, or null.
+ * @returns Masked display string, or "" when there is nothing to show.
+ */
+export const formatCurrencyInput = (value: number | null): string => {
+  if (value === null || !Number.isFinite(value)) {
+    return "";
+  }
+  return inputFormatter.format(value);
+};
+
+/**
+ * Converts cents-style entry into the canonical decimal string the API and
+ * Zod validators expect (e.g. `"120.25"`).
+ *
+ * @param raw Raw text from the field.
+ * @returns Decimal string with two fractional digits, or "" when empty.
+ */
+export const centsInputToAmountString = (raw: string): string => {
+  const value = parseCurrencyCentsInput(raw);
+  return value === null ? "" : value.toFixed(2);
+};
+
+/**
+ * Formats any persisted/display value as BRL currency without ever rendering
+ * `NaN`. Accepts numbers, numeric strings (`"120.25"`), null or undefined.
+ *
+ * @param value Raw value to format.
+ * @returns BRL currency string; falls back to `R$ 0,00` for invalid input.
+ */
+export const safeFormatCurrency = (
+  value: number | string | null | undefined,
+): string => {
+  const numeric = typeof value === "number" ? value : Number(value);
+  return formatCurrency(Number.isFinite(numeric) ? numeric : 0);
+};


### PR DESCRIPTION
Closes #463 (Frente A — Normalização, épico #814).

## O que entrega
- **`shared/utils/currency.ts`** (NaN-safe): `parseCurrencyCentsInput` (cents-first), `formatCurrencyInput`, `centsInputToAmountString`, `safeFormatCurrency`. 9 testes.
- **`shared/forms/CurrencyInputField`**: input monetário com máscara cents-first BRL (digitar `1,2,0,2,5` → `0,01 → 0,12 → 1,20 → 12,02 → 120,25`). 4 testes.
- **Adoção em todos os forms de dinheiro do app**:
  - `transaction-form` (valor)
  - `budget-form` (limite)
  - `goal-form` (valor alvo + acumulado)
  - `goal-simulator-form` (5 campos: alvo, atual, renda, despesa, contribuição)
  - `credit-card-form` (limite)
- **Fuso**: `parseDueDateForPreview` constrói a data no fuso local (antes `T00:00:00.000Z` deslocava 1 dia em BRT).
- **NaN-safe**: preview de parcelas via `safeFormatCurrency`; helpers `parseNumeric`/`formatNumeric` duplicados removidos.

## Testes / qualidade
- Suites tocadas verdes: currency utils, CurrencyInputField, transaction-form, e 127 testes de budgets/goals/credit-cards.
- ESLint limpo em todos os arquivos tocados.
- Typecheck do repo tem 12 erros **pré-existentes** (route codegen `/insights` + arquivo órfão `dashboard-service.test.ts`), **nenhum** nos arquivos desta PR. Pre-push do app trata typecheck como advisory por causa desse drift conhecido.

Refs #814
