### PR TITLE
fix(errors): detalhes técnicos nos error boundaries de tela cheia (diagnóstico alfa)

### DIFF
--- a/core/errors/app-error-boundary.test.tsx
+++ b/core/errors/app-error-boundary.test.tsx
@@ -61,4 +61,39 @@ describe("AppErrorBoundary", () => {
       }),
     );
   });
+
+  it("exibe detalhes tecnicos da excecao em boundary de tela cheia", () => {
+    const BrokenComponent = (): ReactElement => {
+      throw new Error("Cannot read property 'length' of undefined");
+    };
+
+    const { getByText } = render(
+      <TestProviders>
+        <AppErrorBoundary scope="public-layout" presentation="screen">
+          <BrokenComponent />
+        </AppErrorBoundary>
+      </TestProviders>,
+    );
+
+    expect(getByText("Detalhes tecnicos")).toBeTruthy();
+    expect(
+      getByText(/Cannot read property 'length' of undefined/u),
+    ).toBeTruthy();
+  });
+
+  it("nao exibe detalhes tecnicos em boundary inline", () => {
+    const BrokenComponent = (): ReactElement => {
+      throw new Error("Boom inline");
+    };
+
+    const { queryByText } = render(
+      <TestProviders>
+        <AppErrorBoundary scope="widget" presentation="inline">
+          <BrokenComponent />
+        </AppErrorBoundary>
+      </TestProviders>,
+    );
+
+    expect(queryByText("Detalhes tecnicos")).toBeNull();
+  });
 });

--- a/core/errors/app-error-boundary.tsx
+++ b/core/errors/app-error-boundary.tsx
@@ -1,5 +1,4 @@
-import type { ErrorInfo, PropsWithChildren, ReactElement } from "react";
-import { Component } from "react";
+import { Component, type ErrorInfo, type PropsWithChildren, type ReactElement } from "react";
 
 import { runtimeLogger } from "@/core/telemetry/domain-loggers";
 import { AppScreen } from "@/shared/components/app-screen";
@@ -16,13 +15,13 @@ export interface AppErrorBoundaryProps extends PropsWithChildren {
   readonly fallbackDescription?: string;
   readonly resetLabel?: string;
   readonly onReset?: () => void;
-  readonly resetKeys?: ReadonlyArray<unknown>;
+  readonly resetKeys?: readonly unknown[];
   readonly testID?: string;
 }
 
 const haveResetKeysChanged = (
-  previousKeys: ReadonlyArray<unknown> = [],
-  nextKeys: ReadonlyArray<unknown> = [],
+  previousKeys: readonly unknown[] = [],
+  nextKeys: readonly unknown[] = [],
 ): boolean => {
   if (previousKeys.length !== nextKeys.length) {
     return true;
@@ -81,6 +80,10 @@ export class AppErrorBoundary extends Component<
         fallbackDescription={this.props.fallbackDescription}
         actionLabel={this.props.resetLabel}
         onAction={this.handleReset}
+        // Full-screen boundaries expose the original exception during the
+        // alpha: with remote crash reporting deferred (#522), the device
+        // screen is the only channel to diagnose store-build-only failures.
+        showTechnicalDetails={this.props.presentation === "screen"}
         testID={this.props.testID}
       />
     );

--- a/shared/components/app-error-notice.test.tsx
+++ b/shared/components/app-error-notice.test.tsx
@@ -56,6 +56,48 @@ describe("AppErrorNotice", () => {
     );
   });
 
