### PR TITLE
chore(release): Node 24 actions + workflow OTA + runbook do ciclo alfa

### DIFF
--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -1,0 +1,70 @@
+name: OTA Update (EAS Update)
+
+# Publica um update over-the-air (JS-only) no canal escolhido, sem consumir
+# créditos de build do EAS. Para mudanças nativas (nova dependência nativa,
+# bump de version/runtimeVersion), use o workflow Store Release.
+# Regras do ciclo em docs/release-process.md.
+
+on:
+  workflow_dispatch:
+    inputs:
+      channel:
+        description: "Canal do EAS Update"
+        required: true
+        default: preview
+        type: choice
+        options:
+          - preview
+          - production
+      message:
+        description: "Mensagem do update (default: título do último commit)"
+        required: false
+        type: string
+
+jobs:
+  publish-update:
+    name: Publish OTA update
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Validate EXPO_TOKEN
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "${EXPO_TOKEN:-}" ]; then
+            echo "Missing required secret: EXPO_TOKEN" >&2
+            exit 1
+          fi
+
+      - name: Setup Expo
+        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
+        with:
+          eas-version: 16.13.0
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Publish update
+        env:
+          CHANNEL: ${{ inputs.channel }}
+          MESSAGE: ${{ inputs.message }}
+        run: |
+          set -euo pipefail
+          if [ -z "${MESSAGE:-}" ]; then
+            MESSAGE="$(git log -1 --pretty=%s)"
+          fi
+          eas update \
+            --channel "$CHANNEL" \
+            --message "$MESSAGE" \
+            --non-interactive

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -40,10 +40,10 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version-file: .nvmrc
           cache: npm

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,88 +1,106 @@
-# Release process — internal beta
+# Release process — ciclo alfa (Google Play internal + TestFlight)
 
