### PR TITLE
feat(transactions): recurrence form — cadence picker, interval, dates + tz fix

### DIFF
--- a/features/transactions/components/transaction-form.test.tsx
+++ b/features/transactions/components/transaction-form.test.tsx
@@ -96,6 +96,36 @@ describe("TransactionForm installments", () => {
     expect(getByText("12x de R$ 100,00")).toBeTruthy();
   });
 
+  it("revela campos de recorrencia e submete cadencia ao ativar o toggle", async () => {
+    const { getByText, getByLabelText, queryByLabelText, onSubmit } = renderForm();
+
+    // Sub-fields hidden until recurring is enabled.
+    expect(queryByLabelText("Inicio")).toBeNull();
+
+    fireEvent.changeText(getByLabelText("Titulo"), "Aluguel");
+    fireEvent.changeText(getByLabelText("Valor (R$)"), "120000");
+    fireEvent.changeText(getByLabelText("Data"), "2026-05-05");
+    fireEvent(getByLabelText("Transacao recorrente"), "onCheckedChange", true);
+
+    fireEvent.press(getByText("Semana"));
+    fireEvent.changeText(getByLabelText("A cada (intervalo)"), "2");
+    fireEvent.changeText(getByLabelText("Inicio"), "2026-05-05");
+    fireEvent.changeText(getByLabelText("Fim"), "2026-08-05");
+    fireEvent.press(getByText("Criar transacao"));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          isRecurring: true,
+          recurrenceUnit: "week",
+          recurrenceInterval: 2,
+          startDate: "2026-05-05",
+          endDate: "2026-08-05",
+        }),
+      );
+    });
+  });
+
   it("nao renderiza selecao de cartao quando flag de parcelamento esta desligada", () => {
     mockedIsFeatureEnabled.mockReturnValue(false);
 

--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -14,7 +14,10 @@ import { Paragraph, XStack, YStack } from "tamagui";
 
 import type { CreditCard } from "@/features/credit-cards/contracts";
 import { useCreditCardsQuery } from "@/features/credit-cards/hooks/use-credit-cards-query";
-import type { TransactionRecord } from "@/features/transactions/contracts";
+import type {
+  RecurrenceUnit,
+  TransactionRecord,
+} from "@/features/transactions/contracts";
 import { TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY } from "@/features/transactions/installments-config";
 import { previewInstallments } from "@/features/transactions/utils/preview-installments";
 import {
@@ -31,6 +34,15 @@ import { isFeatureEnabled } from "@/shared/feature-flags";
 import { safeFormatCurrency } from "@/shared/utils/currency";
 import { formatShortDate } from "@/shared/utils/formatters";
 
+/** Today's date as `YYYY-MM-DD` in the device's local timezone (never UTC). */
+const todayLocalIsoDate = (): string => {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
 const transactionToFormValues = (
   transaction: TransactionRecord | null | undefined,
 ): CreateTransactionFormValues => {
@@ -39,9 +51,13 @@ const transactionToFormValues = (
       title: "",
       amount: "",
       type: "expense",
-      dueDate: new Date().toISOString().slice(0, 10),
+      dueDate: todayLocalIsoDate(),
       description: null,
       isRecurring: false,
+      startDate: null,
+      endDate: null,
+      recurrenceInterval: 1,
+      recurrenceUnit: "month",
       creditCardId: null,
       isInstallment: false,
       installmentCount: null,
@@ -54,6 +70,10 @@ const transactionToFormValues = (
     dueDate: transaction.dueDate.slice(0, 10),
     description: transaction.description,
     isRecurring: transaction.isRecurring,
+    startDate: transaction.startDate,
+    endDate: transaction.endDate,
+    recurrenceInterval: transaction.recurrenceInterval,
+    recurrenceUnit: transaction.recurrenceUnit,
     creditCardId: transaction.creditCardId,
     isInstallment: transaction.isInstallment,
     installmentCount: transaction.installmentCount,
@@ -106,6 +126,11 @@ export function TransactionForm({
       <YStack gap="$4">
         <TypeToggle control={form.control} />
         <TransactionFormFields control={form.control} errors={form.formState.errors} />
+        <RecurrenceFields
+          control={form.control}
+          errors={form.formState.errors}
+          setValue={form.setValue}
+        />
         {installmentsEnabled ? (
           <TransactionInstallmentFields
             control={form.control}
@@ -168,6 +193,148 @@ function TypeToggle({
         </XStack>
       )}
     />
+  );
+}
+
+const RECURRENCE_UNIT_OPTIONS: readonly { value: RecurrenceUnit; label: string }[] = [
+  { value: "day", label: "Dia" },
+  { value: "week", label: "Semana" },
+  { value: "month", label: "Mes" },
+  { value: "year", label: "Ano" },
+];
+
+interface RecurrenceFieldsProps {
+  readonly control: Control<CreateTransactionFormValues>;
+  readonly errors: FieldErrors<CreateTransactionFormValues>;
+  readonly setValue: UseFormSetValue<CreateTransactionFormValues>;
+}
+
+function RecurrenceFields({
+  control,
+  errors,
+  setValue,
+}: RecurrenceFieldsProps): ReactElement {
+  const isRecurring = useWatch({ control, name: "isRecurring" });
+  return (
+    <YStack gap="$4">
+      <Controller
+        control={control}
+        name="isRecurring"
+        render={({ field: { value, onChange } }) => (
+          <AppToggleRow
+            label="Transacao recorrente"
+            description="Repete automaticamente ate a data final (ex.: aluguel, salario)."
+            checked={Boolean(value)}
+            testID="transaction-recurring-toggle"
+            onCheckedChange={(checked) => {
+              onChange(checked);
+              if (!checked) {
+                setValue("startDate", null, { shouldDirty: true, shouldValidate: true });
+                setValue("endDate", null, { shouldDirty: true, shouldValidate: true });
+              }
+            }}
+          />
+        )}
+      />
+      {isRecurring ? <RecurrenceDetailFields control={control} errors={errors} /> : null}
+    </YStack>
+  );
+}
+
+function RecurrenceUnitPicker({
+  control,
+}: {
+  readonly control: Control<CreateTransactionFormValues>;
+}): ReactElement {
+  return (
+    <Controller
+      control={control}
+      name="recurrenceUnit"
+      render={({ field: { value, onChange } }) => (
+        <YStack gap="$2">
+          <Paragraph size="$3">Frequencia</Paragraph>
+          <XStack gap="$2" flexWrap="wrap">
+            {RECURRENCE_UNIT_OPTIONS.map((option) => (
+              <AppButton
+                key={option.value}
+                tone={value === option.value ? "primary" : "secondary"}
+                onPress={() => onChange(option.value)}
+              >
+                {option.label}
+              </AppButton>
+            ))}
+          </XStack>
+        </YStack>
+      )}
+    />
+  );
+}
+
+interface RecurrenceDetailFieldsProps {
+  readonly control: Control<CreateTransactionFormValues>;
+  readonly errors: FieldErrors<CreateTransactionFormValues>;
+}
+
+function RecurrenceDetailFields({
+  control,
+  errors,
+}: RecurrenceDetailFieldsProps): ReactElement {
+  return (
+    <>
+      <RecurrenceUnitPicker control={control} />
+      <Controller
+        control={control}
+        name="recurrenceInterval"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <AppInputField
+            id="tx-recurrence-interval"
+            label="A cada (intervalo)"
+            placeholder="1"
+            keyboardType="number-pad"
+            value={value ? String(value) : ""}
+            onBlur={onBlur}
+            onChangeText={(text) => {
+              const digits = text.replace(/\D/g, "");
+              onChange(digits.length === 0 ? 1 : Number.parseInt(digits, 10));
+            }}
+            errorText={errors.recurrenceInterval?.message}
+            helperText="Repete a cada N unidades de frequencia."
+          />
+        )}
+      />
+      <Controller
+        control={control}
+        name="startDate"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <AppInputField
+            id="tx-start-date"
+            label="Inicio"
+            placeholder="AAAA-MM-DD"
+            autoCapitalize="none"
+            value={value ?? ""}
+            onBlur={onBlur}
+            onChangeText={(text) => onChange(text.length > 0 ? text : null)}
+            errorText={errors.startDate?.message}
+          />
+        )}
+      />
+      <Controller
+        control={control}
+        name="endDate"
+        render={({ field: { onChange, onBlur, value } }) => (
+          <AppInputField
+            id="tx-end-date"
+            label="Fim"
+            placeholder="AAAA-MM-DD"
+            autoCapitalize="none"
+            value={value ?? ""}
+            onBlur={onBlur}
+            onChangeText={(text) => onChange(text.length > 0 ? text : null)}
+            errorText={errors.endDate?.message}
+          />
+        )}
+      />
+    </>
   );
 }
 

--- a/features/transactions/contracts.ts
+++ b/features/transactions/contracts.ts
@@ -1,5 +1,7 @@
 export type TransactionType = "income" | "expense";
 
+export type RecurrenceUnit = "day" | "week" | "month" | "year";
+
 export type TransactionStatus =
   | "paid"
   | "pending"
@@ -20,6 +22,8 @@ export interface TransactionRecord {
   readonly isRecurring: boolean;
   readonly isInstallment: boolean;
   readonly installmentCount: number | null;
+  readonly recurrenceInterval: number;
+  readonly recurrenceUnit: RecurrenceUnit;
   readonly tagId: string | null;
   readonly accountId: string | null;
   readonly creditCardId: string | null;
@@ -83,6 +87,8 @@ export interface UpsertTransactionCommand {
   readonly description?: string | null;
   readonly observation?: string | null;
   readonly isRecurring?: boolean;
+  readonly recurrenceInterval?: number;
+  readonly recurrenceUnit?: RecurrenceUnit;
   readonly isInstallment?: boolean;
   readonly installmentCount?: number | null;
   readonly tagId?: string | null;

--- a/features/transactions/hooks/use-transactions-screen-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.test.ts
@@ -7,6 +7,7 @@ import {
 } from "@/features/transactions/hooks/use-transaction-mutations";
 import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
 import { useTransactionsScreenController } from "@/features/transactions/hooks/use-transactions-screen-controller";
+import type { CreateTransactionFormValues } from "@/features/transactions/validators";
 
 jest.mock("@/features/transactions/hooks/use-transactions-query", () => ({
   useTransactionsQuery: jest.fn(),
@@ -42,6 +43,8 @@ const buildRecord = (overrides: Record<string, unknown> = {}) => ({
   isRecurring: false,
   isInstallment: false,
   installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month" as const,
   tagId: null,
   accountId: null,
   creditCardId: null,
@@ -54,6 +57,25 @@ const buildRecord = (overrides: Record<string, unknown> = {}) => ({
   paidAt: null,
   createdAt: null,
   updatedAt: null,
+  ...overrides,
+});
+
+const formValues = (
+  overrides: Partial<CreateTransactionFormValues> = {},
+): CreateTransactionFormValues => ({
+  title: "Conta",
+  amount: "150,75",
+  type: "expense",
+  dueDate: "2026-04-30",
+  description: null,
+  isRecurring: false,
+  startDate: null,
+  endDate: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  creditCardId: null,
+  isInstallment: false,
+  installmentCount: null,
   ...overrides,
 });
 
@@ -156,17 +178,9 @@ describe("useTransactionsScreenController mutations", () => {
       result.current.handleOpenCreate();
     });
     await act(async () => {
-      await result.current.handleSubmit({
-        title: "Conta",
-        amount: "150,75",
-        type: "expense",
-        dueDate: "2026-04-30",
-        description: null,
-        isRecurring: false,
-        creditCardId: null,
-        isInstallment: false,
-        installmentCount: null,
-      });
+      await result.current.handleSubmit(
+        formValues({ title: "Conta", amount: "150,75" }),
+      );
     });
     expect(createStub.mutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ title: "Conta", amount: "150.75", type: "expense" }),
@@ -180,17 +194,16 @@ describe("useTransactionsScreenController mutations", () => {
       result.current.handleOpenCreate();
     });
     await act(async () => {
-      await result.current.handleSubmit({
-        title: "Notebook",
-        amount: "1200",
-        type: "expense",
-        dueDate: "2026-05-17",
-        description: null,
-        isRecurring: false,
-        creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
-        isInstallment: true,
-        installmentCount: 12,
-      });
+      await result.current.handleSubmit(
+        formValues({
+          title: "Notebook",
+          amount: "1200",
+          dueDate: "2026-05-17",
+          creditCardId: "018f3a22-6ec3-7dc2-a93a-1bbdecb02000",
+          isInstallment: true,
+          installmentCount: 12,
+        }),
+      );
     });
 
     expect(createStub.mutateAsync).toHaveBeenCalledWith(
@@ -208,17 +221,9 @@ describe("useTransactionsScreenController mutations", () => {
       result.current.handleOpenEdit(buildRecord({ id: "tx-9" }));
     });
     await act(async () => {
-      await result.current.handleSubmit({
-        title: "Updated",
-        amount: "100.00",
-        type: "income",
-        dueDate: "2026-04-30",
-        description: null,
-        isRecurring: false,
-        creditCardId: null,
-        isInstallment: false,
-        installmentCount: null,
-      });
+      await result.current.handleSubmit(
+        formValues({ title: "Updated", amount: "100.00", type: "income" }),
+      );
     });
     expect(updateStub.mutateAsync).toHaveBeenCalledWith(
       expect.objectContaining({ transactionId: "tx-9" }),
@@ -232,17 +237,7 @@ describe("useTransactionsScreenController mutations", () => {
       result.current.handleOpenCreate();
     });
     await act(async () => {
-      await result.current.handleSubmit({
-        title: "X",
-        amount: "1.00",
-        type: "expense",
-        dueDate: "2026-04-30",
-        description: null,
-        isRecurring: false,
-        creditCardId: null,
-        isInstallment: false,
-        installmentCount: null,
-      });
+      await result.current.handleSubmit(formValues({ title: "X", amount: "1.00" }));
     });
     expect(result.current.submitError).toBeInstanceOf(Error);
     expect(result.current.formMode.kind).toBe("create");
@@ -264,17 +259,7 @@ describe("useTransactionsScreenController mutations", () => {
       result.current.handleOpenCreate();
     });
     await act(async () => {
-      await result.current.handleSubmit({
-        title: "X",
-        amount: "1.00",
-        type: "expense",
-        dueDate: "2026-04-30",
-        description: null,
-        isRecurring: false,
-        creditCardId: null,
-        isInstallment: false,
-        installmentCount: null,
-      });
+      await result.current.handleSubmit(formValues({ title: "X", amount: "1.00" }));
     });
     act(() => {
       result.current.dismissSubmitError();

--- a/features/transactions/mocks.ts
+++ b/features/transactions/mocks.ts
@@ -17,6 +17,8 @@ export const transactionFixture: TransactionRecord = {
   isRecurring: true,
   isInstallment: false,
   installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
   tagId: null,
   accountId: "account-1",
   creditCardId: null,

--- a/features/transactions/services/transactions-service.ts
+++ b/features/transactions/services/transactions-service.ts
@@ -30,6 +30,8 @@ interface TransactionPayload {
   readonly is_recurring: boolean;
   readonly is_installment: boolean;
   readonly installment_count: number | null;
+  readonly recurrence_interval: number | null;
+  readonly recurrence_unit: string | null;
   readonly tag_id: string | null;
   readonly account_id: string | null;
   readonly credit_card_id: string | null;
@@ -70,6 +72,8 @@ const mapTransaction = (payload: TransactionPayload): TransactionRecord => {
     isRecurring: payload.is_recurring,
     isInstallment: payload.is_installment,
     installmentCount: payload.installment_count,
+    recurrenceInterval: payload.recurrence_interval ?? 1,
+    recurrenceUnit: (payload.recurrence_unit as TransactionRecord["recurrenceUnit"]) ?? "month",
     tagId: payload.tag_id,
     accountId: payload.account_id,
     creditCardId: payload.credit_card_id,
@@ -135,6 +139,8 @@ const buildTransactionPayload = (
     description: command.description,
     observation: command.observation,
     is_recurring: command.isRecurring,
+    recurrence_interval: command.recurrenceInterval,
+    recurrence_unit: command.recurrenceUnit,
     is_installment: command.isInstallment,
     installment_count: command.installmentCount,
     tag_id: command.tagId,

--- a/features/transactions/validators.test.ts
+++ b/features/transactions/validators.test.ts
@@ -125,6 +125,64 @@ describe("updateTransactionSchema", () => {
   });
 });
 
+describe("createTransactionSchema — recurrence cadence", () => {
+  const recurringBase = {
+    ...validBase,
+    isRecurring: true,
+    startDate: "2026-04-01",
+    endDate: "2026-12-31",
+    dueDate: "2026-04-30",
+  };
+
+  it("aceita recorrente com start/end e cadencia", () => {
+    expect(() =>
+      createTransactionSchema.parse({
+        ...recurringBase,
+        recurrenceInterval: 2,
+        recurrenceUnit: "week",
+      }),
+    ).not.toThrow();
+  });
+
+  it("aplica cadencia mensal por padrao", () => {
+    const parsed = createTransactionSchema.parse(recurringBase);
+    expect(parsed.recurrenceUnit).toBe("month");
+    expect(parsed.recurrenceInterval).toBe(1);
+  });
+
+  it("exige startDate e endDate quando recorrente", () => {
+    expect(() =>
+      createTransactionSchema.parse({
+        ...validBase,
+        isRecurring: true,
+      }),
+    ).toThrow();
+  });
+
+  it("rejeita startDate posterior a endDate", () => {
+    expect(() =>
+      createTransactionSchema.parse({
+        ...recurringBase,
+        startDate: "2026-12-31",
+        endDate: "2026-04-01",
+      }),
+    ).toThrow();
+  });
+
+  it("rejeita unidade de recorrencia invalida", () => {
+    expect(() =>
+      createTransactionSchema.parse({
+        ...recurringBase,
+        recurrenceUnit: "fortnight",
+      }),
+    ).toThrow();
+  });
+
+  it("nao exige datas quando nao recorrente", () => {
+    expect(() => createTransactionSchema.parse(validBase)).not.toThrow();
+  });
+});
+
 describe("normalizeAmount", () => {
   it("converte virgula brasileira para ponto e arredonda 2 casas", () => {
     expect(normalizeAmount("1500,5")).toBe("1500.50");

--- a/features/transactions/validators.ts
+++ b/features/transactions/validators.ts
@@ -22,6 +22,10 @@ const isoDate = z
     message: "Data invalida.",
   });
 
+const optionalIsoDate = isoDate.nullable().optional();
+
+export const recurrenceUnitSchema = z.enum(["day", "week", "month", "year"]);
+
 export const transactionTypeSchema = z.enum(["income", "expense"]);
 
 const creditCardIdSchema = z.string().uuid("Cartao invalido.").nullable();
@@ -52,6 +56,44 @@ const validateInstallmentRequirements = (
   }
 };
 
+const validateRecurringRequirements = (
+  values: {
+    readonly isRecurring?: boolean;
+    readonly startDate?: string | null;
+    readonly endDate?: string | null;
+  },
+  ctx: z.RefinementCtx,
+): void => {
+  if (values.isRecurring !== true) {
+    return;
+  }
+  if (!values.startDate) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["startDate"],
+      message: "Informe a data de inicio da recorrencia.",
+    });
+  }
+  if (!values.endDate) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["endDate"],
+      message: "Informe a data de fim da recorrencia.",
+    });
+  }
+  if (
+    values.startDate &&
+    values.endDate &&
+    new Date(values.startDate) > new Date(values.endDate)
+  ) {
+    ctx.addIssue({
+      code: "custom",
+      path: ["endDate"],
+      message: "A data de fim deve ser posterior a data de inicio.",
+    });
+  }
+};
+
 export const createTransactionFieldsSchema = z.object({
   title: trimmedString(2, 120, "Informe um titulo de 2 a 120 caracteres."),
   amount: decimalAmount,
@@ -59,14 +101,23 @@ export const createTransactionFieldsSchema = z.object({
   dueDate: isoDate,
   description: z.string().trim().max(500, "Descricao muito longa.").optional().nullable(),
   isRecurring: z.boolean().optional(),
+  startDate: optionalIsoDate,
+  endDate: optionalIsoDate,
+  recurrenceInterval: z
+    .number()
+    .int("Informe um intervalo inteiro.")
+    .min(1, "O intervalo deve ser ao menos 1.")
+    .max(365, "Intervalo muito grande.")
+    .default(1),
+  recurrenceUnit: recurrenceUnitSchema.default("month"),
   creditCardId: creditCardIdSchema.default(null),
   isInstallment: z.boolean().default(false),
   installmentCount: installmentCountSchema.default(null),
 });
 
-export const createTransactionSchema = createTransactionFieldsSchema.superRefine(
-  validateInstallmentRequirements,
-);
+export const createTransactionSchema = createTransactionFieldsSchema
+  .superRefine(validateInstallmentRequirements)
+  .superRefine(validateRecurringRequirements);
 
 export const updateTransactionSchema = z
   .object({
@@ -76,6 +127,10 @@ export const updateTransactionSchema = z
     dueDate: isoDate.optional(),
     description: z.string().trim().max(500).optional().nullable(),
     isRecurring: z.boolean().optional(),
+    startDate: optionalIsoDate,
+    endDate: optionalIsoDate,
+    recurrenceInterval: z.number().int().min(1).max(365).optional(),
+    recurrenceUnit: recurrenceUnitSchema.optional(),
     creditCardId: creditCardIdSchema.optional(),
     isInstallment: z.boolean().optional(),
     installmentCount: installmentCountSchema.optional(),

--- a/shared/types/generated/graphql.ts
+++ b/shared/types/generated/graphql.ts
@@ -972,6 +972,8 @@ export type MutationCreateTransactionArgs = {
   isInstallment?: InputMaybe<Scalars['Boolean']['input']>;
   isRecurring?: InputMaybe<Scalars['Boolean']['input']>;
   observation?: InputMaybe<Scalars['String']['input']>;
+  recurrenceInterval?: InputMaybe<Scalars['Int']['input']>;
+  recurrenceUnit?: InputMaybe<Scalars['String']['input']>;
   startDate?: InputMaybe<Scalars['String']['input']>;
   status?: InputMaybe<TransactionStatus>;
   tagId?: InputMaybe<Scalars['UUID']['input']>;
@@ -1773,6 +1775,8 @@ export type TransactionTypeObject = {
   isRecurring: Scalars['Boolean']['output'];
   observation?: Maybe<Scalars['String']['output']>;
   paidAt?: Maybe<Scalars['String']['output']>;
+  recurrenceInterval?: Maybe<Scalars['Int']['output']>;
+  recurrenceUnit?: Maybe<Scalars['String']['output']>;
   source: Scalars['String']['output'];
   startDate?: Maybe<Scalars['String']['output']>;
   status: Scalars['String']['output'];


### PR DESCRIPTION
Closes #464 (Frente B — Recorrência frontend, épico #814). Consome o contrato do backend #1384.

## O que entrega
- **Form de recorrência** no `transaction-form`: toggle "Transacao recorrente" que revela:
  - seletor de **frequência** (Dia/Semana/Mês/Ano)
  - **intervalo** ("a cada N")
  - **início** e **fim** (datas)
- **Validação condicional** (Zod): quando recorrente, `startDate`/`endDate` obrigatórios e `start <= end`; unidade restrita a day/week/month/year; cadência mensal por padrão.
- **Contrato**: `RecurrenceUnit` + `recurrenceInterval`/`recurrenceUnit` em `TransactionRecord` e `UpsertTransactionCommand`; mapeados no request (snake_case) e na resposta (com defaults seguros 1/"month").
- **Fix de fuso**: data de vencimento padrão agora em horário **local** (antes `toISOString()` em UTC podia adiantar 1 dia em BRT).

## Testes / qualidade
- Validators: +6 casos de recorrência (23 no total). Form: novo teste de interação (toggle → cadência → submit). Controller/mocks ajustados aos novos campos obrigatórios.
- Suites de `features/transactions/` verdes (83 + form). ESLint limpo nos arquivos tocados. Typecheck sem erros novos (os 12 do repo são drift pré-existente de route-codegen `/insights` + arquivo órfão).

Refs #814 #1384
