### PR TITLE
feat(design): F1 — tokens do web (light teal), Inter + IBM Plex Mono e FIX da resolução de temas Tamagui

### DIFF
--- a/__tests__/app/private-layout.test.tsx
+++ b/__tests__/app/private-layout.test.tsx
@@ -135,11 +135,11 @@ describe("PrivateLayout", () => {
 
     expect(mockTabsScreenOptions).toMatchObject({
       headerShown: false,
-      tabBarActiveTintColor: "#1598be",
-      tabBarInactiveTintColor: "#6e7f9f",
+      tabBarActiveTintColor: "#087FA7",
+      tabBarInactiveTintColor: "#7A8BA3",
       tabBarStyle: {
         backgroundColor: "#ffffff",
-        borderTopColor: "rgba(29,43,68,0.14)",
+        borderTopColor: "#D8E3EF",
       },
     });
   });

--- a/config/design-tokens.ts
+++ b/config/design-tokens.ts
@@ -44,12 +44,16 @@ export const colorPalette = {
   danger700: "#c53f4a",
 } as const;
 
+// Paridade com o web (auraxis-web/app/theme/tokens/typography.ts):
+// Inter para texto/headings e IBM Plex Mono para valores financeiros.
 export const typography = {
-  heading: "PlayfairDisplay_700Bold",
-  headingSemiBold: "PlayfairDisplay_600SemiBold",
-  body: "Raleway_400Regular",
-  bodyMedium: "Raleway_500Medium",
-  bodySemiBold: "Raleway_600SemiBold",
+  heading: "Inter_700Bold",
+  headingSemiBold: "Inter_600SemiBold",
+  body: "Inter_400Regular",
+  bodyMedium: "Inter_500Medium",
+  bodySemiBold: "Inter_600SemiBold",
+  mono: "IBMPlexMono_500Medium",
+  monoRegular: "IBMPlexMono_400Regular",
 } as const;
 
 export const spacing = (step: number): number => {

--- a/config/tamagui-theme.test.ts
+++ b/config/tamagui-theme.test.ts
@@ -9,10 +9,15 @@ describe("tamagui theme config", () => {
     expect(auraxisThemes.auraxis).toBe(auraxisThemes.auraxis_light);
   });
 
-  it("exposes semantic status tokens for both light and dark modes", () => {
-    expect(auraxisThemes.auraxis_light.warning).toBe("$warningLight");
-    expect(auraxisThemes.auraxis_light.info).toBe("$infoLight");
-    expect(auraxisThemes.auraxis_dark.warning).toBe("$warningDark");
-    expect(auraxisThemes.auraxis_dark.info).toBe("$infoDark");
+  it("exposes semantic status colors as CONCRETE values (nunca referências $token — bug #543)", () => {
+    expect(auraxisThemes.auraxis_light.warning).toBe("#B7791F");
+    expect(auraxisThemes.auraxis_light.info).toBe("#2563EB");
+    expect(auraxisThemes.auraxis_dark.warning).toBe("#ffb861");
+    expect(auraxisThemes.auraxis_dark.info).toBe("#44d4ff");
+    const allValues = [
+      ...Object.values(auraxisThemes.auraxis_light),
+      ...Object.values(auraxisThemes.auraxis_dark),
+    ];
+    expect(allValues.some((value) => String(value).startsWith("$"))).toBe(false);
   });
 });

--- a/config/tamagui-theme.ts
+++ b/config/tamagui-theme.ts
@@ -9,7 +9,7 @@ import {
 } from "@/shared/theme";
 
 const bodyFont = createFont({
-  family: "Raleway_400Regular",
+  family: "Inter_400Regular",
   size: {
     1: fontSizes.xs,
     2: fontSizes.sm,
@@ -37,14 +37,15 @@ const bodyFont = createFont({
     7: "700",
   },
   face: {
-    400: { normal: "Raleway_400Regular" },
-    500: { normal: "Raleway_500Medium" },
-    600: { normal: "Raleway_600SemiBold" },
+    400: { normal: "Inter_400Regular" },
+    500: { normal: "Inter_500Medium" },
+    600: { normal: "Inter_600SemiBold" },
+    700: { normal: "Inter_700Bold" },
   },
 });
 
 const headingFont = createFont({
-  family: "PlayfairDisplay_700Bold",
+  family: "Inter_700Bold",
   size: {
     4: fontSizes.base,
     5: fontSizes.lg,
@@ -59,61 +60,62 @@ const headingFont = createFont({
     6: 28,
     7: 32,
     8: 36,
-    9: 40,
+    9: 42,
   },
   weight: {
     6: "600",
     7: "700",
   },
   face: {
-    600: { normal: "PlayfairDisplay_600SemiBold" },
-    700: { normal: "PlayfairDisplay_700Bold" },
+    600: { normal: "Inter_600SemiBold" },
+    700: { normal: "Inter_700Bold" },
   },
 });
 
-// Token names are namespaced with -dark / -light suffixes so each Tamagui
-// theme can resolve a specific colour while components reference the
-// semantic Tamagui variable (e.g. `$background`).
+// Valores financeiros (R$) — assinatura visual do dashboard web.
+const monoFont = createFont({
+  family: "IBMPlexMono_500Medium",
+  size: {
+    1: fontSizes.xs,
+    2: fontSizes.sm,
+    3: fontSizes.md,
+    4: fontSizes.base,
+    5: fontSizes.lg,
+    6: fontSizes.xl,
+    7: fontSizes["2xl"],
+    8: fontSizes["3xl"],
+    9: fontSizes["4xl"],
+  },
+  lineHeight: {
+    1: 16,
+    2: 18,
+    3: 20,
+    4: 22,
+    5: 24,
+    6: 28,
+    7: 32,
+    8: 38,
+    9: 44,
+  },
+  weight: {
+    4: "400",
+    5: "500",
+    6: "600",
+  },
+  face: {
+    400: { normal: "IBMPlexMono_400Regular" },
+    500: { normal: "IBMPlexMono_500Medium" },
+    600: { normal: "IBMPlexMono_600SemiBold" },
+  },
+});
+
 const tokens = createTokens({
   color: {
-    // dark
-    surfaceBaseDark: darkSemanticColors.background,
-    surfaceCardDark: darkSemanticColors.surface,
-    surfaceRaisedDark: darkSemanticColors.surfaceRaised,
-    textPrimaryDark: darkSemanticColors.foreground,
-    textSecondaryDark: darkSemanticColors.mutedForeground,
-    textMutedDark: darkSemanticColors.subduedForeground,
-    borderMutedDark: darkSemanticColors.border,
-    borderStrongDark: darkSemanticColors.borderStrong,
+    // Mantidos para consumo direto via $token quando necessário.
     brandPrimaryDark: darkSemanticColors.primary,
-    brandPrimaryPressedDark: darkSemanticColors.primaryPressed,
-    brandPrimaryForegroundDark: darkSemanticColors.primaryForeground,
-    brandSecondaryDark: darkSemanticColors.secondary,
-    brandSecondaryPressedDark: darkSemanticColors.secondaryPressed,
-    successDark: darkSemanticColors.success,
-    dangerDark: darkSemanticColors.danger,
-    dangerStrongDark: darkSemanticColors.dangerStrong,
-    warningDark: darkSemanticColors.warning,
-    infoDark: darkSemanticColors.info,
-    // light
-    surfaceBaseLight: lightSemanticColors.background,
-    surfaceCardLight: lightSemanticColors.surface,
-    surfaceRaisedLight: lightSemanticColors.surfaceRaised,
-    textPrimaryLight: lightSemanticColors.foreground,
-    textSecondaryLight: lightSemanticColors.mutedForeground,
-    textMutedLight: lightSemanticColors.subduedForeground,
-    borderMutedLight: lightSemanticColors.border,
-    borderStrongLight: lightSemanticColors.borderStrong,
     brandPrimaryLight: lightSemanticColors.primary,
-    brandPrimaryPressedLight: lightSemanticColors.primaryPressed,
-    brandPrimaryForegroundLight: lightSemanticColors.primaryForeground,
-    brandSecondaryLight: lightSemanticColors.secondary,
-    brandSecondaryPressedLight: lightSemanticColors.secondaryPressed,
-    successLight: lightSemanticColors.success,
-    dangerLight: lightSemanticColors.danger,
-    dangerStrongLight: lightSemanticColors.dangerStrong,
-    warningLight: lightSemanticColors.warning,
-    infoLight: lightSemanticColors.info,
+    surfaceBaseDark: darkSemanticColors.background,
+    surfaceBaseLight: lightSemanticColors.background,
   },
   space: {
     0: 0,
@@ -143,6 +145,7 @@ const tokens = createTokens({
     2: semanticRadii.md,
     3: semanticRadii.lg,
     4: semanticRadii.xl,
+    5: semanticRadii.pill,
   },
   zIndex: {
     0: 0,
@@ -152,42 +155,52 @@ const tokens = createTokens({
   },
 });
 
-const buildModeTheme = (mode: "dark" | "light") => {
-  const suffix = mode === "dark" ? "Dark" : "Light";
+type SemanticColors = Record<keyof typeof lightSemanticColors, string>;
+
+/**
+ * Constrói o tema com VALORES CONCRETOS (hex/rgba).
+ *
+ * Regressão #539/#543: a versão anterior populava os temas com referências
+ * de token ("$brandPrimaryLight") que o resolvedor do Tamagui nunca
+ * converteu para cor — o RN recebia a string crua e o app inteiro
+ * renderizava sem cor. Temas devem carregar valores finais; o teste
+ * `shared/theme/theme-resolution.test.tsx` protege este contrato.
+ */
+const buildModeTheme = (palette: SemanticColors) => {
   return {
-    background: `$surfaceBase${suffix}`,
-    backgroundHover: `$surfaceCard${suffix}`,
-    backgroundPress: `$surfaceRaised${suffix}`,
-    backgroundFocus: `$surfaceRaised${suffix}`,
-    color: `$textPrimary${suffix}`,
-    colorHover: `$textPrimary${suffix}`,
-    colorPress: `$textPrimary${suffix}`,
-    colorFocus: `$textPrimary${suffix}`,
-    borderColor: `$borderMuted${suffix}`,
-    borderColorHover: `$borderStrong${suffix}`,
-    borderColorFocus: `$borderStrong${suffix}`,
-    borderColorPress: `$brandPrimary${suffix}`,
-    placeholderColor: `$textMuted${suffix}`,
-    outlineColor: `$brandPrimary${suffix}`,
-    primary: `$brandPrimary${suffix}`,
-    primaryPressed: `$brandPrimaryPressed${suffix}`,
-    actionPrimaryForeground: `$brandPrimaryForeground${suffix}`,
-    secondary: `$brandSecondary${suffix}`,
-    secondaryPressed: `$brandSecondaryPressed${suffix}`,
-    accentColor: `$brandPrimary${suffix}`,
-    surfaceCard: `$surfaceCard${suffix}`,
-    surfaceRaised: `$surfaceRaised${suffix}`,
-    muted: `$textMuted${suffix}`,
-    success: `$success${suffix}`,
-    danger: `$danger${suffix}`,
-    dangerStrong: `$dangerStrong${suffix}`,
-    warning: `$warning${suffix}`,
-    info: `$info${suffix}`,
+    background: palette.background,
+    backgroundHover: palette.surface,
+    backgroundPress: palette.surfaceRaised,
+    backgroundFocus: palette.surfaceRaised,
+    color: palette.foreground,
+    colorHover: palette.foreground,
+    colorPress: palette.foreground,
+    colorFocus: palette.foreground,
+    borderColor: palette.border,
+    borderColorHover: palette.borderStrong,
+    borderColorFocus: palette.borderStrong,
+    borderColorPress: palette.primary,
+    placeholderColor: palette.subduedForeground,
+    outlineColor: palette.primary,
+    primary: palette.primary,
+    primaryPressed: palette.primaryPressed,
+    actionPrimaryForeground: palette.primaryForeground,
+    secondary: palette.secondary,
+    secondaryPressed: palette.secondaryPressed,
+    accentColor: palette.primary,
+    surfaceCard: palette.surface,
+    surfaceRaised: palette.surfaceRaised,
+    muted: palette.mutedForeground,
+    success: palette.success,
+    danger: palette.danger,
+    dangerStrong: palette.dangerStrong,
+    warning: palette.warning,
+    info: palette.info,
   } as const;
 };
 
-const auraxisLightTheme = buildModeTheme("light");
-const auraxisDarkTheme = buildModeTheme("dark");
+const auraxisLightTheme = buildModeTheme(lightSemanticColors);
+const auraxisDarkTheme = buildModeTheme(darkSemanticColors);
 
 export const auraxisThemes = {
   auraxis: auraxisLightTheme,
@@ -204,6 +217,7 @@ export const tamaguiConfig = createTamagui({
   fonts: {
     body: bodyFont,
     heading: headingFont,
+    mono: monoFont,
   },
   defaultTheme: auraxisDefaultTheme,
   settings: {

--- a/core/shell/use-app-startup.ts
+++ b/core/shell/use-app-startup.ts
@@ -1,14 +1,16 @@
 import { useEffect, useRef } from "react";
 
 import {
-  PlayfairDisplay_600SemiBold,
-  PlayfairDisplay_700Bold,
-} from "@expo-google-fonts/playfair-display";
+  IBMPlexMono_400Regular,
+  IBMPlexMono_500Medium,
+  IBMPlexMono_600SemiBold,
+} from "@expo-google-fonts/ibm-plex-mono";
 import {
-  Raleway_400Regular,
-  Raleway_500Medium,
-  Raleway_600SemiBold,
-} from "@expo-google-fonts/raleway";
+  Inter_400Regular,
+  Inter_500Medium,
+  Inter_600SemiBold,
+  Inter_700Bold,
+} from "@expo-google-fonts/inter";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 
@@ -94,11 +96,13 @@ export const useAppStartup = (): AppStartupState => {
   const hydrated = useSessionStore((state) => state.hydrated);
   const startupMeasurementStarted = useRef(false);
   const [fontsLoaded] = useFonts({
-    PlayfairDisplay_600SemiBold,
-    PlayfairDisplay_700Bold,
-    Raleway_400Regular,
-    Raleway_500Medium,
-    Raleway_600SemiBold,
+    Inter_400Regular,
+    Inter_500Medium,
+    Inter_600SemiBold,
+    Inter_700Bold,
+    IBMPlexMono_400Regular,
+    IBMPlexMono_500Medium,
+    IBMPlexMono_600SemiBold,
   });
 
   useEffect(() => {

--- a/features/credit-cards/components/__snapshots__/credit-card-card.test.tsx.snap
+++ b/features/credit-cards/components/__snapshots__/credit-card-card.test.tsx.snap
@@ -4,26 +4,33 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
 <View
   style={
     {
-      "backgroundColor": "$surfaceCardLight",
-      "borderBottomColor": "$borderMutedLight",
-      "borderBottomLeftRadius": 14,
-      "borderBottomRightRadius": 14,
+      "backgroundColor": "#ffffff",
+      "borderBottomColor": "#D8E3EF",
+      "borderBottomLeftRadius": 20,
+      "borderBottomRightRadius": 20,
       "borderBottomWidth": 1,
-      "borderLeftColor": "$borderMutedLight",
+      "borderLeftColor": "#D8E3EF",
       "borderLeftWidth": 1,
-      "borderRightColor": "$borderMutedLight",
+      "borderRightColor": "#D8E3EF",
       "borderRightWidth": 1,
       "borderStyle": "solid",
-      "borderTopColor": "$borderMutedLight",
-      "borderTopLeftRadius": 14,
-      "borderTopRightRadius": 14,
+      "borderTopColor": "#D8E3EF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
       "borderTopWidth": 1,
       "flexDirection": "column",
-      "gap": 8,
-      "paddingBottom": 16,
-      "paddingLeft": 16,
-      "paddingRight": 16,
-      "paddingTop": 16,
+      "gap": 12,
+      "paddingBottom": 24,
+      "paddingLeft": 24,
+      "paddingRight": 24,
+      "paddingTop": 24,
+      "shadowColor": "rgb(10,22,40)",
+      "shadowOffset": {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 3,
     }
   }
   testID="credit-card-card-card-1"
@@ -58,8 +65,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -71,8 +78,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -85,8 +92,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
       <Text
         style={
           {
-            "color": "$textPrimaryLight",
-            "fontFamily": "PlayfairDisplay_600SemiBold",
+            "color": "#0A1628",
+            "fontFamily": "Inter_600SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
           }
@@ -109,22 +116,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$brandPrimaryLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#087FA7",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$brandPrimaryForegroundLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#ffffff",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -141,22 +148,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -174,22 +181,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -215,7 +222,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
       <View
         style={
           {
-            "backgroundColor": "$surfaceRaisedLight",
+            "backgroundColor": "#F8FBFF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderTopLeftRadius": 28,
@@ -230,7 +237,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$successLight",
+              "backgroundColor": "#087F5B",
               "borderBottomLeftRadius": 28,
               "borderBottomRightRadius": 28,
               "borderTopLeftRadius": 28,
@@ -245,8 +252,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
       <Text
         style={
           {
-            "color": "$textMutedLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#5D6F89",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 14,
             "lineHeight": 20,
           }
@@ -274,22 +281,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -306,22 +313,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -340,8 +347,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
     <Text
       style={
         {
-          "color": "$textMutedLight",
-          "fontFamily": "Raleway_400Regular",
+          "color": "#5D6F89",
+          "fontFamily": "Inter_400Regular",
           "fontSize": 14,
           "lineHeight": 20,
         }
@@ -370,7 +377,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -388,18 +395,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -412,8 +419,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -435,7 +442,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -452,10 +459,10 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "$brandPrimaryLight",
+            "backgroundColor": "#087FA7",
             "borderBottomColor": "transparent",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
             "borderLeftColor": "transparent",
             "borderLeftWidth": 1,
@@ -463,8 +470,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "borderTopColor": "transparent",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -477,8 +484,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <Text
           style={
             {
-              "color": "$brandPrimaryForegroundLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#ffffff",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -500,7 +507,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -518,18 +525,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -542,8 +549,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -565,7 +572,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -583,18 +590,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -607,8 +614,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -628,26 +635,33 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
 <View
   style={
     {
-      "backgroundColor": "$surfaceCardLight",
-      "borderBottomColor": "$borderMutedLight",
-      "borderBottomLeftRadius": 14,
-      "borderBottomRightRadius": 14,
+      "backgroundColor": "#ffffff",
+      "borderBottomColor": "#D8E3EF",
+      "borderBottomLeftRadius": 20,
+      "borderBottomRightRadius": 20,
       "borderBottomWidth": 1,
-      "borderLeftColor": "$borderMutedLight",
+      "borderLeftColor": "#D8E3EF",
       "borderLeftWidth": 1,
-      "borderRightColor": "$borderMutedLight",
+      "borderRightColor": "#D8E3EF",
       "borderRightWidth": 1,
       "borderStyle": "solid",
-      "borderTopColor": "$borderMutedLight",
-      "borderTopLeftRadius": 14,
-      "borderTopRightRadius": 14,
+      "borderTopColor": "#D8E3EF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
       "borderTopWidth": 1,
       "flexDirection": "column",
-      "gap": 8,
-      "paddingBottom": 16,
-      "paddingLeft": 16,
-      "paddingRight": 16,
-      "paddingTop": 16,
+      "gap": 12,
+      "paddingBottom": 24,
+      "paddingLeft": 24,
+      "paddingRight": 24,
+      "paddingTop": 24,
+      "shadowColor": "rgb(10,22,40)",
+      "shadowOffset": {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 3,
     }
   }
   testID="credit-card-card-card-1"
@@ -682,8 +696,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -695,8 +709,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -709,8 +723,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
       <Text
         style={
           {
-            "color": "$textPrimaryLight",
-            "fontFamily": "PlayfairDisplay_600SemiBold",
+            "color": "#0A1628",
+            "fontFamily": "Inter_600SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
           }
@@ -733,22 +747,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$brandPrimaryLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#087FA7",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$brandPrimaryForegroundLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#ffffff",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -765,22 +779,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -798,22 +812,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -839,7 +853,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
       <View
         style={
           {
-            "backgroundColor": "$surfaceRaisedLight",
+            "backgroundColor": "#F8FBFF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderTopLeftRadius": 28,
@@ -854,7 +868,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$successLight",
+              "backgroundColor": "#087F5B",
               "borderBottomLeftRadius": 28,
               "borderBottomRightRadius": 28,
               "borderTopLeftRadius": 28,
@@ -869,8 +883,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
       <Text
         style={
           {
-            "color": "$textMutedLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#5D6F89",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 14,
             "lineHeight": 20,
           }
@@ -898,22 +912,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -930,22 +944,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -964,8 +978,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
     <Text
       style={
         {
-          "color": "$textMutedLight",
-          "fontFamily": "Raleway_400Regular",
+          "color": "#5D6F89",
+          "fontFamily": "Inter_400Regular",
           "fontSize": 14,
           "lineHeight": 20,
         }
@@ -994,7 +1008,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1012,18 +1026,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1036,8 +1050,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1059,7 +1073,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1076,10 +1090,10 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "$brandPrimaryLight",
+            "backgroundColor": "#087FA7",
             "borderBottomColor": "transparent",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
             "borderLeftColor": "transparent",
             "borderLeftWidth": 1,
@@ -1087,8 +1101,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "borderTopColor": "transparent",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1101,8 +1115,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <Text
           style={
             {
-              "color": "$brandPrimaryForegroundLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#ffffff",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1124,7 +1138,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1142,18 +1156,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1166,8 +1180,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1189,7 +1203,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1207,18 +1221,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1231,8 +1245,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1252,26 +1266,33 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
 <View
   style={
     {
-      "backgroundColor": "$surfaceCardLight",
-      "borderBottomColor": "$borderMutedLight",
-      "borderBottomLeftRadius": 14,
-      "borderBottomRightRadius": 14,
+      "backgroundColor": "#ffffff",
+      "borderBottomColor": "#D8E3EF",
+      "borderBottomLeftRadius": 20,
+      "borderBottomRightRadius": 20,
       "borderBottomWidth": 1,
-      "borderLeftColor": "$borderMutedLight",
+      "borderLeftColor": "#D8E3EF",
       "borderLeftWidth": 1,
-      "borderRightColor": "$borderMutedLight",
+      "borderRightColor": "#D8E3EF",
       "borderRightWidth": 1,
       "borderStyle": "solid",
-      "borderTopColor": "$borderMutedLight",
-      "borderTopLeftRadius": 14,
-      "borderTopRightRadius": 14,
+      "borderTopColor": "#D8E3EF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
       "borderTopWidth": 1,
       "flexDirection": "column",
-      "gap": 8,
-      "paddingBottom": 16,
-      "paddingLeft": 16,
-      "paddingRight": 16,
-      "paddingTop": 16,
+      "gap": 12,
+      "paddingBottom": 24,
+      "paddingLeft": 24,
+      "paddingRight": 24,
+      "paddingTop": 24,
+      "shadowColor": "rgb(10,22,40)",
+      "shadowOffset": {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 3,
     }
   }
   testID="credit-card-card-card-1"
@@ -1306,8 +1327,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -1319,8 +1340,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -1333,8 +1354,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
       <Text
         style={
           {
-            "color": "$textPrimaryLight",
-            "fontFamily": "PlayfairDisplay_600SemiBold",
+            "color": "#0A1628",
+            "fontFamily": "Inter_600SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
           }
@@ -1357,22 +1378,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$brandPrimaryLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#087FA7",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$brandPrimaryForegroundLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#ffffff",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -1389,22 +1410,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -1422,22 +1443,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -1463,7 +1484,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
       <View
         style={
           {
-            "backgroundColor": "$surfaceRaisedLight",
+            "backgroundColor": "#F8FBFF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderTopLeftRadius": 28,
@@ -1478,7 +1499,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$dangerLight",
+              "backgroundColor": "#C2414D",
               "borderBottomLeftRadius": 28,
               "borderBottomRightRadius": 28,
               "borderTopLeftRadius": 28,
@@ -1493,8 +1514,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
       <Text
         style={
           {
-            "color": "$textMutedLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#5D6F89",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 14,
             "lineHeight": 20,
           }
@@ -1522,22 +1543,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -1554,22 +1575,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -1588,8 +1609,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
     <Text
       style={
         {
-          "color": "$textMutedLight",
-          "fontFamily": "Raleway_400Regular",
+          "color": "#5D6F89",
+          "fontFamily": "Inter_400Regular",
           "fontSize": 14,
           "lineHeight": 20,
         }
@@ -1618,7 +1639,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1636,18 +1657,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1660,8 +1681,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1683,7 +1704,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1700,10 +1721,10 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "$brandPrimaryLight",
+            "backgroundColor": "#087FA7",
             "borderBottomColor": "transparent",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
             "borderLeftColor": "transparent",
             "borderLeftWidth": 1,
@@ -1711,8 +1732,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "borderTopColor": "transparent",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1725,8 +1746,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <Text
           style={
             {
-              "color": "$brandPrimaryForegroundLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#ffffff",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1748,7 +1769,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1766,18 +1787,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1790,8 +1811,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1813,7 +1834,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -1831,18 +1852,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -1855,8 +1876,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -1876,26 +1897,33 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
 <View
   style={
     {
-      "backgroundColor": "$surfaceCardLight",
-      "borderBottomColor": "$borderMutedLight",
-      "borderBottomLeftRadius": 14,
-      "borderBottomRightRadius": 14,
+      "backgroundColor": "#ffffff",
+      "borderBottomColor": "#D8E3EF",
+      "borderBottomLeftRadius": 20,
+      "borderBottomRightRadius": 20,
       "borderBottomWidth": 1,
-      "borderLeftColor": "$borderMutedLight",
+      "borderLeftColor": "#D8E3EF",
       "borderLeftWidth": 1,
-      "borderRightColor": "$borderMutedLight",
+      "borderRightColor": "#D8E3EF",
       "borderRightWidth": 1,
       "borderStyle": "solid",
-      "borderTopColor": "$borderMutedLight",
-      "borderTopLeftRadius": 14,
-      "borderTopRightRadius": 14,
+      "borderTopColor": "#D8E3EF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
       "borderTopWidth": 1,
       "flexDirection": "column",
-      "gap": 8,
-      "paddingBottom": 16,
-      "paddingLeft": 16,
-      "paddingRight": 16,
-      "paddingTop": 16,
+      "gap": 12,
+      "paddingBottom": 24,
+      "paddingLeft": 24,
+      "paddingRight": 24,
+      "paddingTop": 24,
+      "shadowColor": "rgb(10,22,40)",
+      "shadowOffset": {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 3,
     }
   }
   testID="credit-card-card-card-1"
@@ -1930,8 +1958,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -1943,8 +1971,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -1957,8 +1985,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
       <Text
         style={
           {
-            "color": "$textPrimaryLight",
-            "fontFamily": "PlayfairDisplay_600SemiBold",
+            "color": "#0A1628",
+            "fontFamily": "Inter_600SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
           }
@@ -1981,22 +2009,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$brandPrimaryLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#087FA7",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$brandPrimaryForegroundLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#ffffff",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -2013,22 +2041,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -2046,22 +2074,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -2087,7 +2115,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
       <View
         style={
           {
-            "backgroundColor": "$surfaceRaisedLight",
+            "backgroundColor": "#F8FBFF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderTopLeftRadius": 28,
@@ -2102,7 +2130,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$dangerLight",
+              "backgroundColor": "#C2414D",
               "borderBottomLeftRadius": 28,
               "borderBottomRightRadius": 28,
               "borderTopLeftRadius": 28,
@@ -2117,8 +2145,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
       <Text
         style={
           {
-            "color": "$textMutedLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#5D6F89",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 14,
             "lineHeight": 20,
           }
@@ -2146,22 +2174,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -2178,22 +2206,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -2212,8 +2240,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
     <Text
       style={
         {
-          "color": "$textMutedLight",
-          "fontFamily": "Raleway_400Regular",
+          "color": "#5D6F89",
+          "fontFamily": "Inter_400Regular",
           "fontSize": 14,
           "lineHeight": 20,
         }
@@ -2242,7 +2270,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -2260,18 +2288,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -2284,8 +2312,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -2307,7 +2335,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -2324,10 +2352,10 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "$brandPrimaryLight",
+            "backgroundColor": "#087FA7",
             "borderBottomColor": "transparent",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
             "borderLeftColor": "transparent",
             "borderLeftWidth": 1,
@@ -2335,8 +2363,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "borderTopColor": "transparent",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -2349,8 +2377,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <Text
           style={
             {
-              "color": "$brandPrimaryForegroundLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#ffffff",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -2372,7 +2400,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -2390,18 +2418,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -2414,8 +2442,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -2437,7 +2465,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -2455,18 +2483,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -2479,8 +2507,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -2500,26 +2528,33 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
 <View
   style={
     {
-      "backgroundColor": "$surfaceCardLight",
-      "borderBottomColor": "$borderMutedLight",
-      "borderBottomLeftRadius": 14,
-      "borderBottomRightRadius": 14,
+      "backgroundColor": "#ffffff",
+      "borderBottomColor": "#D8E3EF",
+      "borderBottomLeftRadius": 20,
+      "borderBottomRightRadius": 20,
       "borderBottomWidth": 1,
-      "borderLeftColor": "$borderMutedLight",
+      "borderLeftColor": "#D8E3EF",
       "borderLeftWidth": 1,
-      "borderRightColor": "$borderMutedLight",
+      "borderRightColor": "#D8E3EF",
       "borderRightWidth": 1,
       "borderStyle": "solid",
-      "borderTopColor": "$borderMutedLight",
-      "borderTopLeftRadius": 14,
-      "borderTopRightRadius": 14,
+      "borderTopColor": "#D8E3EF",
+      "borderTopLeftRadius": 20,
+      "borderTopRightRadius": 20,
       "borderTopWidth": 1,
       "flexDirection": "column",
-      "gap": 8,
-      "paddingBottom": 16,
-      "paddingLeft": 16,
-      "paddingRight": 16,
-      "paddingTop": 16,
+      "gap": 12,
+      "paddingBottom": 24,
+      "paddingLeft": 24,
+      "paddingRight": 24,
+      "paddingTop": 24,
+      "shadowColor": "rgb(10,22,40)",
+      "shadowOffset": {
+        "height": 2,
+        "width": 0,
+      },
+      "shadowOpacity": 1,
+      "shadowRadius": 3,
     }
   }
   testID="credit-card-card-card-1"
@@ -2554,8 +2589,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -2567,8 +2602,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -2581,8 +2616,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
       <Text
         style={
           {
-            "color": "$textPrimaryLight",
-            "fontFamily": "PlayfairDisplay_600SemiBold",
+            "color": "#0A1628",
+            "fontFamily": "Inter_600SemiBold",
             "fontSize": 16,
             "lineHeight": 24,
           }
@@ -2605,22 +2640,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$brandPrimaryLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#087FA7",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$brandPrimaryForegroundLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#ffffff",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -2637,22 +2672,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -2670,22 +2705,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         style={
           {
             "alignSelf": "flex-start",
-            "backgroundColor": "$surfaceRaisedLight",
-            "borderBottomColor": "$borderMutedLight",
+            "backgroundColor": "#F8FBFF",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$borderMutedLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$borderMutedLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$borderMutedLight",
+            "borderTopColor": "#D8E3EF",
             "borderTopLeftRadius": 28,
             "borderTopRightRadius": 28,
             "borderTopWidth": 1,
-            "color": "$textPrimaryLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#0A1628",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 13,
             "lineHeight": 18,
             "paddingBottom": 4,
@@ -2711,7 +2746,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
       <View
         style={
           {
-            "backgroundColor": "$surfaceRaisedLight",
+            "backgroundColor": "#F8FBFF",
             "borderBottomLeftRadius": 28,
             "borderBottomRightRadius": 28,
             "borderTopLeftRadius": 28,
@@ -2726,7 +2761,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$dangerLight",
+              "backgroundColor": "#C2414D",
               "borderBottomLeftRadius": 28,
               "borderBottomRightRadius": 28,
               "borderTopLeftRadius": 28,
@@ -2741,8 +2776,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
       <Text
         style={
           {
-            "color": "$textMutedLight",
-            "fontFamily": "Raleway_400Regular",
+            "color": "#5D6F89",
+            "fontFamily": "Inter_400Regular",
             "fontSize": 14,
             "lineHeight": 20,
           }
@@ -2770,22 +2805,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -2802,22 +2837,22 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$surfaceRaisedLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#F8FBFF",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$textPrimaryLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#0A1628",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -2836,8 +2871,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
     <Text
       style={
         {
-          "color": "$textMutedLight",
-          "fontFamily": "Raleway_400Regular",
+          "color": "#5D6F89",
+          "fontFamily": "Inter_400Regular",
           "fontSize": 14,
           "lineHeight": 20,
         }
@@ -2866,7 +2901,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -2884,18 +2919,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -2908,8 +2943,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -2931,7 +2966,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -2948,10 +2983,10 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         style={
           {
             "alignItems": "center",
-            "backgroundColor": "$brandPrimaryLight",
+            "backgroundColor": "#087FA7",
             "borderBottomColor": "transparent",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
             "borderLeftColor": "transparent",
             "borderLeftWidth": 1,
@@ -2959,8 +2994,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             "borderRightWidth": 1,
             "borderStyle": "solid",
             "borderTopColor": "transparent",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -2973,8 +3008,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <Text
           style={
             {
-              "color": "$brandPrimaryForegroundLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#ffffff",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -2996,7 +3031,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -3014,18 +3049,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -3038,8 +3073,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",
@@ -3061,7 +3096,7 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         accessible={true}
         focusVisibleStyle={
           {
-            "outlineColor": "$brandPrimaryLight",
+            "outlineColor": "#087FA7",
             "outlineStyle": "solid",
             "outlineWidth": 2,
           }
@@ -3079,18 +3114,18 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
           {
             "alignItems": "center",
             "backgroundColor": "transparent",
-            "borderBottomColor": "$brandSecondaryLight",
-            "borderBottomLeftRadius": 10,
-            "borderBottomRightRadius": 10,
+            "borderBottomColor": "#D8E3EF",
+            "borderBottomLeftRadius": 999,
+            "borderBottomRightRadius": 999,
             "borderBottomWidth": 1,
-            "borderLeftColor": "$brandSecondaryLight",
+            "borderLeftColor": "#D8E3EF",
             "borderLeftWidth": 1,
-            "borderRightColor": "$brandSecondaryLight",
+            "borderRightColor": "#D8E3EF",
             "borderRightWidth": 1,
             "borderStyle": "solid",
-            "borderTopColor": "$brandSecondaryLight",
-            "borderTopLeftRadius": 10,
-            "borderTopRightRadius": 10,
+            "borderTopColor": "#D8E3EF",
+            "borderTopLeftRadius": 999,
+            "borderTopRightRadius": 999,
             "borderTopWidth": 1,
             "cursor": "pointer",
             "flexDirection": "row",
@@ -3103,8 +3138,8 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "Raleway_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 15,
               "lineHeight": 22,
               "textAlign": "center",

--- a/features/dashboard/components/dashboard-comparison-card.tsx
+++ b/features/dashboard/components/dashboard-comparison-card.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/features/dashboard/services/period-comparison";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { useT } from "@/shared/i18n";
+import { AppMoneyText } from "@/shared/components/app-money-text";
 import { formatCurrency } from "@/shared/utils/formatters";
 
 export interface DashboardComparisonCardProps {
@@ -84,9 +85,9 @@ export function DashboardComparisonCard({
         <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
           {title}
         </Paragraph>
-        <Paragraph color="$color" fontFamily="$heading" fontSize="$7">
+        <AppMoneyText fontSize="$7">
           {formatCurrency(value)}
-        </Paragraph>
+        </AppMoneyText>
         {hasBaseline ? (
           <XStack gap="$1" alignItems="center">
             <MaterialCommunityIcons

--- a/features/dashboard/screens/dashboard-screen.tsx
+++ b/features/dashboard/screens/dashboard-screen.tsx
@@ -45,6 +45,7 @@ import type {
   SavingsRateLevel,
 } from "@/features/dashboard/services/savings-rate-calculator";
 import { AppButton } from "@/shared/components/app-button";
+import { AppMoneyText } from "@/shared/components/app-money-text";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { DashboardSkeleton, MetricGridSkeleton } from "@/shared/skeletons";
 import {
@@ -312,9 +313,9 @@ function BalanceCard({ controller }: ControllerProps): ReactElement {
             <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
               Saldo geral
             </Paragraph>
-            <Paragraph color="$color" fontFamily="$heading" fontSize="$8">
+            <AppMoneyText fontSize="$8">
               {formatCurrency(controller.currentBalance)}
-            </Paragraph>
+            </AppMoneyText>
           </YStack>
         )}
       </AppQueryState>

--- a/features/insights/components/__snapshots__/insight-hub.test.tsx.snap
+++ b/features/insights/components/__snapshots__/insight-hub.test.tsx.snap
@@ -12,26 +12,33 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
   <View
     style={
       {
-        "backgroundColor": "$surfaceCardLight",
-        "borderBottomColor": "$borderMutedLight",
-        "borderBottomLeftRadius": 14,
-        "borderBottomRightRadius": 14,
+        "backgroundColor": "#ffffff",
+        "borderBottomColor": "#D8E3EF",
+        "borderBottomLeftRadius": 20,
+        "borderBottomRightRadius": 20,
         "borderBottomWidth": 1,
-        "borderLeftColor": "$borderMutedLight",
+        "borderLeftColor": "#D8E3EF",
         "borderLeftWidth": 1,
-        "borderRightColor": "$borderMutedLight",
+        "borderRightColor": "#D8E3EF",
         "borderRightWidth": 1,
         "borderStyle": "solid",
-        "borderTopColor": "$borderMutedLight",
-        "borderTopLeftRadius": 14,
-        "borderTopRightRadius": 14,
+        "borderTopColor": "#D8E3EF",
+        "borderTopLeftRadius": 20,
+        "borderTopRightRadius": 20,
         "borderTopWidth": 1,
         "flexDirection": "column",
-        "gap": 8,
-        "paddingBottom": 16,
-        "paddingLeft": 16,
-        "paddingRight": 16,
-        "paddingTop": 16,
+        "gap": 12,
+        "paddingBottom": 24,
+        "paddingLeft": 24,
+        "paddingRight": 24,
+        "paddingTop": 24,
+        "shadowColor": "rgb(10,22,40)",
+        "shadowOffset": {
+          "height": 2,
+          "width": 0,
+        },
+        "shadowOpacity": 1,
+        "shadowRadius": 3,
       }
     }
   >
@@ -39,8 +46,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
       role="heading"
       style={
         {
-          "color": "$textPrimaryLight",
-          "fontFamily": "PlayfairDisplay_700Bold",
+          "color": "#0A1628",
+          "fontFamily": "Inter_700Bold",
           "fontSize": 20,
           "lineHeight": 36,
           "marginBottom": 0,
@@ -56,8 +63,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
     <Text
       style={
         {
-          "color": "$textMutedLight",
-          "fontFamily": "Raleway_400Regular",
+          "color": "#5D6F89",
+          "fontFamily": "Inter_400Regular",
           "fontSize": 14,
           "lineHeight": 20,
         }
@@ -95,22 +102,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             style={
               {
                 "alignSelf": "flex-start",
-                "backgroundColor": "$brandPrimaryLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#087FA7",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 28,
                 "borderBottomRightRadius": 28,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 28,
                 "borderTopRightRadius": 28,
                 "borderTopWidth": 1,
-                "color": "$brandPrimaryForegroundLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#ffffff",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 13,
                 "lineHeight": 18,
                 "paddingBottom": 4,
@@ -126,8 +133,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textMutedLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#5D6F89",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 14,
                 "lineHeight": 20,
               }
@@ -139,8 +146,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textMutedLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#5D6F89",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 14,
                 "lineHeight": 20,
               }
@@ -169,7 +176,7 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             accessible={true}
             focusVisibleStyle={
               {
-                "outlineColor": "$brandPrimaryLight",
+                "outlineColor": "#087FA7",
                 "outlineStyle": "solid",
                 "outlineWidth": 2,
               }
@@ -186,10 +193,10 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             style={
               {
                 "alignItems": "center",
-                "backgroundColor": "$brandPrimaryLight",
+                "backgroundColor": "#087FA7",
                 "borderBottomColor": "transparent",
-                "borderBottomLeftRadius": 10,
-                "borderBottomRightRadius": 10,
+                "borderBottomLeftRadius": 999,
+                "borderBottomRightRadius": 999,
                 "borderBottomWidth": 1,
                 "borderLeftColor": "transparent",
                 "borderLeftWidth": 1,
@@ -197,8 +204,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
                 "borderTopColor": "transparent",
-                "borderTopLeftRadius": 10,
-                "borderTopRightRadius": 10,
+                "borderTopLeftRadius": 999,
+                "borderTopRightRadius": 999,
                 "borderTopWidth": 1,
                 "cursor": "pointer",
                 "flex": 1,
@@ -223,8 +230,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$brandPrimaryForegroundLight",
-                    "fontFamily": "Raleway_600SemiBold",
+                    "color": "#ffffff",
+                    "fontFamily": "Inter_600SemiBold",
                     "fontSize": 15,
                     "lineHeight": 22,
                   }
@@ -239,8 +246,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -261,17 +268,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <View
             style={
               {
-                "backgroundColor": "$surfaceCardLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#ffffff",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 14,
                 "borderBottomRightRadius": 14,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 14,
                 "borderTopRightRadius": 14,
                 "borderTopWidth": 1,
@@ -299,22 +306,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 style={
                   {
                     "alignSelf": "flex-start",
-                    "backgroundColor": "$surfaceRaisedLight",
-                    "borderBottomColor": "$borderMutedLight",
+                    "backgroundColor": "#F8FBFF",
+                    "borderBottomColor": "#D8E3EF",
                     "borderBottomLeftRadius": 28,
                     "borderBottomRightRadius": 28,
                     "borderBottomWidth": 1,
-                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftColor": "#D8E3EF",
                     "borderLeftWidth": 1,
-                    "borderRightColor": "$borderMutedLight",
+                    "borderRightColor": "#D8E3EF",
                     "borderRightWidth": 1,
                     "borderStyle": "solid",
-                    "borderTopColor": "$borderMutedLight",
+                    "borderTopColor": "#D8E3EF",
                     "borderTopLeftRadius": 28,
                     "borderTopRightRadius": 28,
                     "borderTopWidth": 1,
-                    "color": "$textPrimaryLight",
-                    "fontFamily": "Raleway_400Regular",
+                    "color": "#0A1628",
+                    "fontFamily": "Inter_400Regular",
                     "fontSize": 13,
                     "lineHeight": 18,
                     "paddingBottom": 4,
@@ -331,8 +338,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_600SemiBold",
                   "fontSize": 16,
                   "lineHeight": 24,
                 }
@@ -344,8 +351,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textMutedLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#5D6F89",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 14,
                   "lineHeight": 20,
                 }
@@ -358,17 +365,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <View
             style={
               {
-                "backgroundColor": "$surfaceCardLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#ffffff",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 14,
                 "borderBottomRightRadius": 14,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 14,
                 "borderTopRightRadius": 14,
                 "borderTopWidth": 1,
@@ -396,22 +403,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 style={
                   {
                     "alignSelf": "flex-start",
-                    "backgroundColor": "$surfaceRaisedLight",
-                    "borderBottomColor": "$borderMutedLight",
+                    "backgroundColor": "#F8FBFF",
+                    "borderBottomColor": "#D8E3EF",
                     "borderBottomLeftRadius": 28,
                     "borderBottomRightRadius": 28,
                     "borderBottomWidth": 1,
-                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftColor": "#D8E3EF",
                     "borderLeftWidth": 1,
-                    "borderRightColor": "$borderMutedLight",
+                    "borderRightColor": "#D8E3EF",
                     "borderRightWidth": 1,
                     "borderStyle": "solid",
-                    "borderTopColor": "$borderMutedLight",
+                    "borderTopColor": "#D8E3EF",
                     "borderTopLeftRadius": 28,
                     "borderTopRightRadius": 28,
                     "borderTopWidth": 1,
-                    "color": "$textPrimaryLight",
-                    "fontFamily": "Raleway_400Regular",
+                    "color": "#0A1628",
+                    "fontFamily": "Inter_400Regular",
                     "fontSize": 13,
                     "lineHeight": 18,
                     "paddingBottom": 4,
@@ -428,8 +435,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_600SemiBold",
                   "fontSize": 16,
                   "lineHeight": 24,
                 }
@@ -441,8 +448,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textMutedLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#5D6F89",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 14,
                   "lineHeight": 20,
                 }
@@ -455,17 +462,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <View
             style={
               {
-                "backgroundColor": "$surfaceCardLight",
-                "borderBottomColor": "$borderMutedLight",
+                "backgroundColor": "#ffffff",
+                "borderBottomColor": "#D8E3EF",
                 "borderBottomLeftRadius": 14,
                 "borderBottomRightRadius": 14,
                 "borderBottomWidth": 1,
-                "borderLeftColor": "$borderMutedLight",
+                "borderLeftColor": "#D8E3EF",
                 "borderLeftWidth": 1,
-                "borderRightColor": "$borderMutedLight",
+                "borderRightColor": "#D8E3EF",
                 "borderRightWidth": 1,
                 "borderStyle": "solid",
-                "borderTopColor": "$borderMutedLight",
+                "borderTopColor": "#D8E3EF",
                 "borderTopLeftRadius": 14,
                 "borderTopRightRadius": 14,
                 "borderTopWidth": 1,
@@ -493,22 +500,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 style={
                   {
                     "alignSelf": "flex-start",
-                    "backgroundColor": "$surfaceRaisedLight",
-                    "borderBottomColor": "$borderMutedLight",
+                    "backgroundColor": "#F8FBFF",
+                    "borderBottomColor": "#D8E3EF",
                     "borderBottomLeftRadius": 28,
                     "borderBottomRightRadius": 28,
                     "borderBottomWidth": 1,
-                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftColor": "#D8E3EF",
                     "borderLeftWidth": 1,
-                    "borderRightColor": "$borderMutedLight",
+                    "borderRightColor": "#D8E3EF",
                     "borderRightWidth": 1,
                     "borderStyle": "solid",
-                    "borderTopColor": "$borderMutedLight",
+                    "borderTopColor": "#D8E3EF",
                     "borderTopLeftRadius": 28,
                     "borderTopRightRadius": 28,
                     "borderTopWidth": 1,
-                    "color": "$textPrimaryLight",
-                    "fontFamily": "Raleway_400Regular",
+                    "color": "#0A1628",
+                    "fontFamily": "Inter_400Regular",
                     "fontSize": 13,
                     "lineHeight": 18,
                     "paddingBottom": 4,
@@ -525,8 +532,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_600SemiBold",
                   "fontSize": 16,
                   "lineHeight": 24,
                 }
@@ -538,8 +545,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textMutedLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#5D6F89",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 14,
                   "lineHeight": 20,
                 }
@@ -584,8 +591,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           role="heading"
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_700Bold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_700Bold",
               "fontSize": 20,
               "lineHeight": 36,
               "marginBottom": 0,
@@ -601,8 +608,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -633,8 +640,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -646,8 +653,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -669,17 +676,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$surfaceCardLight",
-              "borderBottomColor": "$borderMutedLight",
+              "backgroundColor": "#ffffff",
+              "borderBottomColor": "#D8E3EF",
               "borderBottomLeftRadius": 14,
               "borderBottomRightRadius": 14,
               "borderBottomWidth": 1,
-              "borderLeftColor": "$borderMutedLight",
+              "borderLeftColor": "#D8E3EF",
               "borderLeftWidth": 1,
-              "borderRightColor": "$borderMutedLight",
+              "borderRightColor": "#D8E3EF",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "borderTopColor": "$borderMutedLight",
+              "borderTopColor": "#D8E3EF",
               "borderTopLeftRadius": 14,
               "borderTopRightRadius": 14,
               "borderTopWidth": 1,
@@ -707,22 +714,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               style={
                 {
                   "alignSelf": "flex-start",
-                  "backgroundColor": "$surfaceRaisedLight",
-                  "borderBottomColor": "$borderMutedLight",
+                  "backgroundColor": "#F8FBFF",
+                  "borderBottomColor": "#D8E3EF",
                   "borderBottomLeftRadius": 28,
                   "borderBottomRightRadius": 28,
                   "borderBottomWidth": 1,
-                  "borderLeftColor": "$borderMutedLight",
+                  "borderLeftColor": "#D8E3EF",
                   "borderLeftWidth": 1,
-                  "borderRightColor": "$borderMutedLight",
+                  "borderRightColor": "#D8E3EF",
                   "borderRightWidth": 1,
                   "borderStyle": "solid",
-                  "borderTopColor": "$borderMutedLight",
+                  "borderTopColor": "#D8E3EF",
                   "borderTopLeftRadius": 28,
                   "borderTopRightRadius": 28,
                   "borderTopWidth": 1,
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 13,
                   "lineHeight": 18,
                   "paddingBottom": 4,
@@ -739,8 +746,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textPrimaryLight",
-                "fontFamily": "PlayfairDisplay_600SemiBold",
+                "color": "#0A1628",
+                "fontFamily": "Inter_600SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
               }
@@ -752,8 +759,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textMutedLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#5D6F89",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 14,
                 "lineHeight": 20,
               }
@@ -785,8 +792,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -798,8 +805,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -821,17 +828,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$surfaceCardLight",
-              "borderBottomColor": "$borderMutedLight",
+              "backgroundColor": "#ffffff",
+              "borderBottomColor": "#D8E3EF",
               "borderBottomLeftRadius": 14,
               "borderBottomRightRadius": 14,
               "borderBottomWidth": 1,
-              "borderLeftColor": "$borderMutedLight",
+              "borderLeftColor": "#D8E3EF",
               "borderLeftWidth": 1,
-              "borderRightColor": "$borderMutedLight",
+              "borderRightColor": "#D8E3EF",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "borderTopColor": "$borderMutedLight",
+              "borderTopColor": "#D8E3EF",
               "borderTopLeftRadius": 14,
               "borderTopRightRadius": 14,
               "borderTopWidth": 1,
@@ -859,22 +866,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               style={
                 {
                   "alignSelf": "flex-start",
-                  "backgroundColor": "$surfaceRaisedLight",
-                  "borderBottomColor": "$borderMutedLight",
+                  "backgroundColor": "#F8FBFF",
+                  "borderBottomColor": "#D8E3EF",
                   "borderBottomLeftRadius": 28,
                   "borderBottomRightRadius": 28,
                   "borderBottomWidth": 1,
-                  "borderLeftColor": "$borderMutedLight",
+                  "borderLeftColor": "#D8E3EF",
                   "borderLeftWidth": 1,
-                  "borderRightColor": "$borderMutedLight",
+                  "borderRightColor": "#D8E3EF",
                   "borderRightWidth": 1,
                   "borderStyle": "solid",
-                  "borderTopColor": "$borderMutedLight",
+                  "borderTopColor": "#D8E3EF",
                   "borderTopLeftRadius": 28,
                   "borderTopRightRadius": 28,
                   "borderTopWidth": 1,
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 13,
                   "lineHeight": 18,
                   "paddingBottom": 4,
@@ -891,8 +898,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textPrimaryLight",
-                "fontFamily": "PlayfairDisplay_600SemiBold",
+                "color": "#0A1628",
+                "fontFamily": "Inter_600SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
               }
@@ -904,8 +911,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textMutedLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#5D6F89",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 14,
                 "lineHeight": 20,
               }
@@ -937,8 +944,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_600SemiBold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_600SemiBold",
               "fontSize": 20,
               "lineHeight": 28,
             }
@@ -950,8 +957,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -973,17 +980,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <View
           style={
             {
-              "backgroundColor": "$surfaceCardLight",
-              "borderBottomColor": "$borderMutedLight",
+              "backgroundColor": "#ffffff",
+              "borderBottomColor": "#D8E3EF",
               "borderBottomLeftRadius": 14,
               "borderBottomRightRadius": 14,
               "borderBottomWidth": 1,
-              "borderLeftColor": "$borderMutedLight",
+              "borderLeftColor": "#D8E3EF",
               "borderLeftWidth": 1,
-              "borderRightColor": "$borderMutedLight",
+              "borderRightColor": "#D8E3EF",
               "borderRightWidth": 1,
               "borderStyle": "solid",
-              "borderTopColor": "$borderMutedLight",
+              "borderTopColor": "#D8E3EF",
               "borderTopLeftRadius": 14,
               "borderTopRightRadius": 14,
               "borderTopWidth": 1,
@@ -1011,22 +1018,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               style={
                 {
                   "alignSelf": "flex-start",
-                  "backgroundColor": "$surfaceRaisedLight",
-                  "borderBottomColor": "$borderMutedLight",
+                  "backgroundColor": "#F8FBFF",
+                  "borderBottomColor": "#D8E3EF",
                   "borderBottomLeftRadius": 28,
                   "borderBottomRightRadius": 28,
                   "borderBottomWidth": 1,
-                  "borderLeftColor": "$borderMutedLight",
+                  "borderLeftColor": "#D8E3EF",
                   "borderLeftWidth": 1,
-                  "borderRightColor": "$borderMutedLight",
+                  "borderRightColor": "#D8E3EF",
                   "borderRightWidth": 1,
                   "borderStyle": "solid",
-                  "borderTopColor": "$borderMutedLight",
+                  "borderTopColor": "#D8E3EF",
                   "borderTopLeftRadius": 28,
                   "borderTopRightRadius": 28,
                   "borderTopWidth": 1,
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 13,
                   "lineHeight": 18,
                   "paddingBottom": 4,
@@ -1043,8 +1050,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textPrimaryLight",
-                "fontFamily": "PlayfairDisplay_600SemiBold",
+                "color": "#0A1628",
+                "fontFamily": "Inter_600SemiBold",
                 "fontSize": 16,
                 "lineHeight": 24,
               }
@@ -1056,8 +1063,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textMutedLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#5D6F89",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 14,
                 "lineHeight": 20,
               }
@@ -1101,8 +1108,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           role="heading"
           style={
             {
-              "color": "$textPrimaryLight",
-              "fontFamily": "PlayfairDisplay_700Bold",
+              "color": "#0A1628",
+              "fontFamily": "Inter_700Bold",
               "fontSize": 20,
               "lineHeight": 36,
               "marginBottom": 0,
@@ -1118,8 +1125,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         <Text
           style={
             {
-              "color": "$textMutedLight",
-              "fontFamily": "Raleway_400Regular",
+              "color": "#5D6F89",
+              "fontFamily": "Inter_400Regular",
               "fontSize": 14,
               "lineHeight": 20,
             }
@@ -1141,7 +1148,7 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
       <View
         style={
           {
-            "borderBottomColor": "$borderMutedLight",
+            "borderBottomColor": "#D8E3EF",
             "borderBottomWidth": 1,
             "borderStyle": "solid",
             "flexDirection": "column",
@@ -1170,8 +1177,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textPrimaryLight",
-                  "fontFamily": "PlayfairDisplay_600SemiBold",
+                  "color": "#0A1628",
+                  "fontFamily": "Inter_600SemiBold",
                   "fontSize": 16,
                   "lineHeight": 24,
                 }
@@ -1183,8 +1190,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
             <Text
               style={
                 {
-                  "color": "$textMutedLight",
-                  "fontFamily": "Raleway_400Regular",
+                  "color": "#5D6F89",
+                  "fontFamily": "Inter_400Regular",
                   "fontSize": 14,
                   "lineHeight": 20,
                 }
@@ -1197,8 +1204,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
           <Text
             style={
               {
-                "color": "$textMutedLight",
-                "fontFamily": "Raleway_400Regular",
+                "color": "#5D6F89",
+                "fontFamily": "Inter_400Regular",
                 "fontSize": 14,
                 "lineHeight": 20,
               }
@@ -1227,8 +1234,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$textPrimaryLight",
-                    "fontFamily": "PlayfairDisplay_600SemiBold",
+                    "color": "#0A1628",
+                    "fontFamily": "Inter_600SemiBold",
                     "fontSize": 20,
                     "lineHeight": 28,
                   }
@@ -1240,8 +1247,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$textMutedLight",
-                    "fontFamily": "Raleway_400Regular",
+                    "color": "#5D6F89",
+                    "fontFamily": "Inter_400Regular",
                     "fontSize": 14,
                     "lineHeight": 20,
                   }
@@ -1263,17 +1270,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <View
                 style={
                   {
-                    "backgroundColor": "$surfaceCardLight",
-                    "borderBottomColor": "$borderMutedLight",
+                    "backgroundColor": "#ffffff",
+                    "borderBottomColor": "#D8E3EF",
                     "borderBottomLeftRadius": 14,
                     "borderBottomRightRadius": 14,
                     "borderBottomWidth": 1,
-                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftColor": "#D8E3EF",
                     "borderLeftWidth": 1,
-                    "borderRightColor": "$borderMutedLight",
+                    "borderRightColor": "#D8E3EF",
                     "borderRightWidth": 1,
                     "borderStyle": "solid",
-                    "borderTopColor": "$borderMutedLight",
+                    "borderTopColor": "#D8E3EF",
                     "borderTopLeftRadius": 14,
                     "borderTopRightRadius": 14,
                     "borderTopWidth": 1,
@@ -1301,22 +1308,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                     style={
                       {
                         "alignSelf": "flex-start",
-                        "backgroundColor": "$surfaceRaisedLight",
-                        "borderBottomColor": "$borderMutedLight",
+                        "backgroundColor": "#F8FBFF",
+                        "borderBottomColor": "#D8E3EF",
                         "borderBottomLeftRadius": 28,
                         "borderBottomRightRadius": 28,
                         "borderBottomWidth": 1,
-                        "borderLeftColor": "$borderMutedLight",
+                        "borderLeftColor": "#D8E3EF",
                         "borderLeftWidth": 1,
-                        "borderRightColor": "$borderMutedLight",
+                        "borderRightColor": "#D8E3EF",
                         "borderRightWidth": 1,
                         "borderStyle": "solid",
-                        "borderTopColor": "$borderMutedLight",
+                        "borderTopColor": "#D8E3EF",
                         "borderTopLeftRadius": 28,
                         "borderTopRightRadius": 28,
                         "borderTopWidth": 1,
-                        "color": "$textPrimaryLight",
-                        "fontFamily": "Raleway_400Regular",
+                        "color": "#0A1628",
+                        "fontFamily": "Inter_400Regular",
                         "fontSize": 13,
                         "lineHeight": 18,
                         "paddingBottom": 4,
@@ -1333,8 +1340,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 <Text
                   style={
                     {
-                      "color": "$textPrimaryLight",
-                      "fontFamily": "PlayfairDisplay_600SemiBold",
+                      "color": "#0A1628",
+                      "fontFamily": "Inter_600SemiBold",
                       "fontSize": 16,
                       "lineHeight": 24,
                     }
@@ -1346,8 +1353,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 <Text
                   style={
                     {
-                      "color": "$textMutedLight",
-                      "fontFamily": "Raleway_400Regular",
+                      "color": "#5D6F89",
+                      "fontFamily": "Inter_400Regular",
                       "fontSize": 14,
                       "lineHeight": 20,
                     }
@@ -1379,8 +1386,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$textPrimaryLight",
-                    "fontFamily": "PlayfairDisplay_600SemiBold",
+                    "color": "#0A1628",
+                    "fontFamily": "Inter_600SemiBold",
                     "fontSize": 20,
                     "lineHeight": 28,
                   }
@@ -1392,8 +1399,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$textMutedLight",
-                    "fontFamily": "Raleway_400Regular",
+                    "color": "#5D6F89",
+                    "fontFamily": "Inter_400Regular",
                     "fontSize": 14,
                     "lineHeight": 20,
                   }
@@ -1415,17 +1422,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <View
                 style={
                   {
-                    "backgroundColor": "$surfaceCardLight",
-                    "borderBottomColor": "$borderMutedLight",
+                    "backgroundColor": "#ffffff",
+                    "borderBottomColor": "#D8E3EF",
                     "borderBottomLeftRadius": 14,
                     "borderBottomRightRadius": 14,
                     "borderBottomWidth": 1,
-                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftColor": "#D8E3EF",
                     "borderLeftWidth": 1,
-                    "borderRightColor": "$borderMutedLight",
+                    "borderRightColor": "#D8E3EF",
                     "borderRightWidth": 1,
                     "borderStyle": "solid",
-                    "borderTopColor": "$borderMutedLight",
+                    "borderTopColor": "#D8E3EF",
                     "borderTopLeftRadius": 14,
                     "borderTopRightRadius": 14,
                     "borderTopWidth": 1,
@@ -1453,22 +1460,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                     style={
                       {
                         "alignSelf": "flex-start",
-                        "backgroundColor": "$surfaceRaisedLight",
-                        "borderBottomColor": "$borderMutedLight",
+                        "backgroundColor": "#F8FBFF",
+                        "borderBottomColor": "#D8E3EF",
                         "borderBottomLeftRadius": 28,
                         "borderBottomRightRadius": 28,
                         "borderBottomWidth": 1,
-                        "borderLeftColor": "$borderMutedLight",
+                        "borderLeftColor": "#D8E3EF",
                         "borderLeftWidth": 1,
-                        "borderRightColor": "$borderMutedLight",
+                        "borderRightColor": "#D8E3EF",
                         "borderRightWidth": 1,
                         "borderStyle": "solid",
-                        "borderTopColor": "$borderMutedLight",
+                        "borderTopColor": "#D8E3EF",
                         "borderTopLeftRadius": 28,
                         "borderTopRightRadius": 28,
                         "borderTopWidth": 1,
-                        "color": "$textPrimaryLight",
-                        "fontFamily": "Raleway_400Regular",
+                        "color": "#0A1628",
+                        "fontFamily": "Inter_400Regular",
                         "fontSize": 13,
                         "lineHeight": 18,
                         "paddingBottom": 4,
@@ -1485,8 +1492,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 <Text
                   style={
                     {
-                      "color": "$textPrimaryLight",
-                      "fontFamily": "PlayfairDisplay_600SemiBold",
+                      "color": "#0A1628",
+                      "fontFamily": "Inter_600SemiBold",
                       "fontSize": 16,
                       "lineHeight": 24,
                     }
@@ -1498,8 +1505,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 <Text
                   style={
                     {
-                      "color": "$textMutedLight",
-                      "fontFamily": "Raleway_400Regular",
+                      "color": "#5D6F89",
+                      "fontFamily": "Inter_400Regular",
                       "fontSize": 14,
                       "lineHeight": 20,
                     }
@@ -1531,8 +1538,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$textPrimaryLight",
-                    "fontFamily": "PlayfairDisplay_600SemiBold",
+                    "color": "#0A1628",
+                    "fontFamily": "Inter_600SemiBold",
                     "fontSize": 20,
                     "lineHeight": 28,
                   }
@@ -1544,8 +1551,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <Text
                 style={
                   {
-                    "color": "$textMutedLight",
-                    "fontFamily": "Raleway_400Regular",
+                    "color": "#5D6F89",
+                    "fontFamily": "Inter_400Regular",
                     "fontSize": 14,
                     "lineHeight": 20,
                   }
@@ -1567,17 +1574,17 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
               <View
                 style={
                   {
-                    "backgroundColor": "$surfaceCardLight",
-                    "borderBottomColor": "$borderMutedLight",
+                    "backgroundColor": "#ffffff",
+                    "borderBottomColor": "#D8E3EF",
                     "borderBottomLeftRadius": 14,
                     "borderBottomRightRadius": 14,
                     "borderBottomWidth": 1,
-                    "borderLeftColor": "$borderMutedLight",
+                    "borderLeftColor": "#D8E3EF",
                     "borderLeftWidth": 1,
-                    "borderRightColor": "$borderMutedLight",
+                    "borderRightColor": "#D8E3EF",
                     "borderRightWidth": 1,
                     "borderStyle": "solid",
-                    "borderTopColor": "$borderMutedLight",
+                    "borderTopColor": "#D8E3EF",
                     "borderTopLeftRadius": 14,
                     "borderTopRightRadius": 14,
                     "borderTopWidth": 1,
@@ -1605,22 +1612,22 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                     style={
                       {
                         "alignSelf": "flex-start",
-                        "backgroundColor": "$surfaceRaisedLight",
-                        "borderBottomColor": "$borderMutedLight",
+                        "backgroundColor": "#F8FBFF",
+                        "borderBottomColor": "#D8E3EF",
                         "borderBottomLeftRadius": 28,
                         "borderBottomRightRadius": 28,
                         "borderBottomWidth": 1,
-                        "borderLeftColor": "$borderMutedLight",
+                        "borderLeftColor": "#D8E3EF",
                         "borderLeftWidth": 1,
-                        "borderRightColor": "$borderMutedLight",
+                        "borderRightColor": "#D8E3EF",
                         "borderRightWidth": 1,
                         "borderStyle": "solid",
-                        "borderTopColor": "$borderMutedLight",
+                        "borderTopColor": "#D8E3EF",
                         "borderTopLeftRadius": 28,
                         "borderTopRightRadius": 28,
                         "borderTopWidth": 1,
-                        "color": "$textPrimaryLight",
-                        "fontFamily": "Raleway_400Regular",
+                        "color": "#0A1628",
+                        "fontFamily": "Inter_400Regular",
                         "fontSize": 13,
                         "lineHeight": 18,
                         "paddingBottom": 4,
@@ -1637,8 +1644,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 <Text
                   style={
                     {
-                      "color": "$textPrimaryLight",
-                      "fontFamily": "PlayfairDisplay_600SemiBold",
+                      "color": "#0A1628",
+                      "fontFamily": "Inter_600SemiBold",
                       "fontSize": 16,
                       "lineHeight": 24,
                     }
@@ -1650,8 +1657,8 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 <Text
                   style={
                     {
-                      "color": "$textMutedLight",
-                      "fontFamily": "Raleway_400Regular",
+                      "color": "#5D6F89",
+                      "fontFamily": "Inter_400Regular",
                       "fontSize": 14,
                       "lineHeight": 20,
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "auraxis-app",
       "version": "1.7.0",
       "dependencies": {
-        "@expo-google-fonts/playfair-display": "^0.4.2",
-        "@expo-google-fonts/raleway": "^0.4.2",
+        "@expo-google-fonts/ibm-plex-mono": "^0.4.1",
+        "@expo-google-fonts/inter": "^0.4.2",
         "@expo/vector-icons": "^15.0.3",
         "@hookform/resolvers": "^5.4.0",
         "@react-navigation/bottom-tabs": "^7.16.2",
@@ -2196,23 +2196,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@expo-google-fonts/ibm-plex-mono": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/ibm-plex-mono/-/ibm-plex-mono-0.4.1.tgz",
+      "integrity": "sha512-/yYz1mPZq8Nd4tSiH0SBDPEdJUqiOGBwVgSrQvLuw7SPh6C7ezBzmi6eFyHY4QaQwjHDmOLSBKsxzq8ZDFXVAg==",
+      "license": "MIT AND OFL-1.1"
+    },
+    "node_modules/@expo-google-fonts/inter": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/inter/-/inter-0.4.2.tgz",
+      "integrity": "sha512-syfiImMaDmq7cFi0of+waE2M4uSCyd16zgyWxdPOY7fN2VBmSLKEzkfbZgeOjJq61kSqPBNNtXjggiQiSD6gMQ==",
+      "license": "MIT AND OFL-1.1"
+    },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.38",
       "resolved": "https://registry.npmjs.org/@expo-google-fonts/material-symbols/-/material-symbols-0.4.38.tgz",
       "integrity": "sha512-IJkBtN1o8u9BW5fvSii1MyHPQ7Q0HxbWcVBvOrOzgMLpVtZw7R2w94wBTVR7kZwv3w1JNTESMmLA5Sqn1+Z36A==",
       "license": "MIT AND Apache-2.0"
-    },
-    "node_modules/@expo-google-fonts/playfair-display": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/playfair-display/-/playfair-display-0.4.2.tgz",
-      "integrity": "sha512-mWhBV59RUjSS3aYpytUb7UyHHTnXcHh7epAn7gq+M4XAEh5PuMKUrP8eiUfkJLb6UwHZCi7EhQpUzxHu5OL96w==",
-      "license": "MIT AND OFL-1.1"
-    },
-    "node_modules/@expo-google-fonts/raleway": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@expo-google-fonts/raleway/-/raleway-0.4.2.tgz",
-      "integrity": "sha512-EFHYXFx9/M+6kGt/T2/y2Aqo30SosZUp4d8Dd7aLumhacrwlcRL6GYMqwIYQpLbR0xh5Vn4/APH5N72tEkoKRA==",
-      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo/cli": {
       "version": "55.0.32",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "e2e:visual": "maestro test .maestro/visual_baseline.yaml"
   },
   "dependencies": {
-    "@expo-google-fonts/playfair-display": "^0.4.2",
-    "@expo-google-fonts/raleway": "^0.4.2",
+    "@expo-google-fonts/ibm-plex-mono": "^0.4.1",
+    "@expo-google-fonts/inter": "^0.4.2",
     "@expo/vector-icons": "^15.0.3",
     "@hookform/resolvers": "^5.4.0",
     "@react-navigation/bottom-tabs": "^7.16.2",

--- a/shared/components/app-button.tsx
+++ b/shared/components/app-button.tsx
@@ -9,9 +9,11 @@ import {
   triggerHapticImpact,
 } from "@/shared/feedback/haptics";
 
+// Botões pill (raio total) — paridade com os CTAs do web ("Entrar na
+// Auraxis", chips de período do dashboard).
 const PrimaryButtonFrame = styled(Button, {
   backgroundColor: "$primary",
-  borderRadius: "$1",
+  borderRadius: "$5",
   pressStyle: {
     backgroundColor: "$primaryPressed",
   },
@@ -19,17 +21,18 @@ const PrimaryButtonFrame = styled(Button, {
 
 const SecondaryButtonFrame = styled(Button, {
   backgroundColor: "transparent",
-  borderRadius: "$1",
-  borderColor: "$secondary",
+  borderRadius: "$5",
+  borderColor: "$borderColor",
   borderWidth: borderWidths.hairline,
   pressStyle: {
     backgroundColor: "$surfaceRaised",
+    borderColor: "$borderColorHover",
   },
 });
 
 const DangerButtonFrame = styled(Button, {
   backgroundColor: "$danger",
-  borderRadius: "$1",
+  borderRadius: "$5",
   pressStyle: {
     backgroundColor: "$dangerStrong",
   },

--- a/shared/components/app-input-field.tsx
+++ b/shared/components/app-input-field.tsx
@@ -9,11 +9,15 @@ const FieldInput = styled(Input, {
   backgroundColor: "$surfaceRaised",
   borderColor: "$borderColor",
   borderWidth: borderWidths.hairline,
-  borderRadius: "$1",
+  borderRadius: "$2",
   color: "$color",
   fontFamily: "$body",
   fontSize: "$4",
   placeholderTextColor: "$placeholderColor",
+  focusStyle: {
+    borderColor: "$borderColorFocus",
+    borderWidth: borderWidths.hairline,
+  },
 });
 
 export interface AppInputFieldProps

--- a/shared/components/app-money-text.tsx
+++ b/shared/components/app-money-text.tsx
@@ -1,0 +1,25 @@
+import type { ComponentProps, ReactElement } from "react";
+
+import { Paragraph, styled } from "tamagui";
+
+// Valores financeiros em IBM Plex Mono — assinatura visual do dashboard
+// web (auraxis-web typography.mono). Dígitos tabulares evitam "dança" de
+// layout quando os valores mudam.
+const MoneyParagraph = styled(Paragraph, {
+  fontFamily: "$mono",
+  fontWeight: "$5",
+  color: "$color",
+});
+
+export type AppMoneyTextProps = ComponentProps<typeof MoneyParagraph>;
+
+/**
+ * Texto canônico para valores monetários (R$).
+ *
+ * @param props Estilos Tamagui usuais; o conteúdo deve vir já formatado
+ *              (ex.: via `formatCurrency`).
+ * @returns Paragraph com a fonte mono do DS.
+ */
+export function AppMoneyText(props: AppMoneyTextProps): ReactElement {
+  return <MoneyParagraph {...props} />;
+}

--- a/shared/components/app-surface-card.tsx
+++ b/shared/components/app-surface-card.tsx
@@ -5,13 +5,20 @@ import { Paragraph, YStack, styled } from "tamagui";
 import { borderWidths } from "@/config/design-tokens";
 import { AppHeading } from "@/shared/components/app-heading";
 
+// Cards de superfície com raio 20 + sombra suave — paridade com os cards
+// brancos do dashboard web (border #D8E3EF + shadow card).
 const SurfaceFrame = styled(YStack, {
   backgroundColor: "$surfaceCard",
   borderColor: "$borderColor",
   borderWidth: borderWidths.hairline,
-  borderRadius: "$2",
-  padding: "$4",
-  gap: "$2",
+  borderRadius: "$3",
+  padding: "$5",
+  gap: "$3",
+  shadowColor: "#0A1628",
+  shadowOffset: { width: 0, height: 6 },
+  shadowOpacity: 0.06,
+  shadowRadius: 16,
+  elevation: 2,
 });
 
 export interface AppSurfaceCardProps extends ComponentProps<typeof SurfaceFrame> {

--- a/shared/theme/semantic-theme.test.ts
+++ b/shared/theme/semantic-theme.test.ts
@@ -21,19 +21,19 @@ describe("semantic theme tokens", () => {
     });
   });
 
-  it("keeps light mode on DS v3 accents with high-contrast native surfaces", () => {
+  it("keeps light mode identical to the web canonical light palette (semantic.ts)", () => {
     expect(lightSemanticColors).toMatchObject({
-      background: "#f8fbff",
+      background: "#F4F8FB",
       surface: "#ffffff",
-      surfaceRaised: "#eef4fb",
-      foreground: "#0a0f1a",
-      mutedForeground: "#2d4466",
-      primary: "#1598be",
-      secondary: "#594fc2",
-      success: "#169b6b",
-      danger: "#c53f4a",
-      warning: "#c68431",
-      info: "#1598be",
+      surfaceRaised: "#F8FBFF",
+      foreground: "#0A1628",
+      mutedForeground: "#5D6F89",
+      primary: "#087FA7",
+      secondary: "#6F62E2",
+      success: "#087F5B",
+      danger: "#C2414D",
+      warning: "#B7791F",
+      info: "#2563EB",
     });
   });
 

--- a/shared/theme/semantic-theme.ts
+++ b/shared/theme/semantic-theme.ts
@@ -27,29 +27,29 @@ export const darkSemanticColors = {
 } as const;
 
 /**
- * Light variant for native screens. DS v3 is dark-first on web, so the
- * mobile light mode keeps the same cyan/violet/lime/red accent families
- * while using high-contrast white and blue-grey surfaces.
+ * Light variant — DEFAULT do app, paridade exata com o tema light do web
+ * (`auraxis-web/app/theme/tokens/semantic.ts`, palette `light`). Teal
+ * #087FA7 como ação primária sobre superfícies brancas/azul-acinzentadas.
  */
 export const lightSemanticColors = {
-  background: "#f8fbff",
+  background: "#F4F8FB",
   surface: colorPalette.white,
-  surfaceRaised: "#eef4fb",
-  foreground: colorPalette.neutral900,
-  mutedForeground: colorPalette.neutral600,
-  subduedForeground: colorPalette.text400,
-  primary: colorPalette.cyan700,
-  primaryPressed: colorPalette.cyan600,
-  primaryForeground: colorPalette.neutral950,
-  secondary: colorPalette.violet700,
-  secondaryPressed: colorPalette.violet600,
-  border: "rgba(29,43,68,0.14)",
-  borderStrong: "rgba(21,152,190,0.42)",
-  success: colorPalette.lime700,
-  danger: colorPalette.red700,
-  dangerStrong: colorPalette.red700,
-  warning: colorPalette.orange700,
-  info: colorPalette.cyan700,
+  surfaceRaised: "#F8FBFF",
+  foreground: "#0A1628",
+  mutedForeground: "#5D6F89",
+  subduedForeground: "#7A8BA3",
+  primary: "#087FA7",
+  primaryPressed: "#066985",
+  primaryForeground: colorPalette.white,
+  secondary: "#6F62E2",
+  secondaryPressed: "#594FC2",
+  border: "#D8E3EF",
+  borderStrong: "#087FA7",
+  success: "#087F5B",
+  danger: "#C2414D",
+  dangerStrong: "#A33440",
+  warning: "#B7791F",
+  info: "#2563EB",
 } as const;
 
 /**

--- a/shared/theme/theme-resolution.test.tsx
+++ b/shared/theme/theme-resolution.test.tsx
@@ -1,0 +1,50 @@
+import { render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { AppButton } from "@/shared/components/app-button";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { Paragraph } from "tamagui";
+
+// Regressão do bug "app preto e branco" (#539/#543): os temas do Tamagui
+// referenciavam tokens por string ("$brandPrimaryLight") que NUNCA eram
+// resolvidos para hex — o RN recebia a referência crua e não pintava nada.
+// Estes testes garantem que todo estilo tematizado resolve para cor real.
+
+const isConcreteColor = (value: unknown): boolean =>
+  typeof value === "string" && (value.startsWith("#") || value.startsWith("rgb"));
+
+const flattenStyle = (style: unknown): Record<string, unknown> => {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.map(flattenStyle));
+  }
+  return (style ?? {}) as Record<string, unknown>;
+};
+
+describe("resolução de tema Tamagui → estilos nativos", () => {
+  it("AppButton primary resolve backgroundColor para cor concreta (não referência $token)", () => {
+    const { getByRole } = render(
+      <AppProviders>
+        <AppButton>Entrar</AppButton>
+      </AppProviders>,
+    );
+
+    const style = flattenStyle(getByRole("button").props.style);
+    expect(isConcreteColor(style.backgroundColor)).toBe(true);
+  });
+
+  it("AppSurfaceCard resolve backgroundColor e borderColor para cores concretas", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppSurfaceCard testID="card" title="Resumo">
+          <Paragraph>conteudo</Paragraph>
+        </AppSurfaceCard>
+      </AppProviders>,
+    );
+
+    const style = flattenStyle(getByTestId("card").props.style);
+    expect(isConcreteColor(style.backgroundColor)).toBe(true);
+    expect(
+      isConcreteColor(style.borderColor ?? style.borderTopColor),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #543

Fase 1 do redesign (épico #540).

## A descoberta que muda o jogo

Durante a implementação, um probe de estilos em jest revelou **a verdadeira causa do app preto e branco**: os temas do Tamagui populavam valores com referências de token (`"$brandPrimaryLight"`) que **nunca eram resolvidas para hex** — o RN recebia a string crua e não pintava nada. Pior: `config/tamagui-theme.test.ts` consagrava o bug, assertando os `$tokens`. Ou seja: além do DS divergente (#539), havia um bug real de resolução por cima.

## Mudanças

- **Fix da resolução**: `buildModeTheme` agora popula os temas com **valores concretos** das palettes semânticas; teste de regressão novo (`shared/theme/theme-resolution.test.tsx`) renderiza componentes reais e rejeita qualquer `$referência` vazando para o estilo nativo
- **Palette light = web canônico** (`semantic.ts` do auraxis-web): canvas #F4F8FB, surface #FFF, texto #0A1628, primary teal #087FA7 (pressed #066985), success #087F5B, danger #C2414D, warning #B7791F, info #2563EB, border #D8E3EF. Dark (Market Pulse) mantido — já era idêntico ao web
- **Fontes**: Inter 400/500/600/700 (body+heading) + IBM Plex Mono 400/500/600 (valores R$) substituem PlayfairDisplay/Raleway; fonte `mono` adicionada ao config Tamagui
- **Componentes**: AppButton pill (raio total, secondary com borda neutra), AppSurfaceCard raio 20 + sombra suave + padding generoso, AppInputField raio 14 + focus ring teal
- **`AppMoneyText` novo**: valores monetários em IBM Plex Mono — aplicado no hero do dashboard e nos cards de comparação (sweep completo na F6)
- 3 testes atualizados para a nova palette; 2 snapshots regenerados

## Verificação

- quality-check verde: 1983 testes (2 novos de regressão), 9 policies
- Pós-merge: OTA `--environment production` → validação side-by-side com o PWA pelo Italo