### PR TITLE
fix(goals): envelope real do Flask (items + Decimal-string) + guard central de isEmpty

### DIFF
--- a/core/query/query-feedback-state.test.ts
+++ b/core/query/query-feedback-state.test.ts
@@ -125,3 +125,23 @@ describe("createQueryFeedbackState", () => {
     });
   });
 });
+
+describe("createQueryFeedbackState — isEmpty defensivo", () => {
+  it("trata como vazio quando isEmpty lanca por shape inesperado (nunca propaga ao ErrorBoundary)", () => {
+    const brokenShape = {} as CollectionPayload;
+    const state = createQueryFeedbackState({
+      query: createQuery({
+        data: brokenShape,
+      }),
+      options: {
+        ...createOptions(),
+        isEmpty: (data) => data.items.length === 0,
+      },
+      connectivityStatus: "online",
+      degradedReason: null,
+      onRetry: jest.fn(),
+    });
+
+    expect(state.kind).toBe("empty");
+  });
+});

--- a/core/query/query-feedback-state.ts
+++ b/core/query/query-feedback-state.ts
@@ -103,7 +103,17 @@ const hasMeaningfulData = <TData>(
     return false;
   }
 
-  return isEmpty ? !isEmpty(data) : true;
+  if (!isEmpty) {
+    return true;
+  }
+
+  try {
+    return !isEmpty(data);
+  } catch {
+    // Shape inesperado da API (ex.: envelope divergente do contrato) não
+    // pode derrubar a tela no ErrorBoundary — degrada para empty-state.
+    return false;
+  }
 };
 
 const createNoticeState = (
@@ -191,33 +201,40 @@ export const createQueryFeedbackState = <TData, TError = unknown>(
   }
 
   if (query.isError) {
-    const errorState = createAppErrorState(query.error, {
-      fallbackTitle: options.error?.fallbackTitle,
-      fallbackDescription: options.error?.fallbackDescription,
-      connectivityStatus,
-    });
-
-    if (errorState.category === "network") {
-      return createNoticeState("offline", options.offline ?? DEFAULT_OFFLINE_COPY, onRetry);
-    }
-
-    if (errorState.category === "degraded") {
-      return createNoticeState("degraded", options.degraded ?? DEFAULT_DEGRADED_COPY, onRetry);
-    }
-
-    return {
-      kind: "error",
-      error: query.error,
-      fallbackTitle: options.error?.fallbackTitle,
-      fallbackDescription: options.error?.fallbackDescription,
-      onAction: onRetry,
-    };
+    return createErrorFeedbackState(params);
   }
 
   return {
     kind: "empty",
     title: options.empty.title,
     description: options.empty.description,
+  };
+};
+
+const createErrorFeedbackState = <TData, TError>(
+  params: CreateQueryFeedbackStateParams<TData, TError>,
+): QueryFeedbackState<TData> => {
+  const { connectivityStatus, onRetry, options, query } = params;
+  const errorState = createAppErrorState(query.error, {
+    fallbackTitle: options.error?.fallbackTitle,
+    fallbackDescription: options.error?.fallbackDescription,
+    connectivityStatus,
+  });
+
+  if (errorState.category === "network") {
+    return createNoticeState("offline", options.offline ?? DEFAULT_OFFLINE_COPY, onRetry);
+  }
+
+  if (errorState.category === "degraded") {
+    return createNoticeState("degraded", options.degraded ?? DEFAULT_DEGRADED_COPY, onRetry);
+  }
+
+  return {
+    kind: "error",
+    error: query.error,
+    fallbackTitle: options.error?.fallbackTitle,
+    fallbackDescription: options.error?.fallbackDescription,
+    onAction: onRetry,
   };
 };
 

