### PR TITLE
fix(runtime): desligar React Compiler — corrompia ordem de hooks em release (crash área pública)

### DIFF
--- a/app.json
+++ b/app.json
@@ -200,7 +200,7 @@
     ],
     "experiments": {
       "typedRoutes": true,
-      "reactCompiler": true
+      "reactCompiler": false
     },
     "extra": {
       "router": {},


### PR DESCRIPTION
Closes #529

Parte do épico #537 (Fase 0).

## Causa-raiz (confirmada por A/B via OTA)

Build de loja crashava na área pública: `TypeError: Cannot read property 'length' of undefined` em `areHookInputsEqual` → `useCallback` do `useStore` (zustand), componentStack apontando **LoginScreen**. Os hooks do LoginScreen/controller são comprovadamente incondicionais no código-fonte — a corrupção de ordem de hooks é injetada pelo **React Compiler experimental** (`experiments.reactCompiler`) no bundle minificado de release. Dev nunca manifesta (erro legível de hooks não aparece; assinatura só existe no React de produção). Refs: [react#31205](https://github.com/facebook/react/issues/31205), [zustand#2513](https://github.com/pmndrs/zustand/discussions/2513).

**Prova**: OTA v3 com `reactCompiler: false` → login renderiza e autentica contra produção (validado pelo Italo em device, 2026-06-12).

## Mudança

- `app.json`: `experiments.reactCompiler: true → false`

## Tradeoff

Perde-se a memoização automática do compiler (perf). Aceitável no alfa; re-habilitação só com validação em release build quando o compiler estabilizar — rastreável em issue futura se a perf degradar.

## Verificação

- quality-check verde (1977 testes, 9 policies)
- Device real: área pública renderiza, login funciona (OTA A/B)
- Trilha completa de diagnóstico no incident report: `auraxis-platform/docs/wiki/APP-alpha-first-device-run-incident-2026-06-12.md`