### PR TITLE
fix(ci): capturar exit do KILL para a validação do artefato rodar (bash -e)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,9 +192,10 @@ jobs:
         # `timeout` mata o processo no teardown; o sucesso real é validado
         # pela presença do artefato exportado.
         run: |
-          set -uo pipefail
-          timeout --signal=KILL 15m npx expo export --platform all --output-dir dist
-          status=$?
+          # `|| status=$?` é obrigatório: o GitHub injeta `bash -e`, e o exit
+          # 137 do KILL abortaria o script antes da validação do artefato.
+          status=0
+          timeout --signal=KILL 10m npx expo export --platform all --output-dir dist || status=$?
           if [ ! -f dist/metadata.json ]; then
             echo "::error::expo export did not produce dist/metadata.json (exit $status)"
             exit 1

--- a/.github/workflows/deploy-minimum.yml
+++ b/.github/workflows/deploy-minimum.yml
@@ -41,9 +41,10 @@ jobs:
           EXPO_NO_TELEMETRY: "1"
         # Mata o processo no teardown pós-export e valida o artefato (#510/#532).
         run: |
-          set -uo pipefail
-          timeout --signal=KILL 15m npx expo export --platform web --output-dir dist-web
-          status=$?
+          # `|| status=$?` é obrigatório: o GitHub injeta `bash -e`, e o exit
+          # 137 do KILL abortaria o script antes da validação do artefato.
+          status=0
+          timeout --signal=KILL 10m npx expo export --platform web --output-dir dist-web || status=$?
           if [ ! -d dist-web ] || [ -z "$(ls -A dist-web 2>/dev/null)" ]; then
             echo "::error::expo export did not produce dist-web (exit $status)"
             exit 1


### PR DESCRIPTION
Closes #532
Refs #510

O run do PR #535 provou que a abordagem funciona MAS tinha um bug shell: o GitHub injeta `bash -e` nos steps, então o exit 137 do `timeout --signal=KILL` abortava o script **antes** da validação do artefato — o job falhava mesmo com o export completo ("Exported: dist", 148 rotas, log do Italo).

## Mudanças

- `|| status=$?` na linha do `timeout` (ci.yml + deploy-minimum.yml) — o KILL deixa de abortar o script e a validação decide o resultado
- Timeout interno 15m → **10m**: o export real leva ~4min (evidência do run); economiza ~5min de runner por job pendurado no teardown

## Resultado esperado

"Expo JS Bundle Check" VERDE em ~12min: export completa (~4min) + teardown pendurado morto aos 10min + artefato validado. Com um run verde, #510 pode fechar.