### PR TITLE
feat(navigation): F2 — tab bar nova (Dashboard · Transações · [+] · Planejar · Mais)

### DIFF
--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -4,6 +4,7 @@ import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Redirect, Tabs } from "expo-router";
 
 import { AppErrorBoundary } from "@/core/errors/app-error-boundary";
+import { AppTabBar } from "@/core/navigation/app-tab-bar";
 import { privateTabDefinitions } from "@/core/navigation/routes";
 import { usePrivateRouteGuard } from "@/core/navigation/use-route-guards";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
@@ -17,7 +18,10 @@ const HIDDEN_TAB_NAMES: readonly string[] = [
   "installment-vs-cash",
   "confirm-email-pending",
   "compartilhamentos",
-  "transacoes",
+  "carteira",
+  "metas",
+  "ferramentas",
+  "alertas",
   "importar-transacoes",
   "perfil",
   "fiscal",
@@ -58,6 +62,7 @@ function PrivateLayoutContent(): ReactElement | null {
 
   return (
     <Tabs
+      tabBar={(props) => <AppTabBar {...props} />}
       screenOptions={{
         headerShown: false,
         tabBarActiveTintColor: tabTheme.primary,

--- a/app/(private)/mais.tsx
+++ b/app/(private)/mais.tsx
@@ -1,0 +1,1 @@
+export { MoreHubScreen as default } from "@/core/navigation/more-hub-screen";

--- a/app/(private)/planejamento.tsx
+++ b/app/(private)/planejamento.tsx
@@ -1,0 +1,72 @@
+import { useState, type ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { BudgetsScreen } from "@/features/budgets/screens/budgets-screen";
+import { GoalsScreen } from "@/features/goals/screens/goals-screen";
+import { Pressable } from "react-native";
+
+type PlanningSegment = "metas" | "orcamentos";
+
+const SEGMENTS: readonly { readonly key: PlanningSegment; readonly label: string }[] = [
+  { key: "metas", label: "Metas" },
+  { key: "orcamentos", label: "Orçamentos" },
+];
+
+/**
+ * Aba "Planejar" (redesign F2): Metas e Orçamentos sob um segmented
+ * control — composição feita na camada de rota para não criar import
+ * lateral entre features.
+ */
+export default function PlanningRoute(): ReactElement {
+  const [segment, setSegment] = useState<PlanningSegment>("metas");
+
+  return (
+    <YStack flex={1} backgroundColor="$background">
+      <XStack
+        margin="$4"
+        marginBottom="$2"
+        padding="$1"
+        borderRadius="$5"
+        backgroundColor="$surfaceRaised"
+        borderWidth={1}
+        borderColor="$borderColor"
+      >
+        {SEGMENTS.map(({ key, label }) => {
+          const isActive = segment === key;
+          return (
+            <Pressable
+              key={key}
+              accessibilityRole="tab"
+              accessibilityState={{ selected: isActive }}
+              testID={`planning-segment-${key}`}
+              onPress={() => setSegment(key)}
+              style={{ flex: 1 }}
+            >
+              <YStack
+                paddingVertical="$2"
+                borderRadius="$5"
+                backgroundColor={isActive ? "$surfaceCard" : "transparent"}
+                borderWidth={isActive ? 1 : 0}
+                borderColor="$borderColor"
+              >
+                <Paragraph
+                  textAlign="center"
+                  fontFamily="$body"
+                  fontSize="$3"
+                  fontWeight={isActive ? "$6" : "$4"}
+                  color={isActive ? "$primary" : "$muted"}
+                >
+                  {label}
+                </Paragraph>
+              </YStack>
+            </Pressable>
+          );
+        })}
+      </XStack>
+      <YStack flex={1}>
+        {segment === "metas" ? <GoalsScreen /> : <BudgetsScreen />}
+      </YStack>
+    </YStack>
+  );
+}

--- a/core/navigation/app-tab-bar.test.tsx
+++ b/core/navigation/app-tab-bar.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppTabBar } from "@/core/navigation/app-tab-bar";
+import { AppProviders } from "@/core/providers/app-providers";
+
+jest.mock("react-native-safe-area-context", () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 20, left: 0, right: 0 }),
+}));
+
+const buildProps = (activeIndex = 0) => {
+  const routes = [
+    { key: "dashboard-key", name: "dashboard" },
+    { key: "transacoes-key", name: "transacoes" },
+    { key: "planejamento-key", name: "planejamento" },
+    { key: "mais-key", name: "mais" },
+  ];
+  const navigate = jest.fn();
+  return {
+    props: {
+      state: { index: activeIndex, routes },
+      navigation: { navigate },
+      descriptors: {},
+      insets: { top: 0, bottom: 0, left: 0, right: 0 },
+    } as unknown as Parameters<typeof AppTabBar>[0],
+    navigate,
+  };
+};
+
+describe("AppTabBar", () => {
+  it("renderiza os quatro destinos e o botao central de acao rapida", () => {
+    const { props } = buildProps();
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppTabBar {...props} />
+      </AppProviders>,
+    );
+
+    expect(getByTestId("tab-dashboard")).toBeTruthy();
+    expect(getByTestId("tab-transacoes")).toBeTruthy();
+    expect(getByTestId("tab-planejamento")).toBeTruthy();
+    expect(getByTestId("tab-mais")).toBeTruthy();
+    expect(getByTestId("tab-quick-actions")).toBeTruthy();
+  });
+
+  it("navega ao tocar numa tab nao focada e ignora a tab ja ativa", () => {
+    const { props, navigate } = buildProps(0);
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppTabBar {...props} />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByTestId("tab-transacoes"));
+    expect(navigate).toHaveBeenCalledWith("transacoes");
+
+    fireEvent.press(getByTestId("tab-dashboard"));
+    expect(navigate).toHaveBeenCalledTimes(1);
+  });
+
+  it("abre o sheet de acao rapida e navega para criar transacao", () => {
+    const { props, navigate } = buildProps();
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppTabBar {...props} />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByTestId("tab-quick-actions"));
+    fireEvent.press(getByTestId("quick-action-create"));
+
+    expect(navigate).toHaveBeenCalledWith("transacoes", { intent: "create" });
+  });
+});