--- a/docs/runbooks/api-envelope-contracts.md
+++ b/docs/runbooks/api-envelope-contracts.md
@@ -1,0 +1,65 @@
+# API Envelope Contracts — matriz de auditoria service ↔ Flask
+
+> Issue: [#538](https://github.com/italofelipe/auraxis-app/issues/538) · Épico: [#537](https://github.com/italofelipe/auraxis-app/issues/537)
+> Auditoria executada em 2026-06-12 após crash em produção (dashboard/metas).
+
+## A regra
+
+O Flask responde **envelope** `{status, message, data, meta?}` via `compat_success(data=...)`.
+O shape de `data` definido no **controller** (`app/controllers/**/resources.py`) é a
+fonte de verdade — o snapshot OpenAPI não captura o wrapper interno.
+
+Todo service do app DEVE:
+
+1. Desembrulhar com `unwrapEnvelopeData<ShapeRealDoFlask>(response.data)` — tipado com o
+   shape que o **Flask responde**, não com o que a tela deseja
+2. **Mapear** explicitamente para o contrato interno (camelCase, coerções) — nunca
+   repassar o payload cru tipado com o contrato interno
+3. Tratar coleções ausentes com default (`payload.items ?? []`)
+4. Coagir Decimals: o Flask serializa `fields.Decimal(as_string=True)` → **string**
+   (`"1500.00"`), nunca assumir `number`
+5. Testar com **fixture do envelope real** (copiado do controller), não com o shape
+   desejado
+
+Guard central: `core/query/query-feedback-state.ts` envolve `isEmpty` em try/catch —
+shape inesperado degrada para empty-state em vez de ErrorBoundary. Isso é mitigação,
+não licença para pular o mapeamento.
+
+## Matriz (leituras da área privada, 2026-06-12)
+
+| Service.método | Path | Flask `data=` | App esperava | Veredito |
+|---|---|---|---|---|
+| goals.listGoals | GET /goals | `{items: [GoalSchema]}` (amounts **string**) | `{goals: GoalRecord[]}` | ❌ **CORRIGIDO** — items→goals + coerção Decimal-string |
+| transactions.listTransactions | GET /transactions | `{transactions: [...]}` | `{transactions, pagination}` | ✅ |
+| budgets.listBudgets | GET /budgets | `{items: [...]}` | unwrap defensivo de lista | ✅ |
+| credit-cards.listCreditCards | GET /credit-cards | `{credit_cards: [...]}` | mapeado → `{creditCards}` | ✅ |
+| accounts.listAccounts | GET /accounts | `{accounts: [...]}` | `{accounts}` | ✅ |
+| wallet.listEntries | GET /wallet | `{items, pagination}` | `{items, pagination}` | ✅ |
+| tags.listTags | GET /tags | `{tags: [...]}` | `{tags}` | ✅ |
+| alerts.listAlerts / getPreferences | GET /alerts, /alerts/preferences | `{alerts}` / `{preferences}` | idem | ✅ |
+| spending-patterns.getLatest | GET /ai/insights/spending-patterns/latest | snake_case | mapeado | ✅ |
+| weekly-snapshot.get | GET /ai/insights/weekly-summary | aninhado | mapeado | ✅ |
+| insights.getLatest / history | GET insights | snake_case | `mapInsight` / perPage | ✅ |
+| subscription.listPlans | GET /subscriptions/plans | `{plans: [...]}` | `payload.plans.map(mapPlan)` | ✅ |
+| user-profile.listNotificationPreferences | GET /user/notification-preferences | snake_case | `mapNotificationPreference` | ✅ |
+| fiscal.listReceivables / listFiscalDocuments | GET /fiscal/* | mapeado | mapeado | ✅ |
+
+**Resultado**: 1 divergência real (goals — crash em produção), corrigida nesta issue.
+Dois falsos positivos da primeira passada de auditoria (subscription, notification
+preferences) — descartados por leitura direta do código.
+
+## Por que os testes não pegaram
+
+- Services eram testados (quando eram) com mocks no shape **desejado** — `listGoals`
+  não tinha teste algum
+- Dev roda com `EXPO_PUBLIC_API_MODE=mock` na maior parte do tempo — a integração real
+  só acontece em device/preview
+- O crash só aparece quando `AppQueryState.isEmpty` acessa o campo ausente
+
+## Checklist para NOVOS endpoints
+
+- [ ] Li o `compat_success(data=...)` do controller Flask
+- [ ] Tipei o unwrap com o shape do Flask (snake_case, Decimals como string)
+- [ ] Mapeei para o contrato interno com defaults para coleções
+- [ ] Fixture de teste copiado da resposta real (envelope completo)
+- [ ] `isEmpty` da tela tolera shape parcial (o guard central cobre, mas use `?.`)

--- a/features/goals/services/goals-service.test.ts
+++ b/features/goals/services/goals-service.test.ts
@@ -1,0 +1,80 @@
+import type { AxiosInstance } from "axios";
+
+import { createGoalsService } from "@/features/goals/services/goals-service";
+
+// Fixture espelhando a resposta REAL do Flask (goal/resources.py +
+// goal_schema.py): lista vem em `data.items` (não `data.goals`) e os
+// montantes são Decimal serializados COMO STRING (`as_string=True`).
+const FLASK_GOALS_LIST_ENVELOPE = {
+  status: "success",
+  message: "Metas listadas com sucesso",
+  data: {
+    items: [
+      {
+        id: "0e1f0a52-6f2a-4f5e-9b1c-0c9d6a8f1b21",
+        user_id: "f3b9d3a1-1111-2222-3333-444455556666",
+        title: "Reserva de emergencia",
+        description: "",
+        category: "seguranca",
+        target_amount: "15000.00",
+        current_amount: "2500.50",
+        priority: 3,
+        target_date: "2026-12-31",
+        status: "active",
+      },
+    ],
+  },
+  meta: {
+    pagination: { page: 1, per_page: 20, total: 1, pages: 1 },
+  },
+};
+
+const createClient = (
+  getResponse: unknown,
+): { client: AxiosInstance; get: jest.Mock } => {
+  const get = jest.fn().mockResolvedValue({ data: getResponse });
+  return { client: { get } as unknown as AxiosInstance, get };
+};
+
+describe("goalsService.listGoals", () => {
+  it("desembrulha data.items do envelope real do Flask e mapeia para goals", async () => {
+    const { client, get } = createClient(FLASK_GOALS_LIST_ENVELOPE);
+    const service = createGoalsService(client);
+
+    const result = await service.listGoals();
+
+    expect(get).toHaveBeenCalledWith("/goals");
+    expect(result.goals).toHaveLength(1);
+    expect(result.goals[0]).toEqual({
+      id: "0e1f0a52-6f2a-4f5e-9b1c-0c9d6a8f1b21",
+      title: "Reserva de emergencia",
+      currentAmount: 2500.5,
+      targetAmount: 15000,
+      targetDate: "2026-12-31",
+      status: "active",
+    });
+  });
+
+  it("coage montantes Decimal-string do Flask para number", async () => {
+    const { client } = createClient(FLASK_GOALS_LIST_ENVELOPE);
+    const service = createGoalsService(client);
+
+    const result = await service.listGoals();
+
+    expect(typeof result.goals[0]?.currentAmount).toBe("number");
+    expect(typeof result.goals[0]?.targetAmount).toBe("number");
+  });
+
+  it("retorna lista vazia quando o envelope vem sem items", async () => {
+    const { client } = createClient({
+      status: "success",
+      message: "Metas listadas com sucesso",
+      data: {},
+    });
+    const service = createGoalsService(client);
+
+    const result = await service.listGoals();
+
+    expect(result.goals).toEqual([]);
+  });
+});

--- a/features/goals/services/goals-service.ts
+++ b/features/goals/services/goals-service.ts
@@ -1,6 +1,6 @@
 import type { AxiosInstance } from "axios";
 
-import { unwrapEnvelopeData } from "@/core/http/contracts";
+import { unwrapEnvelopeData, type ApiEnvelope } from "@/core/http/contracts";
 import { httpClient } from "@/core/http/http-client";
 import type {
   CreateGoalCommand,
@@ -18,18 +18,35 @@ import { resolveApiContractPath } from "@/shared/contracts/resolve-api-contract-
 interface GoalPayload {
   readonly id: string;
   readonly title: string;
-  readonly current_amount: number;
-  readonly target_amount: number;
+  // O Flask serializa Decimal como string (GoalSchema, as_string=True).
+  readonly current_amount: number | string;
+  readonly target_amount: number | string;
   readonly target_date: string | null;
   readonly status: string;
 }
+
+const toNumeric = (value: number | string): number => {
+  const parsed = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+};
+
+// O backend responde `data: {items: [...]}` (goal/resources.py) — não
+// `{goals}`. Ver docs/runbooks/api-envelope-contracts.md.
+const mapGoalListEnvelope = (
+  envelope: ApiEnvelope<{ readonly items?: readonly GoalPayload[] }>,
+): GoalListResponse => {
+  const payload = unwrapEnvelopeData(envelope);
+  return {
+    goals: (payload.items ?? []).map(mapGoal),
+  };
+};
 
 const mapGoal = (payload: GoalPayload): GoalRecord => {
   return {
     id: payload.id,
     title: payload.title,
-    currentAmount: payload.current_amount,
-    targetAmount: payload.target_amount,
+    currentAmount: toNumeric(payload.current_amount),
+    targetAmount: toNumeric(payload.target_amount),
     targetDate: payload.target_date,
     status: payload.status,
   };
@@ -91,7 +108,7 @@ export const createGoalsService = (client: AxiosInstance) => {
   return {
     listGoals: async (): Promise<GoalListResponse> => {
       const response = await client.get(apiContractMap.goalsList.path);
-      return unwrapEnvelopeData<GoalListResponse>(response.data);
+      return mapGoalListEnvelope(response.data);
     },
     createGoal: async (command: CreateGoalCommand): Promise<GoalRecord> => {
       const response = await client.post(


### PR DESCRIPTION
Closes #538

Parte do épico #537 (Fase 1). Crash do dashboard em device (componentStack: DashboardGoalsSummaryCard → useQueryFeedbackState).

## Causa-raiz

`GET /goals` responde `data: {items: [GoalSchema]}` com Decimals serializados como **string** (`as_string=True`); `listGoals` retornava o unwrap cru tipado como `{goals: GoalRecord[]}` → `data.goals === undefined` → `isEmpty` lança → ErrorBoundary. Sem teste no método; dev roda em modo mock; mesmo bug-família do web (metas vazias, 2026-06-03).

## Mudanças

- `goals-service`: `mapGoalListEnvelope` desembrulha o shape real (`{items}`) + `mapGoal` coage Decimal-string→number (TDD: 3 testes com fixture copiado do controller Flask)
- `query-feedback-state`: try/catch central no `isEmpty` — shape inesperado degrada para **empty-state**, nunca ErrorBoundary (supera o sweep `?.` por callsite previsto na issue); `createErrorFeedbackState` extraído por limite de complexidade
- `docs/runbooks/api-envelope-contracts.md`: regra canônica, matriz da auditoria (14 endpoints: 1 divergente real corrigido, 2 falsos positivos da 1ª passada descartados por leitura direta) e checklist para novos endpoints

## Verificação

- quality-check verde: 1981 testes (4 novos), 9 policies
- Pós-merge: OTA `--environment production` → validação no device (dashboard renderiza metas)