+  it("exibe detalhes tecnicos sem stack para Error sem stack", () => {
+    const error = new Error("sem stack");
+    error.stack = "";
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppErrorNotice error={error} showTechnicalDetails testID="notice" />
+      </AppProviders>,
+    );
+
+    expect(getByTestId("notice-technical-details").props.children).toBe(
+      "Error: sem stack",
+    );
+  });
+
+  it("serializa erros nao-Error como JSON nos detalhes tecnicos", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppErrorNotice
+          error={{ code: "E_WEIRD", status: 500 }}
+          showTechnicalDetails
+          testID="notice"
+        />
+      </AppProviders>,
+    );
+
+    expect(getByTestId("notice-technical-details").props.children).toContain(
+      "E_WEIRD",
+    );
+  });
+
+  it("degrada para String() quando o erro nao e serializavel", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const { getByText } = render(
+      <AppProviders>
+        <AppErrorNotice error={circular} showTechnicalDetails />
+      </AppProviders>,
+    );
+
+    expect(getByText("[object Object]")).toBeTruthy();
+  });
+
   it("nao exibe detalhes tecnicos por padrao", () => {
     const { queryByText } = render(
       <AppProviders>

--- a/shared/components/app-error-notice.test.tsx
+++ b/shared/components/app-error-notice.test.tsx
@@ -27,6 +27,45 @@ describe("AppErrorNotice", () => {
     expect(handleRetry).toHaveBeenCalledTimes(1);
   });
 
+  it("exibe detalhes tecnicos com a mensagem da excecao original", () => {
+    const { getByText, getByTestId } = render(
+      <AppProviders>
+        <AppErrorNotice
+          error={new Error("Cannot read property 'foo' of undefined")}
+          showTechnicalDetails
+          testID="notice"
+        />
+      </AppProviders>,
+    );
+
+    expect(getByText("Detalhes tecnicos")).toBeTruthy();
+    expect(getByTestId("notice-technical-details").props.children).toContain(
+      "Cannot read property 'foo' of undefined",
+    );
+  });
+
+  it("exibe detalhes tecnicos legiveis para erro nao-Error", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppErrorNotice error="string failure" showTechnicalDetails testID="notice" />
+      </AppProviders>,
+    );
+
+    expect(getByTestId("notice-technical-details").props.children).toContain(
+      "string failure",
+    );
+  });
+
+  it("nao exibe detalhes tecnicos por padrao", () => {
+    const { queryByText } = render(
+      <AppProviders>
+        <AppErrorNotice error={new Error("Boom")} />
+      </AppProviders>,
+    );
+
+    expect(queryByText("Detalhes tecnicos")).toBeNull();
+  });
+
   it("permite copy contextualizada para o fluxo atual", () => {
     const { getByText } = render(
       <AppProviders>

--- a/shared/components/app-error-notice.tsx
+++ b/shared/components/app-error-notice.tsx
@@ -1,5 +1,7 @@
 import type { ReactElement } from "react";
 
+import { Paragraph } from "tamagui";
+
 import { createAppErrorState } from "@/core/errors/app-error";
 import { AppButton } from "@/shared/components/app-button";
 import { AppStack } from "@/shared/components/app-stack";
@@ -13,13 +15,42 @@ export interface AppErrorNoticeProps {
   readonly onAction?: () => void;
   readonly secondaryActionLabel?: string;
   readonly onSecondaryAction?: () => void;
+  readonly showTechnicalDetails?: boolean;
   readonly testID?: string;
 }
+
+const TECHNICAL_DETAILS_STACK_LINES = 4;
+
+const formatTechnicalDetails = (error: unknown): string => {
+  if (error instanceof Error) {
+    const stackHead = (error.stack ?? "")
+      .split("\n")
+      .slice(1, 1 + TECHNICAL_DETAILS_STACK_LINES)
+      .map((line) => line.trim())
+      .join("\n");
+    return stackHead.length > 0
+      ? `${error.name}: ${error.message}\n${stackHead}`
+      : `${error.name}: ${error.message}`;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
 
 /**
  * Canonical error feedback block for query, mutation and boundary failures.
  *
- * @param props Raw error plus optional recovery actions.
+ * @param props Raw error plus optional recovery actions. `showTechnicalDetails`
+ *              appends the original exception message and stack head — used by
+ *              top-level boundaries during the alpha so device-only failures
+ *              are diagnosable without remote crash reporting.
  * @returns Shared error notice with taxonomy-driven copy and recoverability CTA.
  */
 export function AppErrorNotice({
@@ -30,6 +61,7 @@ export function AppErrorNotice({
   onAction,
   secondaryActionLabel,
   onSecondaryAction,
+  showTechnicalDetails = false,
   testID,
 }: AppErrorNoticeProps): ReactElement {
   const errorState = createAppErrorState(error, {
@@ -45,6 +77,19 @@ export function AppErrorNotice({
         title={errorState.title}
         description={errorState.description}
       />
+      {showTechnicalDetails ? (
+        <AppStack gap="$1">
+          <Paragraph size="$2" fontWeight="600" color="$muted">
+            Detalhes tecnicos
+          </Paragraph>
+          <Paragraph
+            size="$1"
+            color="$muted"
+            testID={testID ? `${testID}-technical-details` : undefined}>
+            {formatTechnicalDetails(error)}
+          </Paragraph>
+        </AppStack>
+      ) : null}
       {resolvedActionLabel && onAction ? (
         <AppButton onPress={onAction}>{resolvedActionLabel}</AppButton>
       ) : null}
@@ -56,4 +101,3 @@ export function AppErrorNotice({
     </AppStack>
   );
 }
-


### PR DESCRIPTION
Closes #529 (parte 1 — diagnóstico)

Build TestFlight 1.0.0(4) cai no ErrorBoundary da área pública sem nenhuma informação da exceção — sem Sentry (#522 adiado), a tela do dispositivo é o único canal de diagnóstico.

## Mudanças

- `AppErrorNotice`: novo prop `showTechnicalDetails` — exibe nome/mensagem da exceção + 4 primeiras linhas do stack (TDD: 3 testes novos)
- `AppErrorBoundary`: boundaries `presentation="screen"` (root/público/privado) sempre exibem os detalhes durante o alfa

## Plano de uso

Merge → OTA no canal `production` → build 4 aplica no 2º relaunch → screenshot do Italo revela a exceção real → fix da causa-raiz na parte 2 da #529.

## Verificação

`npm run quality-check` verde — 1969 testes / 9 policies.