--- a/core/navigation/app-tab-bar.tsx
+++ b/core/navigation/app-tab-bar.tsx
@@ -1,0 +1,230 @@
+import { useCallback, useState, type ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
+import { Modal, Pressable } from "react-native";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { appRoutes, privateTabDefinitions } from "@/core/navigation/routes";
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import { AppButton } from "@/shared/components/app-button";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
+import { darkSemanticColors, lightSemanticColors, semanticShadows } from "@/shared/theme";
+
+const TAB_BAR_RADIUS = 24;
+const CENTER_BUTTON_SIZE = 56;
+
+interface QuickActionsSheetProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+  readonly onNavigateToCreate: () => void;
+}
+
+/**
+ * Sheet de ação rápida do botão central [+]: atalhos para registrar
+ * receita/despesa — paridade com os CTAs "Nova Receita"/"Nova Despesa"
+ * do dashboard web.
+ */
+function QuickActionsSheet({
+  visible,
+  onClose,
+  onNavigateToCreate,
+}: QuickActionsSheetProps): ReactElement {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable
+        style={{ flex: 1 }}
+        accessibilityLabel="Fechar ações rápidas"
+        onPress={onClose}
+      >
+        <YStack flex={1} backgroundColor="rgba(10,22,40,0.45)" justifyContent="flex-end">
+          <Pressable>
+            <YStack
+              backgroundColor="$surfaceCard"
+              padding="$5"
+              paddingBottom="$7"
+              gap="$3"
+              borderTopLeftRadius={TAB_BAR_RADIUS}
+              borderTopRightRadius={TAB_BAR_RADIUS}
+            >
+              <Paragraph fontFamily="$body" fontWeight="$6" fontSize="$5" color="$color">
+                Registrar movimento
+              </Paragraph>
+              <AppButton testID="quick-action-create" onPress={onNavigateToCreate}>
+                Nova transação
+              </AppButton>
+              <AppButton tone="secondary" onPress={onClose}>
+                Cancelar
+              </AppButton>
+            </YStack>
+          </Pressable>
+        </YStack>
+      </Pressable>
+    </Modal>
+  );
+}
+
+interface TabItemProps {
+  readonly tab: (typeof privateTabDefinitions)[number];
+  readonly isFocused: boolean;
+  readonly activeColor: string;
+  readonly inactiveColor: string;
+  readonly onPress: () => void;
+}
+
+function TabItem({
+  tab,
+  isFocused,
+  activeColor,
+  inactiveColor,
+  onPress,
+}: TabItemProps): ReactElement {
+  const tint = isFocused ? activeColor : inactiveColor;
+  return (
+    <Pressable
+      accessibilityRole="tab"
+      accessibilityLabel={tab.title}
+      accessibilityState={{ selected: isFocused }}
+      testID={`tab-${tab.name}`}
+      onPress={onPress}
+      style={{ flex: 1, alignItems: "center", gap: 2, paddingVertical: 6 }}
+    >
+      <MaterialCommunityIcons name={tab.icon} size={24} color={tint} />
+      <Paragraph
+        fontFamily="$body"
+        fontSize="$1"
+        color={tint}
+        fontWeight={isFocused ? "$6" : "$4"}
+      >
+        {tab.title}
+      </Paragraph>
+    </Pressable>
+  );
+}
+
+interface CenterActionButtonProps {
+  readonly backgroundColor: string;
+  readonly iconColor: string;
+  readonly onPress: () => void;
+}
+
+function CenterActionButton({
+  backgroundColor,
+  iconColor,
+  onPress,
+}: CenterActionButtonProps): ReactElement {
+  return (
+    <YStack width={CENTER_BUTTON_SIZE + 16} alignItems="center">
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Registrar movimento"
+        testID="tab-quick-actions"
+        onPress={onPress}
+        style={{
+          width: CENTER_BUTTON_SIZE,
+          height: CENTER_BUTTON_SIZE,
+          borderRadius: CENTER_BUTTON_SIZE / 2,
+          marginTop: -(CENTER_BUTTON_SIZE / 2),
+          alignItems: "center",
+          justifyContent: "center",
+          backgroundColor,
+          shadowColor: backgroundColor,
+          shadowOffset: { width: 0, height: 8 },
+          shadowOpacity: 0.35,
+          shadowRadius: 12,
+          elevation: 8,
+        }}
+      >
+        <MaterialCommunityIcons name="plus" size={30} color={iconColor} />
+      </Pressable>
+    </YStack>
+  );
+}
+
+/**
+ * Tab bar customizada do redesign (F2 — épico #540): superfície com
+ * cantos superiores arredondados, quatro destinos e botão central [+]
+ * elevado para registro rápido de transações.
+ */
+export function AppTabBar({ state, navigation }: BottomTabBarProps): ReactElement {
+  const insets = useSafeAreaInsets();
+  const resolvedTheme = useResolvedTheme();
+  const palette =
+    resolvedTheme === "auraxis_dark" ? darkSemanticColors : lightSemanticColors;
+  const [quickActionsVisible, setQuickActionsVisible] = useState(false);
+
+  const navigateToTab = useCallback(
+    (routeName: string): void => {
+      const target = state.routes.find((route) => route.name === routeName);
+      if (!target) {
+        return;
+      }
+      const isFocused = state.routes[state.index]?.name === routeName;
+      if (!isFocused) {
+        navigation.navigate(target.name);
+      }
+    },
+    [navigation, state.index, state.routes],
+  );
+
+  const handleOpenQuickActions = useCallback((): void => {
+    triggerHapticImpact("medium");
+    setQuickActionsVisible(true);
+  }, []);
+
+  const handleNavigateToCreate = useCallback((): void => {
+    setQuickActionsVisible(false);
+    navigation.navigate("transacoes", { intent: "create" });
+  }, [navigation]);
+
+  const leftTabs = privateTabDefinitions.slice(0, 2);
+  const rightTabs = privateTabDefinitions.slice(2);
+
+  const renderTab = (tab: (typeof privateTabDefinitions)[number]): ReactElement => (
+    <TabItem
+      key={tab.name}
+      tab={tab}
+      isFocused={state.routes[state.index]?.name === tab.name}
+      activeColor={palette.primary}
+      inactiveColor={palette.subduedForeground}
+      onPress={() => navigateToTab(tab.name)}
+    />
+  );
+
+  return (
+    <>
+      <XStack
+        testID="app-tab-bar"
+        backgroundColor="$surfaceCard"
+        borderTopLeftRadius={TAB_BAR_RADIUS}
+        borderTopRightRadius={TAB_BAR_RADIUS}
+        borderTopWidth={1}
+        borderTopColor="$borderColor"
+        paddingTop="$2"
+        paddingHorizontal="$3"
+        paddingBottom={Math.max(insets.bottom, 10)}
+        alignItems="center"
+        {...semanticShadows.lg}
+      >
+        {leftTabs.map(renderTab)}
+        <CenterActionButton
+          backgroundColor={palette.primary}
+          iconColor={palette.primaryForeground}
+          onPress={handleOpenQuickActions}
+        />
+        {rightTabs.map(renderTab)}
+      </XStack>
+      <QuickActionsSheet
+        visible={quickActionsVisible}
+        onClose={() => setQuickActionsVisible(false)}
+        onNavigateToCreate={handleNavigateToCreate}
+      />
+    </>
+  );
+}
+
+export const quickCreateTransactionHref = {
+  pathname: appRoutes.private.transactions,
+  params: { intent: "create" },
+} as const;

