### PR TITLE
fix(ci): timeout guard-rails nos jobs de expo export (mitigação #510)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
   expo-bundle:
     name: Expo JS Bundle Check
     runs-on: ubuntu-latest
+    # Guard-rail (#510): sem timeout o job herdava o default de 360min do
+    # GitHub e um export travado segurava a fila de runners por 6h.
+    timeout-minutes: 20
     needs: [lint, typecheck, feature-flag-hygiene, frontend-governance, test, contract-smoke, graphql-codegen]
     outputs:
       enabled: ${{ steps.capability.outputs.enabled }}
@@ -181,6 +184,11 @@ jobs:
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Export JS bundle (Android + iOS)
         if: steps.capability.outputs.enabled == 'true'
+        env:
+          # Evita qualquer caminho interativo/telemetria do expo export em CI
+          # (hipótese de causa do hang — ver #510).
+          CI: "1"
+          EXPO_NO_TELEMETRY: "1"
         run: npx expo export --platform all --output-dir dist
         continue-on-error: false
       - name: Upload bundle artifact
@@ -195,6 +203,7 @@ jobs:
   bundle-analysis:
     name: Bundle Size Analysis (Metro)
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     needs: [expo-bundle]
     if: github.event_name == 'pull_request' && needs.expo-bundle.outputs.enabled == 'true'
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,12 +185,21 @@ jobs:
       - name: Export JS bundle (Android + iOS)
         if: steps.capability.outputs.enabled == 'true'
         env:
-          # Evita qualquer caminho interativo/telemetria do expo export em CI
-          # (hipótese de causa do hang — ver #510).
           CI: "1"
           EXPO_NO_TELEMETRY: "1"
-        run: npx expo export --platform all --output-dir dist
-        continue-on-error: false
+        # O processo do `expo export` não encerra após "Exported: dist" (handle
+        # aberto no event loop — #510/#532) e segurava o runner por 6h. O
+        # `timeout` mata o processo no teardown; o sucesso real é validado
+        # pela presença do artefato exportado.
+        run: |
+          set -uo pipefail
+          timeout --signal=KILL 15m npx expo export --platform all --output-dir dist
+          status=$?
+          if [ ! -f dist/metadata.json ]; then
+            echo "::error::expo export did not produce dist/metadata.json (exit $status)"
+            exit 1
+          fi
+          echo "Export artifact validated (exit $status tolerated as post-export teardown hang)."
       - name: Upload bundle artifact
         if: steps.capability.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy-minimum.yml
+++ b/.github/workflows/deploy-minimum.yml
@@ -39,7 +39,16 @@ jobs:
         env:
           CI: "1"
           EXPO_NO_TELEMETRY: "1"
-        run: npx expo export --platform web --output-dir dist-web
+        # Mata o processo no teardown pós-export e valida o artefato (#510/#532).
+        run: |
+          set -uo pipefail
+          timeout --signal=KILL 15m npx expo export --platform web --output-dir dist-web
+          status=$?
+          if [ ! -d dist-web ] || [ -z "$(ls -A dist-web 2>/dev/null)" ]; then
+            echo "::error::expo export did not produce dist-web (exit $status)"
+            exit 1
+          fi
+          echo "Export artifact validated (exit $status tolerated as post-export teardown hang)."
 
       - name: Upload web baseline artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4

--- a/.github/workflows/deploy-minimum.yml
+++ b/.github/workflows/deploy-minimum.yml
@@ -18,6 +18,8 @@ jobs:
   web-baseline-artifact:
     name: Export Web Baseline Artifact
     runs-on: ubuntu-latest
+    # Guard-rail (#510): export travado não pode segurar runner por 6h.
+    timeout-minutes: 20
     permissions:
       contents: read
     steps:
@@ -34,6 +36,9 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Export web bundle
+        env:
+          CI: "1"
+          EXPO_NO_TELEMETRY: "1"
         run: npx expo export --platform web --output-dir dist-web
 
       - name: Upload web baseline artifact


### PR DESCRIPTION
Closes #532
Refs #510 (causa-raiz documentada; #510 fecha quando um run real comprovar o job < 20min)

O job "Expo JS Bundle Check" trava ~6h e satura a fila de runners. **Evidência do run do PR #528**: o export CONCLUI ("Exported: dist") e o processo node não encerra — o hang é no teardown, não no bundle.

## Mudanças

- `ci.yml` `expo-bundle`: `timeout-minutes: 20` no job + export envolvido em `timeout --signal=KILL 15m` com validação de `dist/metadata.json` — se o artefato existe, o step é sucesso mesmo com o processo morto no teardown
- `ci.yml` `bundle-analysis`: `timeout-minutes: 15`
- `deploy-minimum.yml` `web-baseline-artifact`: mesma proteção (mesmo sintoma)
- `CI=1` + `EXPO_NO_TELEMETRY=1` nos steps de export

## Resultado

Job de bundle passa a concluir (com artefato validado) em minutos; um export realmente quebrado falha explícito; a fila nunca mais fica refém de runs de 6h.