### PR TITLE
feat(transactions): filtros avançados, marcar como pago e exclusão por escopo

### DIFF
--- a/__tests__/e2e/transactions.test.tsx
+++ b/__tests__/e2e/transactions.test.tsx
@@ -175,7 +175,7 @@ describe("Transactions E2E flow", () => {
     });
 
     await act(async () => {
-      await result.current.mutateAsync(transactionFixture.id);
+      await result.current.mutateAsync({ transactionId: transactionFixture.id });
     });
 
     await waitFor(() => {
@@ -183,6 +183,7 @@ describe("Transactions E2E flow", () => {
     });
     expect(mockedTransactionsService.deleteTransaction).toHaveBeenCalledWith(
       transactionFixture.id,
+      "occurrence",
     );
   });
 

--- a/core/observability/analytics-types.ts
+++ b/core/observability/analytics-types.ts
@@ -68,6 +68,7 @@ export interface AnalyticsEventPropertiesByName {
   readonly "transaction.created": TransactionAnalyticsProperties;
   readonly "transaction.deleted": TransactionAnalyticsProperties;
   readonly "transaction.restored": TransactionAnalyticsProperties;
+  readonly "transaction.paid": TransactionAnalyticsProperties;
   readonly "goal.created": GoalCreatedAnalyticsProperties;
   readonly "goal.simulated": GoalSimulatedAnalyticsProperties;
   readonly "tool.used": ToolUsedAnalyticsProperties;

--- a/features/transactions/components/transaction-action-modals.test.tsx
+++ b/features/transactions/components/transaction-action-modals.test.tsx
@@ -1,0 +1,103 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import {
+  DeleteConfirmModal,
+  MarkPaidConfirmModal,
+  todayLocalIsoDate,
+} from "@/features/transactions/components/transaction-action-modals";
+
+describe("MarkPaidConfirmModal", () => {
+  const renderModal = (overrides: Record<string, unknown> = {}) => {
+    const props = {
+      target: { id: "tx-1", title: "Aluguel" },
+      isSubmitting: false,
+      onConfirm: jest.fn(),
+      onClose: jest.fn(),
+      ...overrides,
+    };
+    const rendered = render(
+      <AppProviders>
+        <MarkPaidConfirmModal {...props} />
+      </AppProviders>,
+    );
+    return { ...rendered, props };
+  };
+
+  it("confirma pagamento com a data de hoje por padrao", () => {
+    const { getByTestId, props } = renderModal();
+
+    fireEvent.press(getByTestId("mark-paid-confirm"));
+    expect(props.onConfirm).toHaveBeenCalledWith("tx-1", todayLocalIsoDate());
+  });
+
+  it("confirma pagamento com data customizada", () => {
+    const { getByTestId, props } = renderModal();
+
+    fireEvent.changeText(getByTestId("mark-paid-date-input"), "2026-06-01");
+    fireEvent.press(getByTestId("mark-paid-confirm"));
+    expect(props.onConfirm).toHaveBeenCalledWith("tx-1", "2026-06-01");
+  });
+
+  it("bloqueia confirmacao com data invalida", () => {
+    const { getByTestId, getByText, props } = renderModal();
+
+    fireEvent.changeText(getByTestId("mark-paid-date-input"), "01/06/2026");
+    expect(getByText("Use o formato AAAA-MM-DD.")).toBeTruthy();
+
+    fireEvent.press(getByTestId("mark-paid-confirm"));
+    expect(props.onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("cancelar fecha o modal", () => {
+    const { getByText, props } = renderModal();
+
+    fireEvent.press(getByText("Cancelar"));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});
+
+describe("DeleteConfirmModal", () => {
+  const renderModal = (overrides: Record<string, unknown> = {}) => {
+    const props = {
+      target: { id: "tx-9", title: "Energia", isSeries: false },
+      isDeleting: false,
+      onConfirm: jest.fn(),
+      onClose: jest.fn(),
+      ...overrides,
+    };
+    const rendered = render(
+      <AppProviders>
+        <DeleteConfirmModal {...props} />
+      </AppProviders>,
+    );
+    return { ...rendered, props };
+  };
+
+  it("transacao simples confirma exclusao com escopo occurrence", () => {
+    const { getByTestId, queryByTestId, props } = renderModal();
+
+    expect(queryByTestId("delete-series")).toBeNull();
+
+    fireEvent.press(getByTestId("delete-occurrence"));
+    expect(props.onConfirm).toHaveBeenCalledWith("tx-9", "occurrence");
+  });
+
+  it("serie oferece excluir somente esta ou a serie inteira", () => {
+    const { getByTestId, getByText, props } = renderModal({
+      target: { id: "tx-9", title: "Assinatura", isSeries: true },
+    });
+
+    expect(getByText("Excluir somente esta")).toBeTruthy();
+
+    fireEvent.press(getByTestId("delete-series"));
+    expect(props.onConfirm).toHaveBeenCalledWith("tx-9", "series");
+  });
+
+  it("cancelar fecha o modal", () => {
+    const { getByText, props } = renderModal();
+
+    fireEvent.press(getByText("Cancelar"));
+    expect(props.onClose).toHaveBeenCalled();
+  });
+});

--- a/features/transactions/components/transaction-action-modals.tsx
+++ b/features/transactions/components/transaction-action-modals.tsx
@@ -1,0 +1,183 @@
+import { useEffect, useState, type ReactElement } from "react";
+
+import { Modal } from "react-native";
+import { YStack } from "tamagui";
+
+import type { TransactionDeleteScope } from "@/features/transactions/contracts";
+import { AppButton } from "@/shared/components/app-button";
+import { AppInputField } from "@/shared/components/app-input-field";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+
+const ISO_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Today's date in the device timezone formatted as YYYY-MM-DD. */
+export const todayLocalIsoDate = (): string => {
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+};
+
+interface ActionSheetProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+  readonly children: ReactElement;
+}
+
+function ActionSheet({ visible, onClose, children }: ActionSheetProps): ReactElement {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
+        <YStack
+          backgroundColor="$background"
+          padding="$4"
+          gap="$3"
+          borderTopLeftRadius="$3"
+          borderTopRightRadius="$3"
+        >
+          {children}
+        </YStack>
+      </YStack>
+    </Modal>
+  );
+}
+
+export interface MarkPaidTarget {
+  readonly id: string;
+  readonly title: string;
+}
+
+export interface MarkPaidConfirmModalProps {
+  readonly target: MarkPaidTarget | null;
+  readonly isSubmitting: boolean;
+  readonly onConfirm: (transactionId: string, paidAt: string) => void;
+  readonly onClose: () => void;
+}
+
+/**
+ * Confirmation sheet for marking a transaction as paid. Asks for the
+ * effective payment date (defaults to today) before confirming — mirrors
+ * the web pay-confirmation modal.
+ */
+export function MarkPaidConfirmModal({
+  target,
+  isSubmitting,
+  onConfirm,
+  onClose,
+}: MarkPaidConfirmModalProps): ReactElement {
+  const [paidAt, setPaidAt] = useState<string>(todayLocalIsoDate);
+  const targetId = target?.id ?? null;
+
+  useEffect(() => {
+    if (targetId) {
+      setPaidAt(todayLocalIsoDate());
+    }
+  }, [targetId]);
+
+  const isDateValid = ISO_DATE_PATTERN.test(paidAt);
+
+  return (
+    <ActionSheet visible={Boolean(target)} onClose={onClose}>
+      <AppSurfaceCard
+        title="Marcar como pago"
+        description={target ? `Confirmar pagamento de "${target.title}".` : ""}
+      >
+        <YStack gap="$3">
+          <AppInputField
+            id="mark-paid-date"
+            label="Data do pagamento"
+            value={paidAt}
+            onChangeText={setPaidAt}
+            placeholder="AAAA-MM-DD"
+            autoCapitalize="none"
+            errorText={isDateValid ? undefined : "Use o formato AAAA-MM-DD."}
+            testID="mark-paid-date-input"
+          />
+          <AppButton
+            onPress={() => {
+              if (target && isDateValid) {
+                onConfirm(target.id, paidAt);
+              }
+            }}
+            disabled={isSubmitting || !isDateValid}
+            testID="mark-paid-confirm"
+          >
+            {isSubmitting ? "Confirmando..." : "Confirmar pagamento"}
+          </AppButton>
+          <AppButton tone="secondary" onPress={onClose} disabled={isSubmitting}>
+            Cancelar
+          </AppButton>
+        </YStack>
+      </AppSurfaceCard>
+    </ActionSheet>
+  );
+}
+
+export interface DeleteTarget {
+  readonly id: string;
+  readonly title: string;
+  /** True for recurring/installment rows — offers whole-series deletion. */
+  readonly isSeries: boolean;
+}
+
+export interface DeleteConfirmModalProps {
+  readonly target: DeleteTarget | null;
+  readonly isDeleting: boolean;
+  readonly onConfirm: (transactionId: string, scope: TransactionDeleteScope) => void;
+  readonly onClose: () => void;
+}
+
+/**
+ * Confirmation sheet for deleting a transaction. For recurring/installment
+ * rows it offers deleting only this occurrence or the whole series —
+ * mirrors the web delete-confirmation modal.
+ */
+export function DeleteConfirmModal({
+  target,
+  isDeleting,
+  onConfirm,
+  onClose,
+}: DeleteConfirmModalProps): ReactElement {
+  return (
+    <ActionSheet visible={Boolean(target)} onClose={onClose}>
+      <AppSurfaceCard
+        title="Excluir transacao"
+        description={
+          target
+            ? target.isSeries
+              ? `"${target.title}" faz parte de uma serie. O que deseja excluir?`
+              : `Excluir "${target.title}"? Ela vai para a lixeira.`
+            : ""
+        }
+      >
+        <YStack gap="$3">
+          <AppButton
+            tone="danger"
+            onPress={() => {
+              if (target) {
+                onConfirm(target.id, "occurrence");
+              }
+            }}
+            disabled={isDeleting}
+            testID="delete-occurrence"
+          >
+            {target?.isSeries ? "Excluir somente esta" : "Excluir"}
+          </AppButton>
+          {target?.isSeries ? (
+            <AppButton
+              tone="danger"
+              onPress={() => onConfirm(target.id, "series")}
+              disabled={isDeleting}
+              testID="delete-series"
+            >
+              Excluir serie inteira
+            </AppButton>
+          ) : null}
+          <AppButton tone="secondary" onPress={onClose} disabled={isDeleting}>
+            Cancelar
+          </AppButton>
+        </YStack>
+      </AppSurfaceCard>
+    </ActionSheet>
+  );
+}

--- a/features/transactions/components/transaction-filters.test.tsx
+++ b/features/transactions/components/transaction-filters.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
+import { TransactionFilters } from "@/features/transactions/components/transaction-filters";
+
+jest.mock("@/features/tags/hooks/use-tags-query", () => ({
+  useTagsQuery: jest.fn(),
+}));
+
+const mockedUseTagsQuery = jest.mocked(useTagsQuery);
+
+const buildProps = () => ({
+  typeFilter: "all" as const,
+  onTypeFilterChange: jest.fn(),
+  statusFilter: "all" as const,
+  onStatusFilterChange: jest.fn(),
+  tagFilter: "all" as const,
+  onTagFilterChange: jest.fn(),
+  periodLabel: "Junho de 2026",
+  onPreviousMonth: jest.fn(),
+  onNextMonth: jest.fn(),
+  onClearFilters: jest.fn(),
+});
+
+const renderFilters = (props = buildProps()) => {
+  const rendered = render(
+    <AppProviders>
+      <TransactionFilters {...props} />
+    </AppProviders>,
+  );
+  return { ...rendered, props };
+};
+
+describe("TransactionFilters", () => {
+  beforeEach(() => {
+    mockedUseTagsQuery.mockReturnValue({ data: { tags: [] } } as never);
+  });
+
+  it("renderiza label do periodo e navega entre meses", () => {
+    const { getByText, getByLabelText, props } = renderFilters();
+
+    expect(getByText("Junho de 2026")).toBeTruthy();
+
+    fireEvent.press(getByLabelText("Mes anterior"));
+    expect(props.onPreviousMonth).toHaveBeenCalled();
+
+    fireEvent.press(getByLabelText("Proximo mes"));
+    expect(props.onNextMonth).toHaveBeenCalled();
+  });
+
+  it("dispara mudanca de filtro de status", () => {
+    const { getByText, props } = renderFilters();
+
+    fireEvent.press(getByText("Vencido"));
+    expect(props.onStatusFilterChange).toHaveBeenCalledWith("overdue");
+  });
+
+  it("dispara mudanca de filtro de tipo", () => {
+    const { getByText, props } = renderFilters();
+
+    fireEvent.press(getByText("Receitas"));
+    expect(props.onTypeFilterChange).toHaveBeenCalledWith("income");
+  });
+
+  it("oculta linha de tags quando nao ha tags", () => {
+    const { queryByText } = renderFilters();
+    expect(queryByText("Todas as tags")).toBeNull();
+  });
+
+  it("lista tags e dispara filtro por tag", () => {
+    mockedUseTagsQuery.mockReturnValue({
+      data: {
+        tags: [
+          { id: "tag-1", name: "Mercado" },
+          { id: "tag-2", name: "Transporte" },
+        ],
+      },
+    } as never);
+
+    const { getByText, props } = renderFilters();
+
+    fireEvent.press(getByText("Mercado"));
+    expect(props.onTagFilterChange).toHaveBeenCalledWith("tag-1");
+
+    fireEvent.press(getByText("Todas as tags"));
+    expect(props.onTagFilterChange).toHaveBeenCalledWith("all");
+  });
+
+  it("dispara limpar filtros", () => {
+    const { getByText, props } = renderFilters();
+
+    fireEvent.press(getByText("Limpar filtros"));
+    expect(props.onClearFilters).toHaveBeenCalled();
+  });
+});

--- a/features/transactions/components/transaction-filters.tsx
+++ b/features/transactions/components/transaction-filters.tsx
@@ -1,0 +1,195 @@
+import { type ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
+import type {
+  TransactionsStatusFilter,
+  TransactionsTagFilter,
+  TransactionsTypeFilter,
+} from "@/features/transactions/hooks/use-transactions-screen-controller";
+import { AppButton } from "@/shared/components/app-button";
+
+const TYPE_LABELS: Record<TransactionsTypeFilter, string> = {
+  all: "Todas",
+  income: "Receitas",
+  expense: "Despesas",
+};
+
+const TYPE_ORDER: readonly TransactionsTypeFilter[] = ["all", "income", "expense"];
+
+const STATUS_LABELS: Record<TransactionsStatusFilter, string> = {
+  all: "Todos",
+  pending: "Pendente",
+  paid: "Pago",
+  overdue: "Vencido",
+  cancelled: "Cancelado",
+  postponed: "Adiado",
+};
+
+const STATUS_ORDER: readonly TransactionsStatusFilter[] = [
+  "all",
+  "pending",
+  "paid",
+  "overdue",
+  "cancelled",
+  "postponed",
+];
+
+export interface TransactionFiltersProps {
+  readonly typeFilter: TransactionsTypeFilter;
+  readonly onTypeFilterChange: (filter: TransactionsTypeFilter) => void;
+  readonly statusFilter: TransactionsStatusFilter;
+  readonly onStatusFilterChange: (filter: TransactionsStatusFilter) => void;
+  readonly tagFilter: TransactionsTagFilter;
+  readonly onTagFilterChange: (filter: TransactionsTagFilter) => void;
+  readonly periodLabel: string;
+  readonly onPreviousMonth: () => void;
+  readonly onNextMonth: () => void;
+  readonly onClearFilters: () => void;
+}
+
+interface FilterChipProps {
+  readonly label: string;
+  readonly selected: boolean;
+  readonly onPress: () => void;
+}
+
+function FilterChip({ label, selected, onPress }: FilterChipProps): ReactElement {
+  return (
+    <AppButton
+      tone={selected ? "primary" : "secondary"}
+      onPress={onPress}
+      accessibilityState={{ selected }}
+    >
+      {label}
+    </AppButton>
+  );
+}
+
+interface PeriodNavigatorProps {
+  readonly periodLabel: string;
+  readonly onPreviousMonth: () => void;
+  readonly onNextMonth: () => void;
+}
+
+function PeriodNavigator({
+  periodLabel,
+  onPreviousMonth,
+  onNextMonth,
+}: PeriodNavigatorProps): ReactElement {
+  return (
+    <XStack alignItems="center" gap="$2">
+      <AppButton
+        tone="secondary"
+        onPress={onPreviousMonth}
+        accessibilityLabel="Mes anterior"
+      >
+        {"<"}
+      </AppButton>
+      <Paragraph
+        flex={1}
+        textAlign="center"
+        color="$color"
+        fontFamily="$body"
+        fontSize="$4"
+        accessibilityRole="header"
+      >
+        {periodLabel}
+      </Paragraph>
+      <AppButton
+        tone="secondary"
+        onPress={onNextMonth}
+        accessibilityLabel="Proximo mes"
+      >
+        {">"}
+      </AppButton>
+    </XStack>
+  );
+}
+
+interface TagFilterRowProps {
+  readonly tagFilter: TransactionsTagFilter;
+  readonly onTagFilterChange: (filter: TransactionsTagFilter) => void;
+}
+
+function TagFilterRow({
+  tagFilter,
+  onTagFilterChange,
+}: TagFilterRowProps): ReactElement | null {
+  const tagsQuery = useTagsQuery();
+  const tags = tagsQuery.data?.tags ?? [];
+
+  if (tags.length === 0) {
+    return null;
+  }
+
+  return (
+    <XStack gap="$2" flexWrap="wrap">
+      <FilterChip
+        label="Todas as tags"
+        selected={tagFilter === "all"}
+        onPress={() => onTagFilterChange("all")}
+      />
+      {tags.map((tag) => (
+        <FilterChip
+          key={tag.id}
+          label={tag.name}
+          selected={tagFilter === tag.id}
+          onPress={() => onTagFilterChange(tag.id)}
+        />
+      ))}
+    </XStack>
+  );
+}
+
+/**
+ * Filter bar for the transactions screen: monthly period navigation, type,
+ * status and tag filters plus a reset action. Mirrors the web filters.
+ */
+export function TransactionFilters({
+  typeFilter,
+  onTypeFilterChange,
+  statusFilter,
+  onStatusFilterChange,
+  tagFilter,
+  onTagFilterChange,
+  periodLabel,
+  onPreviousMonth,
+  onNextMonth,
+  onClearFilters,
+}: TransactionFiltersProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      <PeriodNavigator
+        periodLabel={periodLabel}
+        onPreviousMonth={onPreviousMonth}
+        onNextMonth={onNextMonth}
+      />
+      <XStack gap="$2" flexWrap="wrap">
+        {TYPE_ORDER.map((filter) => (
+          <FilterChip
+            key={filter}
+            label={TYPE_LABELS[filter]}
+            selected={typeFilter === filter}
+            onPress={() => onTypeFilterChange(filter)}
+          />
+        ))}
+      </XStack>
+      <XStack gap="$2" flexWrap="wrap">
+        {STATUS_ORDER.map((filter) => (
+          <FilterChip
+            key={filter}
+            label={STATUS_LABELS[filter]}
+            selected={statusFilter === filter}
+            onPress={() => onStatusFilterChange(filter)}
+          />
+        ))}
+      </XStack>
+      <TagFilterRow tagFilter={tagFilter} onTagFilterChange={onTagFilterChange} />
+      <AppButton tone="secondary" onPress={onClearFilters}>
+        Limpar filtros
+      </AppButton>
+    </YStack>
+  );
+}

--- a/features/transactions/contracts.ts
+++ b/features/transactions/contracts.ts
@@ -9,6 +9,13 @@ export type TransactionStatus =
   | "postponed"
   | "overdue";
 
+/**
+ * Scope accepted by DELETE /transactions/{id}: "occurrence" removes only the
+ * target row (default), "series" soft-deletes the whole recurring/installment
+ * series. Mirrors the web client contract.
+ */
+export type TransactionDeleteScope = "occurrence" | "series";
+
 export interface TransactionRecord {
   readonly id: string;
   readonly title: string;

--- a/features/transactions/hooks/use-transaction-mutations.test.ts
+++ b/features/transactions/hooks/use-transaction-mutations.test.ts
@@ -8,6 +8,7 @@ import type {
 import {
   useCreateTransactionMutation,
   useDeleteTransactionMutation,
+  useMarkTransactionPaidMutation,
   useRestoreTransactionMutation,
 } from "@/features/transactions/hooks/use-transaction-mutations";
 import { transactionFixture } from "@/features/transactions/mocks";
@@ -26,6 +27,7 @@ const mockCreateTransaction = jest.fn();
 const mockUpdateTransaction = jest.fn();
 const mockDeleteTransaction = jest.fn();
 const mockRestoreTransaction = jest.fn();
+const mockMarkTransactionPaid = jest.fn();
 
 jest.mock("@tanstack/react-query", () => ({
   useMutation: (...args: readonly unknown[]) => mockUseMutation(...args),
@@ -46,6 +48,8 @@ jest.mock("@/features/transactions/services/transactions-service", () => ({
       mockDeleteTransaction(...args),
     restoreTransaction: (...args: readonly unknown[]) =>
       mockRestoreTransaction(...args),
+    markTransactionPaid: (...args: readonly unknown[]) =>
+      mockMarkTransactionPaid(...args),
   },
 }));
 
@@ -83,18 +87,18 @@ const expectedAnalyticsProperties = (
   currency: transaction.currency,
 });
 
-describe("useTransactionMutations analytics", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUseMutation.mockImplementation((options: unknown) => options);
-    mockInvalidateQueries.mockResolvedValue(undefined);
-    mockGetQueriesData.mockReturnValue([]);
-    mockUseQueryClient.mockReturnValue({
-      invalidateQueries: mockInvalidateQueries,
-      getQueriesData: mockGetQueriesData,
-    });
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseMutation.mockImplementation((options: unknown) => options);
+  mockInvalidateQueries.mockResolvedValue(undefined);
+  mockGetQueriesData.mockReturnValue([]);
+  mockUseQueryClient.mockReturnValue({
+    invalidateQueries: mockInvalidateQueries,
+    getQueriesData: mockGetQueriesData,
   });
+});
 
+describe("useTransactionMutations analytics", () => {
   it("captures transaction.created without PII when creation succeeds", async () => {
     const command: CreateTransactionCommand = {
       title: "Confidential vendor",
@@ -154,18 +158,19 @@ describe("useTransactionMutations analytics", () => {
     const mutation =
       useDeleteTransactionMutation() as unknown as MutationConfig<
         void,
-        string,
+        { readonly transactionId: string; readonly scope?: "occurrence" | "series" },
         { readonly transaction?: TransactionRecord }
       >;
 
-    const mutationContext = mutation.onMutate?.(deletedTransaction.id);
-    await expect(mutation.mutationFn(deletedTransaction.id)).resolves.toBeUndefined();
-    await mutation.onSuccess?.(
-      undefined,
-      deletedTransaction.id,
-      mutationContext ?? {},
-    );
+    const variables = { transactionId: deletedTransaction.id } as const;
+    const mutationContext = mutation.onMutate?.(variables);
+    await expect(mutation.mutationFn(variables)).resolves.toBeUndefined();
+    await mutation.onSuccess?.(undefined, variables, mutationContext ?? {});
 
+    expect(mockDeleteTransaction).toHaveBeenCalledWith(
+      deletedTransaction.id,
+      "occurrence",
+    );
     expect(mutationContext).toEqual({ transaction: deletedTransaction });
     expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
       "transaction.deleted",
@@ -207,6 +212,65 @@ describe("useTransactionMutations analytics", () => {
     );
     expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
       restoredTransaction.title,
+    );
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: queryKeys.transactions.root,
+    });
+  });
+});
+
+describe("useTransactionMutations pay + delete scope", () => {
+  it("repassa scope series ao service ao excluir serie inteira", async () => {
+    mockDeleteTransaction.mockResolvedValue(undefined);
+
+    const mutation =
+      useDeleteTransactionMutation() as unknown as MutationConfig<
+        void,
+        { readonly transactionId: string; readonly scope?: "occurrence" | "series" },
+        { readonly transaction?: TransactionRecord }
+      >;
+
+    await expect(
+      mutation.mutationFn({ transactionId: "tx-series", scope: "series" }),
+    ).resolves.toBeUndefined();
+
+    expect(mockDeleteTransaction).toHaveBeenCalledWith("tx-series", "series");
+  });
+
+  it("captures transaction.paid without PII when mark paid succeeds", async () => {
+    const paidTransaction: TransactionRecord = {
+      ...transactionFixture,
+      id: "tx-paid",
+      title: "Private paid title",
+      type: "expense",
+      source: "manual",
+      status: "paid",
+      paidAt: "2026-06-11",
+    };
+    mockMarkTransactionPaid.mockResolvedValue(paidTransaction);
+
+    const mutation =
+      useMarkTransactionPaidMutation() as unknown as MutationConfig<
+        TransactionRecord,
+        { readonly transactionId: string; readonly paidAt: string }
+      >;
+
+    await expect(
+      mutation.mutationFn({ transactionId: paidTransaction.id, paidAt: "2026-06-11" }),
+    ).resolves.toEqual(paidTransaction);
+    await mutation.onSuccess?.(
+      paidTransaction,
+      { transactionId: paidTransaction.id, paidAt: "2026-06-11" },
+      undefined,
+    );
+
+    expect(mockMarkTransactionPaid).toHaveBeenCalledWith("tx-paid", "2026-06-11");
+    expect(mockAnalyticsClient.capture).toHaveBeenCalledWith(
+      "transaction.paid",
+      expectedAnalyticsProperties(paidTransaction),
+    );
+    expect(JSON.stringify(mockAnalyticsClient.capture.mock.calls)).not.toContain(
+      paidTransaction.title,
     );
     expect(mockInvalidateQueries).toHaveBeenCalledWith({
       queryKey: queryKeys.transactions.root,

--- a/features/transactions/hooks/use-transaction-mutations.ts
+++ b/features/transactions/hooks/use-transaction-mutations.ts
@@ -10,6 +10,7 @@ import { queryKeys } from "@/core/query/query-keys";
 import type {
   CreateTransactionCommand,
   TransactionCollection,
+  TransactionDeleteScope,
   TransactionRecord,
   UpdateTransactionCommand,
 } from "@/features/transactions/contracts";
@@ -87,16 +88,28 @@ export const useUpdateTransactionMutation = () => {
   });
 };
 
+export interface DeleteTransactionVariables {
+  readonly transactionId: string;
+  /** "series" soft-deletes the whole recurring/installment series. */
+  readonly scope?: TransactionDeleteScope;
+}
+
 export const useDeleteTransactionMutation = () => {
   const analytics = useAnalytics();
   const queryClient = useQueryClient();
 
-  return useMutation<void, Error, string, DeleteTransactionMutationContext>({
-    mutationFn: (transactionId) => transactionsService.deleteTransaction(transactionId),
-    onMutate: (transactionId) => ({
+  return useMutation<
+    void,
+    Error,
+    DeleteTransactionVariables,
+    DeleteTransactionMutationContext
+  >({
+    mutationFn: ({ transactionId, scope }) =>
+      transactionsService.deleteTransaction(transactionId, scope ?? "occurrence"),
+    onMutate: ({ transactionId }) => ({
       transaction: findCachedTransaction(queryClient, transactionId),
     }),
-    onSuccess: async (_data, _transactionId, mutationContext) => {
+    onSuccess: async (_data, _variables, mutationContext) => {
       if (mutationContext?.transaction) {
         analytics.capture(
           "transaction.deleted",
@@ -104,6 +117,31 @@ export const useDeleteTransactionMutation = () => {
         );
       } else {
         analytics.capture("transaction.deleted");
+      }
+      await queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root });
+    },
+  });
+};
+
+export interface MarkTransactionPaidVariables {
+  readonly transactionId: string;
+  /** Effective payment date in YYYY-MM-DD format. */
+  readonly paidAt: string;
+}
+
+export const useMarkTransactionPaidMutation = () => {
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+
+  return useMutation<TransactionRecord, Error, MarkTransactionPaidVariables>({
+    mutationFn: ({ transactionId, paidAt }) =>
+      transactionsService.markTransactionPaid(transactionId, paidAt),
+    onSuccess: async (transaction) => {
+      if (transaction) {
+        analytics.capture(
+          "transaction.paid",
+          toTransactionAnalyticsProperties(transaction),
+        );
       }
       await queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root });
     },

--- a/features/transactions/hooks/use-transactions-query.test.ts
+++ b/features/transactions/hooks/use-transactions-query.test.ts
@@ -148,18 +148,23 @@ describe("transactions hooks", () => {
       onSuccess: () => Promise<void>;
     };
     const deleteMutation = useDeleteTransactionMutation() as unknown as {
-      mutationFn: (transactionId: string) => Promise<void>;
+      mutationFn: (input: {
+        readonly transactionId: string;
+        readonly scope?: "occurrence" | "series";
+      }) => Promise<void>;
       onSuccess: () => Promise<void>;
     };
 
     await expect(
       updateMutation.mutationFn({ transactionId: "txn-10", payload }),
     ).resolves.toEqual({ id: "txn-10" });
-    await expect(deleteMutation.mutationFn("txn-10")).resolves.toBeUndefined();
+    await expect(
+      deleteMutation.mutationFn({ transactionId: "txn-10" }),
+    ).resolves.toBeUndefined();
     await updateMutation.onSuccess();
     await deleteMutation.onSuccess();
     expect(mockUpdateTransaction).toHaveBeenCalledWith("txn-10", payload);
-    expect(mockDeleteTransaction).toHaveBeenCalledWith("txn-10");
+    expect(mockDeleteTransaction).toHaveBeenCalledWith("txn-10", "occurrence");
     expect(mockInvalidateQueries).toHaveBeenCalledTimes(2);
   });
 });

--- a/features/transactions/hooks/use-transactions-screen-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.test.ts
@@ -3,6 +3,7 @@ import { act, renderHook } from "@testing-library/react-native";
 import {
   useCreateTransactionMutation,
   useDeleteTransactionMutation,
+  useMarkTransactionPaidMutation,
   useUpdateTransactionMutation,
 } from "@/features/transactions/hooks/use-transaction-mutations";
 import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
@@ -16,12 +17,14 @@ jest.mock("@/features/transactions/hooks/use-transaction-mutations", () => ({
   useCreateTransactionMutation: jest.fn(),
   useUpdateTransactionMutation: jest.fn(),
   useDeleteTransactionMutation: jest.fn(),
+  useMarkTransactionPaidMutation: jest.fn(),
 }));
 
 const mockedUseQuery = jest.mocked(useTransactionsQuery);
 const mockedUseCreate = jest.mocked(useCreateTransactionMutation);
 const mockedUseUpdate = jest.mocked(useUpdateTransactionMutation);
 const mockedUseDelete = jest.mocked(useDeleteTransactionMutation);
+const mockedUseMarkPaid = jest.mocked(useMarkTransactionPaidMutation);
 
 const buildMutationStub = () => ({
   mutateAsync: jest.fn().mockResolvedValue(undefined),
@@ -82,14 +85,26 @@ const formValues = (
 let createStub: ReturnType<typeof buildMutationStub>;
 let updateStub: ReturnType<typeof buildMutationStub>;
 let deleteStub: ReturnType<typeof buildMutationStub>;
+let markPaidStub: ReturnType<typeof buildMutationStub>;
+
+beforeAll(() => {
+  jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+  jest.setSystemTime(new Date("2026-06-11T12:00:00"));
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
 
 beforeEach(() => {
   createStub = buildMutationStub();
   updateStub = buildMutationStub();
   deleteStub = buildMutationStub();
+  markPaidStub = buildMutationStub();
   mockedUseCreate.mockReturnValue(createStub as never);
   mockedUseUpdate.mockReturnValue(updateStub as never);
   mockedUseDelete.mockReturnValue(deleteStub as never);
+  mockedUseMarkPaid.mockReturnValue(markPaidStub as never);
 });
 
 describe("useTransactionsScreenController data projection", () => {
@@ -243,13 +258,49 @@ describe("useTransactionsScreenController mutations", () => {
     expect(result.current.formMode.kind).toBe("create");
   });
 
-  it("delete dispara deleteMutation pelo id", async () => {
+  it("delete dispara deleteMutation com escopo occurrence por padrao", async () => {
     const { result } = renderHook(() => useTransactionsScreenController());
     await act(async () => {
       await result.current.handleDelete("tx-9");
     });
-    expect(deleteStub.mutateAsync).toHaveBeenCalledWith("tx-9");
+    expect(deleteStub.mutateAsync).toHaveBeenCalledWith({
+      transactionId: "tx-9",
+      scope: "occurrence",
+    });
     expect(result.current.deletingTransactionId).toBeNull();
+  });
+
+  it("delete com scope series repassa o escopo para a mutation", async () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    await act(async () => {
+      await result.current.handleDelete("tx-9", "series");
+    });
+    expect(deleteStub.mutateAsync).toHaveBeenCalledWith({
+      transactionId: "tx-9",
+      scope: "series",
+    });
+  });
+
+  it("handleMarkPaid dispara mutation com data e limpa estado de paying", async () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    await act(async () => {
+      await result.current.handleMarkPaid("tx-3", "2026-06-11");
+    });
+    expect(markPaidStub.mutateAsync).toHaveBeenCalledWith({
+      transactionId: "tx-3",
+      paidAt: "2026-06-11",
+    });
+    expect(result.current.payingTransactionId).toBeNull();
+  });
+
+  it("handleMarkPaid captura erro em submitError", async () => {
+    markPaidStub.mutateAsync.mockRejectedValueOnce(new Error("pay boom"));
+    const { result } = renderHook(() => useTransactionsScreenController());
+    await act(async () => {
+      await result.current.handleMarkPaid("tx-3", "2026-06-11");
+    });
+    expect(result.current.submitError).toBeInstanceOf(Error);
+    expect(result.current.payingTransactionId).toBeNull();
   });
 
   it("dismissSubmitError limpa estado e reseta mutations", async () => {
@@ -266,5 +317,81 @@ describe("useTransactionsScreenController mutations", () => {
     });
     expect(result.current.submitError).toBeNull();
     expect(createStub.reset).toHaveBeenCalled();
+  });
+});
+
+describe("useTransactionsScreenController server-side filters", () => {
+  beforeEach(() => {
+    mockedUseQuery.mockReturnValue({
+      data: { transactions: [], pagination: { total: 0 } },
+    } as never);
+  });
+
+  it("usa o mes corrente como periodo default da query", () => {
+    renderHook(() => useTransactionsScreenController());
+    expect(mockedUseQuery).toHaveBeenLastCalledWith({
+      startDate: "2026-06-01",
+      endDate: "2026-06-30",
+    });
+  });
+
+  it("expoe label do periodo em pt-BR capitalizado", () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    expect(result.current.periodLabel).toBe("Junho de 2026");
+  });
+
+  it("envia type, status e tag na query quando filtros ativos", () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    act(() => {
+      result.current.setTypeFilter("income");
+      result.current.setStatusFilter("pending");
+      result.current.setTagFilter("tag-1");
+    });
+    expect(mockedUseQuery).toHaveBeenLastCalledWith({
+      type: "income",
+      status: "pending",
+      tagId: "tag-1",
+      startDate: "2026-06-01",
+      endDate: "2026-06-30",
+    });
+  });
+
+  it("navega para o mes anterior e seguinte ajustando o range", () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    act(() => {
+      result.current.goToPreviousMonth();
+    });
+    expect(mockedUseQuery).toHaveBeenLastCalledWith({
+      startDate: "2026-05-01",
+      endDate: "2026-05-31",
+    });
+    expect(result.current.periodLabel).toBe("Maio de 2026");
+
+    act(() => {
+      result.current.goToNextMonth();
+      result.current.goToNextMonth();
+    });
+    expect(mockedUseQuery).toHaveBeenLastCalledWith({
+      startDate: "2026-07-01",
+      endDate: "2026-07-31",
+    });
+  });
+
+  it("clearFilters reseta filtros e volta ao mes corrente", () => {
+    const { result } = renderHook(() => useTransactionsScreenController());
+    act(() => {
+      result.current.setStatusFilter("overdue");
+      result.current.setTagFilter("tag-9");
+      result.current.goToPreviousMonth();
+    });
+    act(() => {
+      result.current.clearFilters();
+    });
+    expect(result.current.statusFilter).toBe("all");
+    expect(result.current.tagFilter).toBe("all");
+    expect(mockedUseQuery).toHaveBeenLastCalledWith({
+      startDate: "2026-06-01",
+      endDate: "2026-06-30",
+    });
   });
 });

--- a/features/transactions/hooks/use-transactions-screen-controller.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.ts
@@ -1,9 +1,15 @@
 import { useMemo, useState } from "react";
 
-import type { TransactionRecord } from "@/features/transactions/contracts";
+import type {
+  TransactionDeleteScope,
+  TransactionListQuery,
+  TransactionRecord,
+  TransactionStatus,
+} from "@/features/transactions/contracts";
 import {
   useCreateTransactionMutation,
   useDeleteTransactionMutation,
+  useMarkTransactionPaidMutation,
   useUpdateTransactionMutation,
 } from "@/features/transactions/hooks/use-transaction-mutations";
 import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
@@ -13,6 +19,8 @@ import {
 } from "@/features/transactions/validators";
 
 export type TransactionsTypeFilter = "all" | "income" | "expense";
+export type TransactionsStatusFilter = "all" | TransactionStatus;
+export type TransactionsTagFilter = "all" | string;
 export type TransactionsViewMode = "list" | "calendar";
 
 export type TransactionFormMode =
@@ -34,12 +42,26 @@ export interface TransactionViewModel {
   readonly installmentNumber: number | null;
 }
 
+interface SelectedMonth {
+  readonly year: number;
+  readonly month: number;
+}
+
 export interface TransactionsScreenController {
   readonly transactionsQuery: ReturnType<typeof useTransactionsQuery>;
   readonly transactions: readonly TransactionViewModel[];
   readonly total: number;
   readonly typeFilter: TransactionsTypeFilter;
   readonly setTypeFilter: (filter: TransactionsTypeFilter) => void;
+  readonly statusFilter: TransactionsStatusFilter;
+  readonly setStatusFilter: (filter: TransactionsStatusFilter) => void;
+  readonly tagFilter: TransactionsTagFilter;
+  readonly setTagFilter: (filter: TransactionsTagFilter) => void;
+  readonly periodLabel: string;
+  readonly goToPreviousMonth: () => void;
+  readonly goToNextMonth: () => void;
+  readonly resetToCurrentMonth: () => void;
+  readonly clearFilters: () => void;
   readonly installmentGroupFilter: string | null;
   readonly viewMode: TransactionsViewMode;
   readonly setViewMode: (mode: TransactionsViewMode) => void;
@@ -48,11 +70,16 @@ export interface TransactionsScreenController {
   readonly submitError: unknown | null;
   readonly deletingTransactionId: string | null;
   readonly duplicatingTransactionId: string | null;
+  readonly payingTransactionId: string | null;
   readonly handleOpenCreate: () => void;
   readonly handleOpenEdit: (transaction: TransactionRecord) => void;
   readonly handleCloseForm: () => void;
   readonly handleSubmit: (values: CreateTransactionFormValues) => Promise<void>;
-  readonly handleDelete: (transactionId: string) => Promise<void>;
+  readonly handleDelete: (
+    transactionId: string,
+    scope?: TransactionDeleteScope,
+  ) => Promise<void>;
+  readonly handleMarkPaid: (transactionId: string, paidAt: string) => Promise<void>;
   readonly handleDuplicate: (transactionId: string) => Promise<void>;
   readonly handleShowInstallmentGroup: (installmentGroupId: string) => void;
   readonly handleClearInstallmentGroupFilter: () => void;
@@ -130,35 +157,153 @@ const buildSubmitPayload = (values: CreateTransactionFormValues) => ({
       : null,
 });
 
+const currentMonth = (): SelectedMonth => {
+  const now = new Date();
+  return { year: now.getFullYear(), month: now.getMonth() };
+};
+
+const shiftMonth = (selected: SelectedMonth, delta: number): SelectedMonth => {
+  const date = new Date(selected.year, selected.month + delta, 1);
+  return { year: date.getFullYear(), month: date.getMonth() };
+};
+
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, "0");
+  const day = `${date.getDate()}`.padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+const monthStartIso = (selected: SelectedMonth): string =>
+  toIsoDate(new Date(selected.year, selected.month, 1));
+
+const monthEndIso = (selected: SelectedMonth): string =>
+  toIsoDate(new Date(selected.year, selected.month + 1, 0));
+
+const formatMonthLabel = (selected: SelectedMonth): string => {
+  const label = new Intl.DateTimeFormat("pt-BR", {
+    month: "long",
+    year: "numeric",
+  }).format(new Date(selected.year, selected.month, 1));
+  return label.charAt(0).toUpperCase() + label.slice(1);
+};
+
+interface ListQueryInputs {
+  readonly typeFilter: TransactionsTypeFilter;
+  readonly statusFilter: TransactionsStatusFilter;
+  readonly tagFilter: TransactionsTagFilter;
+  readonly selectedMonth: SelectedMonth;
+}
+
 /**
- * Canonical controller for the transactions screen. Owns the create/edit
- * form state machine, the per-transaction delete tracker, the type filter
- * and the three mutations. The screen remains view-only.
+ * Builds the server-side list query from the active UI filters. Mirrors the
+ * web behaviour: "all" filters are omitted and the month range is always
+ * sent as start/end dates.
+ */
+const buildListQuery = ({
+  typeFilter,
+  statusFilter,
+  tagFilter,
+  selectedMonth,
+}: ListQueryInputs): TransactionListQuery => ({
+  ...(typeFilter !== "all" ? { type: typeFilter } : {}),
+  ...(statusFilter !== "all" ? { status: statusFilter } : {}),
+  ...(tagFilter !== "all" ? { tagId: tagFilter } : {}),
+  startDate: monthStartIso(selectedMonth),
+  endDate: monthEndIso(selectedMonth),
+});
+
+interface TransactionsFiltersState {
+  readonly typeFilter: TransactionsTypeFilter;
+  readonly setTypeFilter: (filter: TransactionsTypeFilter) => void;
+  readonly statusFilter: TransactionsStatusFilter;
+  readonly setStatusFilter: (filter: TransactionsStatusFilter) => void;
+  readonly tagFilter: TransactionsTagFilter;
+  readonly setTagFilter: (filter: TransactionsTagFilter) => void;
+  readonly periodLabel: string;
+  readonly goToPreviousMonth: () => void;
+  readonly goToNextMonth: () => void;
+  readonly resetToCurrentMonth: () => void;
+  readonly clearFilters: () => void;
+  readonly listQuery: TransactionListQuery;
+}
+
+/**
+ * Owns the server-side filter state (type, status, tag and monthly period)
+ * and derives the list query sent to the API.
+ */
+function useTransactionsFilters(): TransactionsFiltersState {
+  const [typeFilter, setTypeFilter] = useState<TransactionsTypeFilter>("all");
+  const [statusFilter, setStatusFilter] = useState<TransactionsStatusFilter>("all");
+  const [tagFilter, setTagFilter] = useState<TransactionsTagFilter>("all");
+  const [selectedMonth, setSelectedMonth] = useState<SelectedMonth>(currentMonth);
+  const listQuery = useMemo(
+    () => buildListQuery({ typeFilter, statusFilter, tagFilter, selectedMonth }),
+    [typeFilter, statusFilter, tagFilter, selectedMonth],
+  );
+
+  return {
+    typeFilter,
+    setTypeFilter,
+    statusFilter,
+    setStatusFilter,
+    tagFilter,
+    setTagFilter,
+    periodLabel: formatMonthLabel(selectedMonth),
+    goToPreviousMonth: () => setSelectedMonth((current) => shiftMonth(current, -1)),
+    goToNextMonth: () => setSelectedMonth((current) => shiftMonth(current, 1)),
+    resetToCurrentMonth: () => setSelectedMonth(currentMonth()),
+    clearFilters: () => {
+      setTypeFilter("all");
+      setStatusFilter("all");
+      setTagFilter("all");
+      setSelectedMonth(currentMonth());
+    },
+    listQuery,
+  };
+}
+
+interface TransactionsActionsArgs {
+  readonly formMode: TransactionFormMode;
+  readonly closeForm: () => void;
+  readonly transactionsQuery: ReturnType<typeof useTransactionsQuery>;
+}
+
+interface TransactionsActionsState {
+  readonly isSubmitting: boolean;
+  readonly submitError: unknown | null;
+  readonly deletingTransactionId: string | null;
+  readonly duplicatingTransactionId: string | null;
+  readonly payingTransactionId: string | null;
+  readonly clearSubmitError: () => void;
+  readonly handleSubmit: (values: CreateTransactionFormValues) => Promise<void>;
+  readonly handleDelete: (
+    transactionId: string,
+    scope?: TransactionDeleteScope,
+  ) => Promise<void>;
+  readonly handleMarkPaid: (transactionId: string, paidAt: string) => Promise<void>;
+  readonly handleDuplicate: (transactionId: string) => Promise<void>;
+  readonly dismissSubmitError: () => void;
+}
+
+/**
+ * Owns the four transaction mutations, the per-transaction action trackers
+ * and the shared submit error state for the transactions screen.
  */
 // eslint-disable-next-line max-lines-per-function
-export function useTransactionsScreenController(): TransactionsScreenController {
-  const transactionsQuery = useTransactionsQuery();
+function useTransactionsActions({
+  formMode,
+  closeForm,
+  transactionsQuery,
+}: TransactionsActionsArgs): TransactionsActionsState {
   const createMutation = useCreateTransactionMutation();
   const updateMutation = useUpdateTransactionMutation();
   const deleteMutation = useDeleteTransactionMutation();
-  const [formMode, setFormMode] = useState<TransactionFormMode>({ kind: "closed" });
+  const markPaidMutation = useMarkTransactionPaidMutation();
   const [submitError, setSubmitError] = useState<unknown | null>(null);
   const [deletingTransactionId, setDeletingTransactionId] = useState<string | null>(null);
   const [duplicatingTransactionId, setDuplicatingTransactionId] = useState<string | null>(null);
-  const [typeFilter, setTypeFilter] = useState<TransactionsTypeFilter>("all");
-  const [viewMode, setViewMode] = useState<TransactionsViewMode>("list");
-  const [installmentGroupFilter, setInstallmentGroupFilter] = useState<string | null>(null);
-
-  const transactions = useMemo<readonly TransactionViewModel[]>(() => {
-    const records = transactionsQuery.data?.transactions ?? [];
-    const installmentNumbers = buildInstallmentNumberMap(records);
-    return records
-      .filter((record) => matchesFilter(record.type, typeFilter))
-      .filter((record) =>
-        installmentGroupFilter ? record.installmentGroupId === installmentGroupFilter : true,
-      )
-      .map((record) => toViewModel(record, installmentNumbers.get(record.id) ?? null));
-  }, [installmentGroupFilter, transactionsQuery.data, typeFilter]);
+  const [payingTransactionId, setPayingTransactionId] = useState<string | null>(null);
 
   const handleSubmit = async (values: CreateTransactionFormValues): Promise<void> => {
     setSubmitError(null);
@@ -172,20 +317,38 @@ export function useTransactionsScreenController(): TransactionsScreenController 
       } else {
         await createMutation.mutateAsync(payload);
       }
-      setFormMode({ kind: "closed" });
+      closeForm();
     } catch (error) {
       setSubmitError(error);
     }
   };
 
-  const handleDelete = async (transactionId: string): Promise<void> => {
+  const handleDelete = async (
+    transactionId: string,
+    scope: TransactionDeleteScope = "occurrence",
+  ): Promise<void> => {
     setDeletingTransactionId(transactionId);
     try {
-      await deleteMutation.mutateAsync(transactionId);
+      await deleteMutation.mutateAsync({ transactionId, scope });
     } catch (error) {
       setSubmitError(error);
     } finally {
       setDeletingTransactionId(null);
+    }
+  };
+
+  const handleMarkPaid = async (
+    transactionId: string,
+    paidAt: string,
+  ): Promise<void> => {
+    setPayingTransactionId(transactionId);
+    setSubmitError(null);
+    try {
+      await markPaidMutation.mutateAsync({ transactionId, paidAt });
+    } catch (error) {
+      setSubmitError(error);
+    } finally {
+      setPayingTransactionId(null);
     }
   };
 
@@ -220,45 +383,102 @@ export function useTransactionsScreenController(): TransactionsScreenController 
   };
 
   return {
-    transactionsQuery,
-    transactions,
-    total: transactionsQuery.data?.pagination.total ?? 0,
-    typeFilter,
-    setTypeFilter,
-    installmentGroupFilter,
-    viewMode,
-    setViewMode,
-    formMode,
     isSubmitting: createMutation.isPending || updateMutation.isPending,
     submitError,
     deletingTransactionId,
     duplicatingTransactionId,
-    handleOpenCreate: () => {
-      setSubmitError(null);
-      setFormMode({ kind: "create" });
-    },
-    handleOpenEdit: (transaction) => {
-      setSubmitError(null);
-      setFormMode({ kind: "edit", transaction });
-    },
-    handleCloseForm: () => {
-      setSubmitError(null);
-      setFormMode({ kind: "closed" });
-    },
+    payingTransactionId,
+    clearSubmitError: () => setSubmitError(null),
     handleSubmit,
     handleDelete,
+    handleMarkPaid,
     handleDuplicate,
-    handleShowInstallmentGroup: (installmentGroupId) => {
-      setInstallmentGroupFilter(installmentGroupId);
-      setTypeFilter("expense");
-    },
-    handleClearInstallmentGroupFilter: () => {
-      setInstallmentGroupFilter(null);
-    },
     dismissSubmitError: () => {
       setSubmitError(null);
       createMutation.reset();
       updateMutation.reset();
+      markPaidMutation.reset();
     },
+  };
+}
+
+/**
+ * Canonical controller for the transactions screen. Owns the create/edit
+ * form state machine, server-side filters (type, status, tag and monthly
+ * period — web parity), the per-transaction delete/pay trackers and the
+ * mutations. The screen remains view-only.
+ */
+ 
+export function useTransactionsScreenController(): TransactionsScreenController {
+  const filters = useTransactionsFilters();
+  const transactionsQuery = useTransactionsQuery(filters.listQuery);
+  const [formMode, setFormMode] = useState<TransactionFormMode>({ kind: "closed" });
+  const [viewMode, setViewMode] = useState<TransactionsViewMode>("list");
+  const [installmentGroupFilter, setInstallmentGroupFilter] = useState<string | null>(null);
+  const actions = useTransactionsActions({
+    formMode,
+    closeForm: () => setFormMode({ kind: "closed" }),
+    transactionsQuery,
+  });
+
+  const transactions = useMemo<readonly TransactionViewModel[]>(() => {
+    const records = transactionsQuery.data?.transactions ?? [];
+    const installmentNumbers = buildInstallmentNumberMap(records);
+    return records
+      .filter((record) => matchesFilter(record.type, filters.typeFilter))
+      .filter((record) =>
+        installmentGroupFilter ? record.installmentGroupId === installmentGroupFilter : true,
+      )
+      .map((record) => toViewModel(record, installmentNumbers.get(record.id) ?? null));
+  }, [installmentGroupFilter, transactionsQuery.data, filters.typeFilter]);
+
+  return {
+    transactionsQuery,
+    transactions,
+    total: transactionsQuery.data?.pagination.total ?? 0,
+    typeFilter: filters.typeFilter,
+    setTypeFilter: filters.setTypeFilter,
+    statusFilter: filters.statusFilter,
+    setStatusFilter: filters.setStatusFilter,
+    tagFilter: filters.tagFilter,
+    setTagFilter: filters.setTagFilter,
+    periodLabel: filters.periodLabel,
+    goToPreviousMonth: filters.goToPreviousMonth,
+    goToNextMonth: filters.goToNextMonth,
+    resetToCurrentMonth: filters.resetToCurrentMonth,
+    clearFilters: filters.clearFilters,
+    installmentGroupFilter,
+    viewMode,
+    setViewMode,
+    formMode,
+    isSubmitting: actions.isSubmitting,
+    submitError: actions.submitError,
+    deletingTransactionId: actions.deletingTransactionId,
+    duplicatingTransactionId: actions.duplicatingTransactionId,
+    payingTransactionId: actions.payingTransactionId,
+    handleOpenCreate: () => {
+      actions.clearSubmitError();
+      setFormMode({ kind: "create" });
+    },
+    handleOpenEdit: (transaction) => {
+      actions.clearSubmitError();
+      setFormMode({ kind: "edit", transaction });
+    },
+    handleCloseForm: () => {
+      actions.clearSubmitError();
+      setFormMode({ kind: "closed" });
+    },
+    handleSubmit: actions.handleSubmit,
+    handleDelete: actions.handleDelete,
+    handleMarkPaid: actions.handleMarkPaid,
+    handleDuplicate: actions.handleDuplicate,
+    handleShowInstallmentGroup: (installmentGroupId) => {
+      setInstallmentGroupFilter(installmentGroupId);
+      filters.setTypeFilter("expense");
+    },
+    handleClearInstallmentGroupFilter: () => {
+      setInstallmentGroupFilter(null);
+    },
+    dismissSubmitError: actions.dismissSubmitError,
   };
 }

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -10,12 +10,18 @@ import { queryKeys } from "@/core/query/query-keys";
 import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
 import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
 import { FinancialCalendar } from "@/features/transactions/components/financial-calendar";
+import {
+  DeleteConfirmModal,
+  MarkPaidConfirmModal,
+  type DeleteTarget,
+  type MarkPaidTarget,
+} from "@/features/transactions/components/transaction-action-modals";
+import { TransactionFilters } from "@/features/transactions/components/transaction-filters";
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
 import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
 import {
   useTransactionsScreenController,
   type TransactionsScreenController,
-  type TransactionsTypeFilter,
   type TransactionsViewMode,
   type TransactionViewModel,
 } from "@/features/transactions/hooks/use-transactions-screen-controller";
@@ -40,14 +46,6 @@ const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
   cancelled: "default",
   postponed: "default",
 };
-
-const FILTER_LABELS: Record<TransactionsTypeFilter, string> = {
-  all: "Todas",
-  income: "Receitas",
-  expense: "Despesas",
-};
-
-const FILTER_ORDER: readonly TransactionsTypeFilter[] = ["all", "income", "expense"];
 
 const TRANSACTIONS_REFRESH_KEYS = [
   queryKeys.transactions.list(),
@@ -181,7 +179,18 @@ function FilterHeaderControls({
         listLabel={listLabel}
         calendarLabel={calendarLabel}
       />
-      <TransactionTypeFilter controller={controller} />
+      <TransactionFilters
+        typeFilter={controller.typeFilter}
+        onTypeFilterChange={controller.setTypeFilter}
+        statusFilter={controller.statusFilter}
+        onStatusFilterChange={controller.setStatusFilter}
+        tagFilter={controller.tagFilter}
+        onTagFilterChange={controller.setTagFilter}
+        periodLabel={controller.periodLabel}
+        onPreviousMonth={controller.goToPreviousMonth}
+        onNextMonth={controller.goToNextMonth}
+        onClearFilters={controller.clearFilters}
+      />
       <XStack gap="$2">
         <AppButton flex={1} onPress={controller.handleOpenCreate}>
           Nova transacao
@@ -197,22 +206,6 @@ function FilterHeaderControls({
       ) : null}
       <InstallmentGroupFilterNotice controller={controller} />
     </YStack>
-  );
-}
-
-function TransactionTypeFilter({ controller }: ControllerProps): ReactElement {
-  return (
-    <XStack gap="$2" flexWrap="wrap">
-      {FILTER_ORDER.map((filter) => (
-        <AppButton
-          key={filter}
-          tone={controller.typeFilter === filter ? "primary" : "secondary"}
-          onPress={() => controller.setTypeFilter(filter)}
-        >
-          {FILTER_LABELS[filter]}
-        </AppButton>
-      ))}
-    </XStack>
   );
 }
 
@@ -395,9 +388,12 @@ function TransactionsListCard({ controller }: ControllerProps): ReactElement {
   );
 }
 
+// eslint-disable-next-line max-lines-per-function
 function TransactionsList({ controller }: ControllerProps): ReactElement {
   const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
   const [detailTransactionId, setDetailTransactionId] = useState<string | null>(null);
+  const [payTarget, setPayTarget] = useState<MarkPaidTarget | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
   const detailTransaction = useMemo(
     () => controller.transactions.find((item) => item.id === detailTransactionId) ?? null,
     [controller.transactions, detailTransactionId],
@@ -417,9 +413,26 @@ function TransactionsList({ controller }: ControllerProps): ReactElement {
 
   const handleDelete = useCallback(
     (txId: string): void => {
-      void controller.handleDelete(txId);
+      const tx = controller.transactions.find((item) => item.id === txId);
+      if (tx) {
+        setDeleteTarget({
+          id: tx.id,
+          title: tx.title,
+          isSeries: tx.isRecurring || tx.isInstallment,
+        });
+      }
     },
-    [controller],
+    [controller.transactions],
+  );
+
+  const handleMarkPaid = useCallback(
+    (txId: string): void => {
+      const tx = controller.transactions.find((item) => item.id === txId);
+      if (tx) {
+        setPayTarget({ id: tx.id, title: tx.title });
+      }
+    },
+    [controller.transactions],
   );
 
   const handleDuplicate = useCallback(
@@ -443,19 +456,23 @@ function TransactionsList({ controller }: ControllerProps): ReactElement {
         tx={item}
         isDeleting={controller.deletingTransactionId === item.id}
         isDuplicating={controller.duplicatingTransactionId === item.id}
+        isPaying={controller.payingTransactionId === item.id}
         onDetails={handleDetails}
         onEdit={handleEdit}
         onDelete={handleDelete}
+        onMarkPaid={handleMarkPaid}
         onDuplicate={handleDuplicate}
       />
     ),
     [
       controller.deletingTransactionId,
       controller.duplicatingTransactionId,
+      controller.payingTransactionId,
       handleDelete,
       handleDetails,
       handleDuplicate,
       handleEdit,
+      handleMarkPaid,
     ],
   );
 
@@ -477,6 +494,24 @@ function TransactionsList({ controller }: ControllerProps): ReactElement {
         onClose={handleCloseDetails}
         onShowInstallmentGroup={controller.handleShowInstallmentGroup}
       />
+      <MarkPaidConfirmModal
+        target={payTarget}
+        isSubmitting={controller.payingTransactionId !== null}
+        onConfirm={(txId, paidAt) => {
+          void controller.handleMarkPaid(txId, paidAt);
+          setPayTarget(null);
+        }}
+        onClose={() => setPayTarget(null)}
+      />
+      <DeleteConfirmModal
+        target={deleteTarget}
+        isDeleting={controller.deletingTransactionId !== null}
+        onConfirm={(txId, scope) => {
+          void controller.handleDelete(txId, scope);
+          setDeleteTarget(null);
+        }}
+        onClose={() => setDeleteTarget(null)}
+      />
     </>
   );
 }
@@ -493,22 +528,28 @@ interface TransactionRowProps {
   readonly tx: TransactionViewModel;
   readonly isDeleting: boolean;
   readonly isDuplicating: boolean;
+  readonly isPaying: boolean;
   readonly onDetails: (txId: string) => void;
   readonly onEdit: (txId: string) => void;
   readonly onDelete: (txId: string) => void;
+  readonly onMarkPaid: (txId: string) => void;
   readonly onDuplicate: (txId: string) => void;
 }
 
+ 
 const TransactionRow = function TransactionRow({
   tx,
   isDeleting,
   isDuplicating,
+  isPaying,
   onDetails,
   onEdit,
   onDelete,
+  onMarkPaid,
   onDuplicate,
 }: TransactionRowProps): ReactElement {
   const installmentLabel = getInstallmentLabel(tx);
+  const isBusy = isDeleting || isDuplicating || isPaying;
   const handleDetails = useCallback(() => {
     onDetails(tx.id);
   }, [onDetails, tx.id]);
@@ -520,6 +561,10 @@ const TransactionRow = function TransactionRow({
   const handleDelete = useCallback(() => {
     onDelete(tx.id);
   }, [onDelete, tx.id]);
+
+  const handleMarkPaid = useCallback(() => {
+    onMarkPaid(tx.id);
+  }, [onMarkPaid, tx.id]);
 
   const handleDuplicate = useCallback(() => {
     onDuplicate(tx.id);
@@ -552,24 +597,21 @@ const TransactionRow = function TransactionRow({
         }
       />
       <XStack gap="$2" flexWrap="wrap">
-        <AppButton
-          tone="secondary"
-          onPress={handleDetails}
-          disabled={isDeleting || isDuplicating}
-        >
+        <AppButton tone="secondary" onPress={handleDetails} disabled={isBusy}>
           Detalhes
         </AppButton>
-        <AppButton tone="secondary" onPress={handleEdit} disabled={isDeleting || isDuplicating}>
+        {tx.status !== "paid" ? (
+          <AppButton onPress={handleMarkPaid} disabled={isBusy}>
+            {isPaying ? "Pagando..." : "Pagar"}
+          </AppButton>
+        ) : null}
+        <AppButton tone="secondary" onPress={handleEdit} disabled={isBusy}>
           Editar
         </AppButton>
-        <AppButton
-          tone="secondary"
-          onPress={handleDuplicate}
-          disabled={isDeleting || isDuplicating}
-        >
+        <AppButton tone="secondary" onPress={handleDuplicate} disabled={isBusy}>
           {isDuplicating ? "Duplicando..." : "Duplicar"}
         </AppButton>
-        <AppButton tone="secondary" onPress={handleDelete} disabled={isDeleting || isDuplicating}>
+        <AppButton tone="secondary" onPress={handleDelete} disabled={isBusy}>
           {isDeleting ? "Excluindo..." : "Excluir"}
         </AppButton>
       </XStack>

--- a/features/transactions/services/transactions-service.test.ts
+++ b/features/transactions/services/transactions-service.test.ts
@@ -500,3 +500,61 @@ describe("transactionsService - error paths and trash", () => {
     );
   });
 });
+
+describe("transactionsService - mark paid + delete scope", () => {
+  it("markTransactionPaid faz PATCH parcial com status paid e paid_at", async () => {
+    const client = createClient();
+    client.patch.mockResolvedValue({
+      data: {
+        data: {
+          transaction: buildTransactionPayload({
+            status: "paid",
+            paid_at: "2026-06-11",
+          }),
+        },
+      },
+    });
+
+    const service = createTransactionsService(client as unknown as AxiosInstance);
+    const result = await service.markTransactionPaid("tx-1", "2026-06-11");
+
+    expect(client.patch).toHaveBeenCalledWith("/transactions/tx-1", {
+      status: "paid",
+      paid_at: "2026-06-11",
+    });
+    expect(result.status).toBe("paid");
+    expect(result.paidAt).toBe("2026-06-11");
+  });
+
+  it("markTransactionPaid lanca erro quando payload nao volta", async () => {
+    const client = createClient();
+    client.patch.mockResolvedValue({ data: { data: {} } });
+
+    const service = createTransactionsService(client as unknown as AxiosInstance);
+    await expect(service.markTransactionPaid("tx-1", "2026-06-11")).rejects.toThrow(
+      "Transacao paga veio sem payload.",
+    );
+  });
+
+  it("deleteTransaction com scope series envia query param scope", async () => {
+    const client = createClient();
+    client.delete.mockResolvedValue({ data: {} });
+
+    const service = createTransactionsService(client as unknown as AxiosInstance);
+    await service.deleteTransaction("tx-9", "series");
+
+    expect(client.delete).toHaveBeenCalledWith("/transactions/tx-9", {
+      params: { scope: "series" },
+    });
+  });
+
+  it("deleteTransaction com scope occurrence mantem chamada sem params", async () => {
+    const client = createClient();
+    client.delete.mockResolvedValue({ data: {} });
+
+    const service = createTransactionsService(client as unknown as AxiosInstance);
+    await service.deleteTransaction("tx-9", "occurrence");
+
+    expect(client.delete).toHaveBeenCalledWith("/transactions/tx-9");
+  });
+});

--- a/features/transactions/services/transactions-service.ts
+++ b/features/transactions/services/transactions-service.ts
@@ -7,6 +7,7 @@ import type {
   DeletedTransactionListResponse,
   DeletedTransactionRecord,
   TransactionCollection,
+  TransactionDeleteScope,
   TransactionListQuery,
   TransactionPagination,
   TransactionRecord,
@@ -309,12 +310,36 @@ export const createTransactionsService = (client: AxiosInstance) => {
       );
       return extractTransactionFromMutation(response.data);
     },
-    deleteTransaction: async (transactionId: string): Promise<void> => {
-      await client.delete(
-        resolveApiContractPath(apiContractMap.transactionDelete.path, {
+    deleteTransaction: async (
+      transactionId: string,
+      scope: TransactionDeleteScope = "occurrence",
+    ): Promise<void> => {
+      const path = resolveApiContractPath(apiContractMap.transactionDelete.path, {
+        transaction_id: transactionId,
+      });
+      if (scope === "series") {
+        await client.delete(path, { params: { scope: "series" } });
+        return;
+      }
+      await client.delete(path);
+    },
+    markTransactionPaid: async (
+      transactionId: string,
+      paidAt: string,
+    ): Promise<TransactionRecord> => {
+      const response = await client.patch(
+        resolveApiContractPath(apiContractMap.transactionUpdate.path, {
           transaction_id: transactionId,
         }),
+        { status: "paid", paid_at: paidAt },
       );
+      const payload = unwrapEnvelopeData<{ readonly transaction?: TransactionPayload }>(
+        response.data,
+      );
+      if (!payload.transaction) {
+        throw new Error("Transacao paga veio sem payload.");
+      }
+      return mapTransaction(payload.transaction);
     },
     getSummary: (query: TransactionSummaryQuery) =>
       getSummaryRequest(client, query),


### PR DESCRIPTION
## Summary

Paridade web↔app na tela de transações (auditoria Frente 0 / Frente A):

- **Filtros server-side** espelhando a web: tipo, status (pendente/pago/vencido/cancelado/adiado), tag e **período mensal** com navegação ← mês → (default = mês corrente, como na web). Filtros "all" são omitidos da query.
- **Marcar como pago**: novo `markTransactionPaid` no service (`PATCH /transactions/{id}` com `{status:"paid", paid_at}`, mesmo contrato da web), mutation com analytics `transaction.paid` (sem PII) e modal de confirmação com data editável (default hoje).
- **Exclusão por escopo**: `DELETE /transactions/{id}?scope=series` para excluir série inteira de recorrência/parcelamento; modal oferece "somente esta" vs "série inteira" quando aplicável (paridade com a web). Delete agora pede confirmação (antes era imediato).
- Componentes novos: `transaction-filters.tsx` e `transaction-action-modals.tsx`, com testes.

### Notas da auditoria (revalidação dos findings)
- **Lixeira/restore**: já estava 100% implementada (`listDeleted` + `restoreTransaction` + controller) — finding da auditoria estava errado; nada a fazer.
- **Filtro por conta/cartão**: a web **não** tem esses filtros na UI (só tipo/status/data/tag) — contrato já suporta (`TransactionListQuery`), ficam fora para manter paridade exata.

### Testes
- TDD em service/mutations/controller (RED→GREEN documentado nos commits).
- `npm run quality-check` verde: 310 suítes, 1900 testes, coverage global 94,22% (≥85%).

## Refs
Closes #500