--- a/core/navigation/more-hub-screen.test.tsx
+++ b/core/navigation/more-hub-screen.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { MoreHubScreen } from "@/core/navigation/more-hub-screen";
+import { AppProviders } from "@/core/providers/app-providers";
+
+const mockPush = jest.fn();
+
+jest.mock("expo-router", () => ({
+  ...jest.requireActual("expo-router"),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+describe("MoreHubScreen", () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it("renderiza os destinos que sairam da tab bar", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <MoreHubScreen />
+      </AppProviders>,
+    );
+
+    for (const key of ["wallet", "tools", "alerts", "profile"]) {
+      expect(getByTestId(`hub-item-${key}`)).toBeTruthy();
+    }
+  });
+
+  it("navega para a rota do item tocado", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <MoreHubScreen />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByTestId("hub-item-wallet"));
+    expect(mockPush).toHaveBeenCalledWith("/carteira");
+  });
+});

--- a/core/navigation/more-hub-screen.tsx
+++ b/core/navigation/more-hub-screen.tsx
@@ -1,0 +1,182 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useRouter, type Href } from "expo-router";
+import { Pressable, View, type StyleProp, type ViewStyle } from "react-native";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import Animated from "react-native-reanimated";
+
+import { appRoutes } from "@/core/navigation/routes";
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import { usePressScaleAnimation } from "@/shared/animations/use-press-scale-animation";
+import { AppHeading } from "@/shared/components/app-heading";
+import { AppScreen } from "@/shared/components/app-screen";
+import { darkSemanticColors, lightSemanticColors } from "@/shared/theme";
+
+type HubIconName =
+  | "wallet-outline"
+  | "tools"
+  | "bell-outline"
+  | "lightbulb-on-outline"
+  | "account-circle-outline"
+  | "credit-card-outline"
+  | "bank-outline"
+  | "tag-multiple-outline"
+  | "crown-outline"
+  | "shield-account-outline";
+
+interface HubItem {
+  readonly key: string;
+  readonly title: string;
+  readonly description: string;
+  readonly icon: HubIconName;
+  readonly href: Href;
+}
+
+const HUB_ITEMS: readonly HubItem[] = [
+  {
+    key: "wallet",
+    title: "Carteira",
+    description: "Investimentos e patrimônio",
+    icon: "wallet-outline",
+    href: appRoutes.private.wallet,
+  },
+  {
+    key: "tools",
+    title: "Ferramentas",
+    description: "Calculadoras e simuladores",
+    icon: "tools",
+    href: appRoutes.private.tools,
+  },
+  {
+    key: "alerts",
+    title: "Alertas",
+    description: "Avisos e vencimentos",
+    icon: "bell-outline",
+    href: appRoutes.private.alerts,
+  },
+  {
+    key: "insights",
+    title: "Insights",
+    description: "Leituras com IA",
+    icon: "lightbulb-on-outline",
+    href: appRoutes.private.insights,
+  },
+  {
+    key: "accounts",
+    title: "Contas",
+    description: "Contas bancárias",
+    icon: "bank-outline",
+    href: appRoutes.private.accounts,
+  },
+  {
+    key: "creditCards",
+    title: "Cartões",
+    description: "Faturas e ciclos",
+    icon: "credit-card-outline",
+    href: appRoutes.private.creditCards,
+  },
+  {
+    key: "tags",
+    title: "Tags",
+    description: "Categorias personalizadas",
+    icon: "tag-multiple-outline",
+    href: appRoutes.private.tags,
+  },
+  {
+    key: "subscription",
+    title: "Assinatura",
+    description: "Plano e benefícios",
+    icon: "crown-outline",
+    href: appRoutes.private.subscription,
+  },
+  {
+    key: "profile",
+    title: "Perfil",
+    description: "Conta, aparência e privacidade",
+    icon: "account-circle-outline",
+    href: appRoutes.private.profile,
+  },
+  {
+    key: "privacy",
+    title: "Privacidade",
+    description: "Dados e permissões",
+    icon: "shield-account-outline",
+    href: appRoutes.private.privacyCenter,
+  },
+];
+
+interface HubCardProps {
+  readonly item: HubItem;
+  readonly accentColor: string;
+  readonly onPress: () => void;
+}
+
+function HubCard({ item, accentColor, onPress }: HubCardProps): ReactElement {
+  const { animatedStyle, onPressIn, onPressOut } = usePressScaleAnimation();
+
+  return (
+    <View style={{ flexBasis: "47%", flexGrow: 1 }}>
+      <Animated.View style={animatedStyle as StyleProp<ViewStyle>}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={item.title}
+        testID={`hub-item-${item.key}`}
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+      >
+        <YStack
+          backgroundColor="$surfaceCard"
+          borderRadius="$3"
+          borderWidth={1}
+          borderColor="$borderColor"
+          padding="$4"
+          gap="$2"
+          minHeight={110}
+        >
+          <MaterialCommunityIcons name={item.icon} size={26} color={accentColor} />
+          <Paragraph fontFamily="$body" fontWeight="$6" fontSize="$4" color="$color">
+            {item.title}
+          </Paragraph>
+          <Paragraph fontFamily="$body" fontSize="$2" color="$muted">
+            {item.description}
+          </Paragraph>
+        </YStack>
+      </Pressable>
+      </Animated.View>
+    </View>
+  );
+}
+
+/**
+ * Hub "Mais" (redesign F2): grade elegante com os destinos que saíram da
+ * tab bar — nada fica inacessível com a navegação nova.
+ */
+export function MoreHubScreen(): ReactElement {
+  const router = useRouter();
+  const resolvedTheme = useResolvedTheme();
+  const palette =
+    resolvedTheme === "auraxis_dark" ? darkSemanticColors : lightSemanticColors;
+
+  return (
+    <AppScreen testID="more-hub-screen">
+      <YStack gap="$4">
+        <AppHeading level={1} fontSize="$8">
+          Mais
+        </AppHeading>
+        <XStack flexWrap="wrap" gap="$3">
+          {HUB_ITEMS.map((item) => (
+            <HubCard
+              key={item.key}
+              item={item}
+              accentColor={palette.primary}
+              onPress={() => router.push(item.href)}
+            />
+          ))}
+        </XStack>
+      </YStack>
+    </AppScreen>
+  );
+}