-This runbook covers the first real internal beta target: TestFlight for iOS
-and EAS internal APK for Android. Google Play Internal Testing remains pending
-until Play Console and the service account are configured.
+Runbook canônico do ciclo de publicação do app durante o alfa.
+Épico de referência: [#518](https://github.com/italofelipe/auraxis-app/issues/518).
 
-## Required secrets
+## Visão geral do ciclo
 
-Configure these before creating preview or production builds:
+```
+mudança JS-only  ──────────────► OTA via EAS Update (workflow ota-update.yml)
+                                  └─ não gasta build credits, chega em minutos
 
-```bash
-eas secret:create --scope project --name EXPO_TOKEN --value "<expo-token>" --type string
-eas secret:create --scope project --name EXPO_PUBLIC_SENTRY_DSN --value "<dsn>" --type string
-eas secret:create --scope project --name EXPO_PUBLIC_POSTHOG_API_KEY --value "<phc-token>" --type string
-eas secret:create --scope project --name EXPO_PUBLIC_APP_ENV --value "preview" --type string
+mudança nativa / bump version ─► build + submit (workflow store-release.yml)
+                                  ├─ Android → Play internal testing (draft)
+                                  └─ iOS → TestFlight
 ```
 
-GitHub Actions also needs `EXPO_TOKEN`. App Store submission needs
-`ASC_APP_ID`. Android Play submission remains blocked until Play Console exists.
+Gatilhos do `store-release.yml`:
 
-## Internal build
+- **Tag `v*`** (criada pelo release-please ao mergear o PR de release):
+  build `production` nas duas plataformas com `--auto-submit`.
+- **Manual (`workflow_dispatch`)**: escolhe plataforma, profile e auto-submit.
+
+Gatilho do `ota-update.yml`: somente manual (`workflow_dispatch`), escolhendo
+canal `preview` ou `production` — publica o estado JS do commit checked-out.
+
+## OTA vs build novo — regra de decisão
+
+Use **OTA** (EAS Update) apenas para mudanças de JavaScript/TypeScript, assets,
+copy, i18n e feature flags.
+
+Exige **build nativo novo** qualquer mudança em: dependência com código nativo,
+plugin Expo, permissão, `app.json` (bundle id, plist, manifest, ícones, splash),
+`eas.json`, ou bump de `version`.
+
+> **Atenção — `runtimeVersion.policy: appVersion`**: um OTA publicado só
+> alcança builds instalados com a **mesma `version`** do `app.json`. Depois de
+> um release que bumpou a version, builds antigos não recebem mais OTA — eles
+> precisam atualizar pela loja.
+
+## Variáveis de ambiente (EAS)
+
+As envs de runtime ficam no **EAS environment** (`eas env:list --environment
+production|preview`), não em secrets do GitHub. Matriz mínima de produção
+(issue [#522](https://github.com/italofelipe/auraxis-app/issues/522)):
+
+| Var | Valor (produção) |
+|-----|------------------|
+| `EXPO_PUBLIC_API_URL` | `https://api.auraxis.com.br` |
+| `EXPO_PUBLIC_APP_ENV` | `production` |
+| `EXPO_PUBLIC_SENTRY_DSN` | DSN do projeto Sentry `auraxis-app` |
+| `EXPO_PUBLIC_POSTHOG_API_KEY` / `EXPO_PUBLIC_POSTHOG_HOST` | key/host do PostHog |
+| `SENTRY_AUTH_TOKEN` | secret — upload de source maps no build |
+| `APPLE_TEAM_ID`, `ASC_*` (5 vars) | submit iOS (já configuradas) |
+| `GOOGLE_SERVICE_ACCOUNT` | secret file — submit Android (setup no guia do Play) |
+
+GitHub Actions precisa apenas de `EXPO_TOKEN`.
+
+## Fluxos
+
+### Release completo (build + lojas)
+
+1. Mergear o PR do release-please (cria a tag `v*`) — ou disparar
+   `store-release.yml` manualmente.
+2. Acompanhar o build no [dashboard do EAS](https://expo.dev/accounts/italofelipe/projects/auraxis-app/builds).
+3. Android: o submit entra como **draft** no internal track — promover no Play
+   Console. iOS: o build aparece no TestFlight após o processamento.
+
+### OTA (JS-only)
+
+1. Garantir que a mudança está mergeada em `main`.
+2. Actions → "OTA Update (EAS Update)" → Run workflow → canal `production`
+   (ou `preview` para validar antes em build interno).
+3. Verificar com `eas update:list --channel <canal> --limit 3`.
+4. Apps instalados aplicam o update no segundo relaunch.
+
+### Rollback de OTA
 
 ```bash
-eas build --profile preview --platform ios
-eas build --profile preview --platform android
+eas update:list --channel production --limit 10
 ```
 
-Expected outputs:
+Republicar o estado JS anterior (checkout do commit bom + `eas update`) ou usar
+o rollback do dashboard EAS no branch/canal afetado. Registrar o update ID no
+incident note e confirmar que um dispositivo instalado recebe o rollback.
 
-- iOS: install via TestFlight once the build is uploaded and processed.
-- Android: install the EAS internal APK directly on the Samsung test device.
+## Smoke checklist (alfa)
 
-The current `eas.json` preview profile already uses internal distribution and
-Android APK. Do not modify `app.json` or `eas.json` without explicit approval.
-
-## OTA updates
-
-Use OTA only for JavaScript, TypeScript, assets, copy, and feature-flag changes.
-Any native dependency, Expo plugin, permission, bundle identifier, build number,
-Android manifest, iOS plist, or store capability change needs a new native build.
-
-Preview publish:
-
-```bash
-eas update --channel preview --message "internal beta smoke"
-```
-
-Production publish after store builds are installed:
-
-```bash
-eas update --channel production --message "production hotfix"
-```
-
-Channel mapping is still pending native config approval. Until `app.json` /
-`eas.json` are explicitly updated with update channels, validate the target
-channel in EAS before publishing.
-
-## Rollback
-
-Find the last known-good update:
-
-```bash
-eas update:list --channel preview --limit 10
-```
-
-Republish the previous JS state or use EAS dashboard rollback for the affected
-branch/channel. Record the rollback update ID in the incident note and verify
-that the installed preview build receives it after relaunch.
-
-## Internal smoke checklist
-
-- Login, dashboard, monthly period switch, transaction create/delete/restore.
-- Goal create and simulation.
-- Tools hub opens one calculator.
-- Subscription screen opens hosted checkout in preview; store checkout must fail
-  safely until StoreKit/Google Play Billing are configured.
-- Privacy center toggles analytics opt-out and PostHog stops receiving events.
-- Push opt-in screen opens and handles denied/unavailable permission states.
-- Deep links: valid private link routes after login; invalid link falls back.
-- Sentry receives a test error without PII.
-- PostHog receives screen and product events without email/CPF/token/raw amounts.
+- Cadastro de conta nova + login + logout.
+- Dashboard carrega contra `api.auraxis.com.br` (nunca localhost — guard #521).
+- Transação: criar/excluir/restaurar; troca de período mensal.
+- Meta: criar e simular.
+- Assinatura abre hosted checkout; store checkout falha com segurança até
+  StoreKit/Play Billing serem configurados.
+- Privacy center: opt-out de analytics interrompe eventos PostHog.
+- Push opt-in trata permissão negada/indisponível.
+- Deep links: link privado roteia após login; link inválido cai no fallback.
+- Sentry recebe erro de teste sem PII.
+- PostHog recebe eventos de tela/produto sem email/CPF/token/valores brutos.
+- OTA de teste aplicado em dispositivo com o build instalado.
 
 ## Maestro
 
-Local smoke:
+Smoke local:
 
 ```bash
 maestro test .maestro/01_login.yaml
@@ -94,6 +112,12 @@ maestro test .maestro/09_notification_preferences_smoke.yaml
 maestro test .maestro/05_logout.yaml
 ```
 
-The scheduled CI workflow still needs human-approved workflow changes before it
-can fail the build on critical Maestro smoke regressions and add Android
-artifacts.
+## Troubleshooting
+
+| Sintoma | Causa provável | Ação |
+|---------|----------------|------|
+| Build iOS falha com "Distribution Certificate is not validated for non-interactive builds" | Cert nunca validado interativamente | Italo roda `npx eas-cli credentials` (iOS) uma vez |
+| Build falha com warning de channel sem expo-updates | Pacote `expo-updates` ausente | Issue #519 |
+| Submit Android falha por credencial | `GOOGLE_SERVICE_ACCOUNT` ausente/sem permissão | Guia `docs/runbooks/googleplay-setup-italo.md` |
+| OTA não chega no dispositivo | `version` do build ≠ version do update (`runtimeVersion: appVersion`) | Publicar build novo pela loja |
+| App de produção aponta para localhost | EAS env `EXPO_PUBLIC_API_URL` ausente | Issue #522 / guard #521 |


### PR DESCRIPTION
Closes #520

Parte do épico #518 (Fase 1 — pipeline & DX para o alfa).

## Mudanças

- **`store-release.yml`**: bump `actions/checkout` v4→v5 e `actions/setup-node` v4→v5 (pins por SHA) — elimina o warning de Node 20, que vira bloqueio forçado em 16/jun/2026. `ci.yml` e demais workflows serão bumpados junto do fix #510 para evitar conflito de arquivos entre frentes.
- **`ota-update.yml` (novo)**: `workflow_dispatch` que publica EAS Update no canal `preview` ou `production` — mudanças JS-only chegam aos testadores sem gastar build credits. Funcional após o merge de #519 (expo-updates).
- **`docs/release-process.md`**: reescrito para o ciclo alfa aprovado — regra OTA vs build novo, gotcha do `runtimeVersion.policy: appVersion`, matriz de envs EAS, fluxos de release/OTA/rollback, smoke checklist e troubleshooting (incluindo a causa da falha das tags v1.6.x). Remove conteúdo stale (Play Console "pendente", `eas secret:create` deprecado, channels "não aprovados").

## Verificação

- YAML dos dois workflows validado (yaml.safe_load)
- Sem mudança de código de app — quality-check não afetado
- `ota-update.yml` será validado end-to-end na Fase 5 do épico (após #519 e envs #522)