### PR TITLE
fix(theme): default light explícito (paridade com o web) independente do dark mode do aparelho

### DIFF
--- a/core/shell/app-shell-store.ts
+++ b/core/shell/app-shell-store.ts
@@ -92,7 +92,10 @@ export const appShellStateDefaults: AppShellStateSnapshot = {
   fontsReady: false,
   reducedMotionEnabled: false,
   hapticsEnabled: true,
-  themePreference: "system",
+  // Paridade com o web: light é o default explícito (defaultThemePreference
+  // em auraxis-web), independente do dark mode do aparelho. O usuário troca
+  // no Perfil → Aparência.
+  themePreference: "light",
   locale: "pt",
   biometricLockEnabled: false,
   startupReady: false,


### PR DESCRIPTION
Closes #543 (follow-up — AC "light default" não valia em devices com dark mode do sistema)

A F1 (PR #549) entregou tokens/fontes/resolução, mas `themePreference` defaultava `system` → iPhone em dark mode renderizava o dark Market Pulse (como no print do Italo às 20:02 — que de quebra provou a F1 funcionando). Paridade com o web = default **light** explícito (`defaultThemePreference` do auraxis-web), trocável em Perfil → Aparência (UI já existente).

1 linha + comentário; preferência é in-memory (sem migração necessária). quality-check verde.