--- a/core/navigation/routes.ts
+++ b/core/navigation/routes.ts
@@ -5,7 +5,10 @@ type MaterialCommunityIconName =
   | "wallet-outline"
   | "tools"
   | "bell-outline"
-  | "flag-outline";
+  | "flag-outline"
+  | "swap-horizontal"
+  | "target"
+  | "view-grid-outline";
 
 export const appRoutes = {
   root: "/",
@@ -52,6 +55,8 @@ export const appRoutes = {
     privacyCenter: "/privacidade",
     dangerZone: "/perfil-zona-de-perigo",
     simulationsHistory: "/simulacoes",
+    planning: "/planejamento",
+    moreHub: "/mais",
     checkoutSuccess: "/checkout/success",
     checkoutCancel: "/checkout/cancel",
   },
@@ -140,42 +145,39 @@ export interface AppRouteDefinition {
 }
 
 export interface PrivateTabDefinition {
-  readonly name: "dashboard" | "carteira" | "metas" | "ferramentas" | "alertas";
+  readonly name: "dashboard" | "transacoes" | "planejamento" | "mais";
   readonly href: PrivateAppRoute;
   readonly title: string;
   readonly icon: MaterialCommunityIconName;
 }
 
+// Destinos das tabs (redesign F2 — épico #540): Transações ganha lugar de
+// destaque; Carteira/Ferramentas/Alertas/Metas vivem no hub "Mais" e no
+// Planejamento. O slot central [+] é renderizado pela AppTabBar.
 export const privateTabDefinitions: readonly PrivateTabDefinition[] = [
   {
     name: "dashboard",
     href: appRoutes.private.dashboard,
-    title: "Dashboard",
+    title: "Início",
     icon: "view-dashboard-outline",
   },
   {
-    name: "carteira",
-    href: appRoutes.private.wallet,
-    title: "Carteira",
-    icon: "wallet-outline",
+    name: "transacoes",
+    href: appRoutes.private.transactions,
+    title: "Transações",
+    icon: "swap-horizontal",
   },
   {
-    name: "metas",
-    href: appRoutes.private.goals,
-    title: "Metas",
-    icon: "flag-outline",
+    name: "planejamento",
+    href: appRoutes.private.planning,
+    title: "Planejar",
+    icon: "target",
   },
   {
-    name: "ferramentas",
-    href: appRoutes.private.tools,
-    title: "Ferramentas",
-    icon: "tools",
-  },
-  {
-    name: "alertas",
-    href: appRoutes.private.alerts,
-    title: "Alertas",
-    icon: "bell-outline",
+    name: "mais",
+    href: appRoutes.private.moreHub,
+    title: "Mais",
+    icon: "view-grid-outline",
   },
 ] as const;
 
@@ -233,28 +235,28 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
     key: "wallet",
     path: appRoutes.private.wallet,
     access: "private",
-    tabVisible: true,
+    tabVisible: false,
     supportsHostedCheckoutReturn: false,
   },
   {
     key: "goals",
     path: appRoutes.private.goals,
     access: "private",
-    tabVisible: true,
+    tabVisible: false,
     supportsHostedCheckoutReturn: false,
   },
   {
     key: "tools",
     path: appRoutes.private.tools,
     access: "private",
-    tabVisible: true,
+    tabVisible: false,
     supportsHostedCheckoutReturn: false,
   },
   {
     key: "alerts",
     path: appRoutes.private.alerts,
     access: "private",
-    tabVisible: true,
+    tabVisible: false,
     supportsHostedCheckoutReturn: false,
   },
   {
@@ -286,10 +288,24 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
     supportsHostedCheckoutReturn: false,
   },
   {
+    key: "planning",
+    path: appRoutes.private.planning,
+    access: "private",
+    tabVisible: true,
+    supportsHostedCheckoutReturn: false,
+  },
+  {
+    key: "moreHub",
+    path: appRoutes.private.moreHub,
+    access: "private",
+    tabVisible: true,
+    supportsHostedCheckoutReturn: false,
+  },
+  {
     key: "transactions",
     path: appRoutes.private.transactions,
     access: "private",
-    tabVisible: false,
+    tabVisible: true,
     supportsHostedCheckoutReturn: false,
   },
   {

--- a/features/transactions/hooks/use-transactions-screen-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.test.ts
@@ -395,3 +395,30 @@ describe("useTransactionsScreenController server-side filters", () => {
     });
   });
 });
