### PR TITLE
fix(release): submit usa EAS credentials service (env vars não existem no runner)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -35,16 +35,12 @@
   "submit": {
     "production": {
       "android": {
-        "serviceAccountKeyPath": "@secret:GOOGLE_SERVICE_ACCOUNT",
         "track": "internal",
         "releaseStatus": "draft"
       },
       "ios": {
-        "ascAppId": "${ASC_APP_ID}",
-        "appleTeamId": "${APPLE_TEAM_ID}",
-        "ascApiKeyPath": "@secret:ASC_API_KEY_FILE",
-        "ascApiKeyId": "${ASC_API_KEY_ID}",
-        "ascApiKeyIssuerId": "${ASC_API_KEY_ISSUER_ID}"
+        "ascAppId": "6772551270",
+        "appleTeamId": "725XG6A2A7"
       }
     }
   }


### PR DESCRIPTION
Closes #527

Parte do épico #518 (Fase 5). Causa da falha do store-release da tag v1.7.0 (run 27383980689): `${ASC_*}` no `eas.json` interpolam do ambiente do runner do GitHub, onde não existem (EAS env secrets só materializam no builder).

## Mudanças

- `submit.production.ios`: literais `ascAppId: "6772551270"` + `appleTeamId: "725XG6A2A7"` (identificadores não-secretos) e campos de API key removidos — o `eas submit` resolve a App Store Connect API Key pelo **credentials service**
- `submit.production.android`: `serviceAccountKeyPath` removido — a Google Service Account key também virá do credentials service quando cadastrada (Parte C do guia do Play)

## Dependência operacional (Italo, 1 comando)

`eas credentials` → iOS → production → **App Store Connect: Manage your API Key** → Set up — o EAS cria a key via login Apple e armazena para submissions (a key antiga YD4F4C9726 não tem .p8 recuperável).

## Verificação

- `eas.json` JSON válido; `check-runtime-release-governance` OK
- Validação end-to-end: `eas submit -p ios --id 97cf7906` após a key cadastrada (build da v1.7.0 em andamento)