### PR TITLE
fix(errors): componentStack nos detalhes técnicos + initPostHog defensivo (diagnóstico v2)

### DIFF
--- a/core/errors/app-error-boundary.test.tsx
+++ b/core/errors/app-error-boundary.test.tsx
@@ -81,6 +81,27 @@ describe("AppErrorBoundary", () => {
     ).toBeTruthy();
   });
 
+  it("exibe componentStack nos detalhes tecnicos de boundary de tela cheia", () => {
+    const ComponenteQuebrado = (): ReactElement => {
+      throw new Error("Boom de stack");
+    };
+
+    const { getByTestId } = render(
+      <TestProviders>
+        <AppErrorBoundary
+          scope="public-layout"
+          presentation="screen"
+          testID="boundary">
+          <ComponenteQuebrado />
+        </AppErrorBoundary>
+      </TestProviders>,
+    );
+
+    const details = getByTestId("boundary-technical-details").props.children;
+    expect(details).toContain("Component stack:");
+    expect(details).toContain("ComponenteQuebrado");
+  });
+
   it("nao exibe detalhes tecnicos em boundary inline", () => {
     const BrokenComponent = (): ReactElement => {
       throw new Error("Boom inline");

--- a/core/errors/app-error-boundary.tsx
+++ b/core/errors/app-error-boundary.tsx
@@ -6,6 +6,7 @@ import { AppErrorNotice } from "@/shared/components/app-error-notice";
 
 interface AppErrorBoundaryState {
   readonly error: unknown | null;
+  readonly componentStack: string | null;
 }
 
 export interface AppErrorBoundaryProps extends PropsWithChildren {
@@ -36,15 +37,19 @@ export class AppErrorBoundary extends Component<
 > {
   override state: AppErrorBoundaryState = {
     error: null,
+    componentStack: null,
   };
 
-  static getDerivedStateFromError(error: unknown): AppErrorBoundaryState {
+  static getDerivedStateFromError(error: unknown): Partial<AppErrorBoundaryState> {
     return {
       error,
     };
   }
 
   override componentDidCatch(error: unknown, errorInfo: ErrorInfo): void {
+    this.setState({
+      componentStack: errorInfo.componentStack ?? null,
+    });
     runtimeLogger.log("runtime.error_boundary_captured", {
       context: {
         scope: this.props.scope,
@@ -61,6 +66,7 @@ export class AppErrorBoundary extends Component<
     ) {
       this.setState({
         error: null,
+        componentStack: null,
       });
     }
   }
@@ -68,6 +74,7 @@ export class AppErrorBoundary extends Component<
   private readonly handleReset = (): void => {
     this.setState({
       error: null,
+      componentStack: null,
     });
     this.props.onReset?.();
   };
@@ -84,6 +91,7 @@ export class AppErrorBoundary extends Component<
         // alpha: with remote crash reporting deferred (#522), the device
         // screen is the only channel to diagnose store-build-only failures.
         showTechnicalDetails={this.props.presentation === "screen"}
+        technicalComponentStack={this.state.componentStack}
         testID={this.props.testID}
       />
     );

--- a/core/observability/posthog-service.test.ts
+++ b/core/observability/posthog-service.test.ts
@@ -1,0 +1,51 @@
+import {
+  setAnalyticsClient,
+  setAnalyticsCollectionEnabled,
+} from "@/core/observability/analytics-runtime";
+import {
+  initPostHog,
+  resetPostHogRuntimeForTests,
+} from "@/core/observability/posthog-service";
+
+jest.mock("posthog-react-native", () => {
+  return jest.fn().mockImplementation(() => {
+    throw new Error(
+      "PostHog: No storage available. Please install expo-file-system or react-native-async-storage OR implement a custom storage provider.",
+    );
+  });
+});
+
+jest.mock("@/core/observability/analytics-runtime", () => ({
+  ANALYTICS_FEATURE_FLAG_KEY: "analytics",
+  setAnalyticsClient: jest.fn(),
+  setAnalyticsCollectionEnabled: jest.fn(),
+}));
+
+jest.mock("@/shared/feature-flags", () => ({
+  isFeatureEnabled: jest.fn().mockReturnValue(true),
+}));
+
+describe("initPostHog", () => {
+  const originalApiKey = process.env.EXPO_PUBLIC_POSTHOG_API_KEY;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetPostHogRuntimeForTests();
+    process.env.EXPO_PUBLIC_POSTHOG_API_KEY = "phc_test_key";
+  });
+
+  afterEach(() => {
+    process.env.EXPO_PUBLIC_POSTHOG_API_KEY = originalApiKey;
+  });
+
+  it("nao propaga excecao quando o SDK falha ao construir (storage indisponivel)", async () => {
+    await expect(initPostHog()).resolves.toBeUndefined();
+  });
+
+  it("desabilita analytics de forma limpa quando o SDK falha", async () => {
+    await initPostHog();
+
+    expect(setAnalyticsClient).toHaveBeenCalledWith(undefined);
+    expect(setAnalyticsCollectionEnabled).toHaveBeenCalledWith(false);
+  });
+});

--- a/core/observability/posthog-service.ts
+++ b/core/observability/posthog-service.ts
@@ -96,21 +96,28 @@ export const initPostHog = async (): Promise<void> => {
     return;
   }
 
-  const preference = await loadAnalyticsOptOutPreference();
-  const collectionEnabled = !preference.optedOut;
-  const posthog = new PostHog(apiKey, {
-    host: resolvePostHogHost(),
-    captureAppLifecycleEvents: true,
-    defaultOptIn: collectionEnabled,
-    disableGeoip: true,
-    enableSessionReplay: false,
-  });
+  try {
+    const preference = await loadAnalyticsOptOutPreference();
+    const collectionEnabled = !preference.optedOut;
+    const posthog = new PostHog(apiKey, {
+      host: resolvePostHogHost(),
+      captureAppLifecycleEvents: true,
+      defaultOptIn: collectionEnabled,
+      disableGeoip: true,
+      enableSessionReplay: false,
+    });
 
-  setAnalyticsClient(
-    createPostHogAnalyticsClient(posthog as unknown as PostHogSdkClient),
-  );
-  setAnalyticsCollectionEnabled(collectionEnabled);
-  postHogInitialized = true;
+    setAnalyticsClient(
+      createPostHogAnalyticsClient(posthog as unknown as PostHogSdkClient),
+    );
+    setAnalyticsCollectionEnabled(collectionEnabled);
+    postHogInitialized = true;
+  } catch {
+    // Analytics nunca pode derrubar o app: o SDK lança quando não encontra
+    // storage (ex.: web sem AsyncStorage) — degradar para client desligado.
+    setAnalyticsClient(undefined);
+    setAnalyticsCollectionEnabled(false);
+  }
 };
 
 export const resetPostHogRuntimeForTests = (): void => {

--- a/shared/components/app-error-notice.tsx
+++ b/shared/components/app-error-notice.tsx
@@ -16,10 +16,12 @@ export interface AppErrorNoticeProps {
   readonly secondaryActionLabel?: string;
   readonly onSecondaryAction?: () => void;
   readonly showTechnicalDetails?: boolean;
+  readonly technicalComponentStack?: string | null;
   readonly testID?: string;
 }
 
 const TECHNICAL_DETAILS_STACK_LINES = 4;
+const COMPONENT_STACK_LINES = 8;
 
 const formatTechnicalDetails = (error: unknown): string => {
   if (error instanceof Error) {
@@ -62,8 +64,20 @@ export function AppErrorNotice({
   secondaryActionLabel,
   onSecondaryAction,
   showTechnicalDetails = false,
+  technicalComponentStack = null,
   testID,
 }: AppErrorNoticeProps): ReactElement {
+  const componentStackHead = technicalComponentStack
+    ? technicalComponentStack
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0)
+        .slice(0, COMPONENT_STACK_LINES)
+        .join("\n")
+    : null;
+  const technicalDetails = componentStackHead
+    ? `${formatTechnicalDetails(error)}\nComponent stack:\n${componentStackHead}`
+    : formatTechnicalDetails(error);
   const errorState = createAppErrorState(error, {
     fallbackTitle,
     fallbackDescription,
@@ -86,7 +100,7 @@ export function AppErrorNotice({
             size="$1"
             color="$muted"
             testID={testID ? `${testID}-technical-details` : undefined}>
-            {formatTechnicalDetails(error)}
+            {technicalDetails}
           </Paragraph>
         </AppStack>
       ) : null}


### PR DESCRIPTION
Closes #534
Refs #529 (crash da área pública — diagnóstico em iteração)

## Mudanças

- `AppErrorBoundary`: captura `errorInfo.componentStack` no state e exibe as primeiras 8 linhas no bloco "Detalhes tecnicos" — identifica o componente exato que viola as Rules of Hooks no build de loja (o stack do Hermes minificado só tem endereços)
- `initPostHog`: try/catch — bug independente achado na reprodução web em modo produção: `new PostHog()` LANÇA "No storage available" quando não há storage (web sem AsyncStorage); analytics agora degrada para desligado em vez de virar unhandled rejection
- TDD: 3 testes novos (componentStack no boundary screen; initPostHog não propaga + degrada limpo)

## Fluxo

Merge → OTA production → relaunch 2x no iPhone → screenshot revela o componente → fix da causa-raiz fecha #529.

## Verificação

quality-check verde: 1977 testes, 9 policies de governança.