+
+describe("useTransactionsScreenController quick-create intent (tab [+])", () => {
+  it("abre o form de criacao quando a rota recebe intent=create", () => {
+    const { useLocalSearchParams } = jest.requireMock("expo-router");
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ intent: "create" });
+
+    const { result } = renderHook(() => useTransactionsScreenController());
+
+    expect(result.current.formMode.kind).toBe("create");
+
+    (useLocalSearchParams as jest.Mock).mockReturnValue({});
+  });
+
+  it("nao reabre o form apos o usuario fechar com o intent ainda na rota", () => {
+    const { useLocalSearchParams } = jest.requireMock("expo-router");
+    (useLocalSearchParams as jest.Mock).mockReturnValue({ intent: "create" });
+
+    const { result } = renderHook(() => useTransactionsScreenController());
+    act(() => {
+      result.current.handleCloseForm();
+    });
+
+    expect(result.current.formMode.kind).toBe("closed");
+
+    (useLocalSearchParams as jest.Mock).mockReturnValue({});
+  });
+});

--- a/features/transactions/hooks/use-transactions-screen-controller.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.ts
@@ -1,4 +1,6 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useLocalSearchParams } from "expo-router";
 
 import type {
   TransactionDeleteScope,
@@ -413,6 +415,19 @@ export function useTransactionsScreenController(): TransactionsScreenController 
   const filters = useTransactionsFilters();
   const transactionsQuery = useTransactionsQuery(filters.listQuery);
   const [formMode, setFormMode] = useState<TransactionFormMode>({ kind: "closed" });
+  const searchParams = useLocalSearchParams<{ readonly intent?: string }>();
+  const quickCreateHandled = useRef(false);
+
+  // Atalho do botão central [+] da tab bar (F2): /transacoes?intent=create
+  // abre o form de criação uma única vez por montagem — fechar o form não
+  // deve reabri-lo enquanto o param continua na rota.
+  useEffect(() => {
+    if (searchParams.intent === "create" && !quickCreateHandled.current) {
+      quickCreateHandled.current = true;
+      setFormMode({ kind: "create" });
+    }
+  }, [searchParams.intent]);
+
   const [viewMode, setViewMode] = useState<TransactionsViewMode>("list");
   const [installmentGroupFilter, setInstallmentGroupFilter] = useState<string | null>(null);
   const actions = useTransactionsActions({


### PR DESCRIPTION
Closes #544

Fase 2 do redesign (épico #540).

## Mudanças

- **`AppTabBar` custom** (`core/navigation/app-tab-bar.tsx`): superfície com cantos superiores arredondados (raio 24), sombra, safe-area, 4 destinos + **botão central [+] elevado** (círculo teal, glow) que abre sheet de ação rápida → "Nova transação" navega com `intent=create`
- **Transações ganha lugar na tab bar** (estava escondida!); Carteira/Metas/Ferramentas/Alertas saem das tabs e vivem no hub
- **"Planejar"** (`app/(private)/planejamento.tsx`): Metas + Orçamentos sob segmented control pill — composição na camada de rota (sem import lateral entre features)
- **"Mais"** (`core/navigation/more-hub-screen.tsx`): grid 2 colunas com microinteração de scale (Reanimated) — Carteira, Ferramentas, Alertas, Insights, Contas, Cartões, Tags, Assinatura, Perfil, Privacidade. **Nenhuma rota ficou inacessível**
- Controller de transações: `?intent=create` abre o form de criação uma vez por montagem (fechar não reabre) — TDD
- Registry de rotas atualizado (tabVisible reflete a navegação nova; 2 rotas novas registradas)

## Verificação

- quality-check verde: 1990 testes (7 novos), 9 policies
- Pós-merge: OTA `--environment production` → validação do Italo (navegar pelas 4 tabs + criar transação pelo [+])

Nota: badge de weekly insight na tab Dashboard saiu nesta v1 da barra custom (o insight segue visível no dashboard) — recoloco na F6 se fizer falta.