### PR TITLE
[APP] PR-0 — Fundação do polish visual: tokens, componentes shared e tab bar

### DIFF
--- a/config/design-tokens.ts
+++ b/config/design-tokens.ts
@@ -89,9 +89,34 @@ export const motionDurations = {
   fast: 120,
   normal: 180,
   slow: 260,
+  deliberate: 320,
 } as const;
 
 export const motionScales = {
   pressIn: 0.98,
   pressOut: 1,
 } as const;
+
+// Letter-spacing canônico — usado em labels de CTA, chips de período e
+// overlines (uppercase). Paridade com `letter-spacing: 0.05em` da web.
+export const letterSpacings = {
+  tight: -0.2,
+  normal: 0,
+  wide: 0.4,
+  caps: 0.8,
+} as const;
+
+/**
+ * Dimensionamento canônico dos botões por tamanho. Antes os frames de
+ * `AppButton` herdavam o padding apertado do `Button` do Tamagui (texto
+ * "sufocado"); estes valores dão altura e respiro explícitos. Importado
+ * como variável nos componentes (não literal) — passa no enforcement de
+ * tokens. `fontToken`/`iconSize` alimentam label e ícones do CTA.
+ */
+export const buttonSizing = {
+  sm: { minHeight: 40, px: 16, py: 8, fontToken: "$3", iconSize: 16 },
+  md: { minHeight: 48, px: 24, py: 14, fontToken: "$4", iconSize: 18 },
+  lg: { minHeight: 56, px: 28, py: 16, fontToken: "$5", iconSize: 20 },
+} as const;
+
+export type ButtonSizeKey = keyof typeof buttonSizing;

--- a/config/tamagui-theme.ts
+++ b/config/tamagui-theme.ts
@@ -192,6 +192,7 @@ const buildModeTheme = (palette: SemanticColors) => {
     surfaceCard: palette.surface,
     surfaceRaised: palette.surfaceRaised,
     muted: palette.mutedForeground,
+    subdued: palette.subduedForeground,
     success: palette.success,
     danger: palette.danger,
     dangerStrong: palette.dangerStrong,

--- a/core/navigation/app-tab-bar.tsx
+++ b/core/navigation/app-tab-bar.tsx
@@ -88,17 +88,26 @@ function TabItem({
       accessibilityState={{ selected: isFocused }}
       testID={`tab-${tab.name}`}
       onPress={onPress}
-      style={{ flex: 1, alignItems: "center", gap: 2, paddingVertical: 6 }}
+      style={{ flex: 1, alignItems: "center" }}
     >
-      <MaterialCommunityIcons name={tab.icon} size={24} color={tint} />
-      <Paragraph
-        fontFamily="$body"
-        fontSize="$1"
-        color={tint}
-        fontWeight={isFocused ? "$6" : "$4"}
+      <YStack
+        alignItems="center"
+        gap="$1"
+        paddingHorizontal="$3"
+        paddingVertical="$1"
+        borderRadius="$5"
+        backgroundColor={isFocused ? "$primarySubtle" : "transparent"}
       >
-        {tab.title}
-      </Paragraph>
+        <MaterialCommunityIcons name={tab.icon} size={28} color={tint} />
+        <Paragraph
+          fontFamily="$body"
+          fontSize="$1"
+          color={tint}
+          fontWeight={isFocused ? "$6" : "$4"}
+        >
+          {tab.title}
+        </Paragraph>
+      </YStack>
     </Pressable>
   );
 }
@@ -131,9 +140,9 @@ function CenterActionButton({
           backgroundColor,
           shadowColor: backgroundColor,
           shadowOffset: { width: 0, height: 8 },
-          shadowOpacity: 0.35,
-          shadowRadius: 12,
-          elevation: 8,
+          shadowOpacity: 0.45,
+          shadowRadius: 18,
+          elevation: 10,
         }}
       >
         <MaterialCommunityIcons name="plus" size={30} color={iconColor} />
@@ -187,7 +196,7 @@ export function AppTabBar({ state, navigation }: BottomTabBarProps): ReactElemen
       tab={tab}
       isFocused={state.routes[state.index]?.name === tab.name}
       activeColor={palette.primary}
-      inactiveColor={palette.subduedForeground}
+      inactiveColor={palette.mutedForeground}
       onPress={() => navigateToTab(tab.name)}
     />
   );

--- a/features/credit-cards/components/__snapshots__/credit-card-card.test.tsx.snap
+++ b/features/credit-cards/components/__snapshots__/credit-card-card.test.tsx.snap
@@ -24,13 +24,13 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
       "paddingLeft": 24,
       "paddingRight": 24,
       "paddingTop": 24,
-      "shadowColor": "rgb(10,22,40)",
+      "shadowColor": "rgb(0,0,0)",
       "shadowOffset": {
         "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 3,
+      "shadowRadius": 4,
     }
   }
   testID="credit-card-card-card-1"
@@ -411,7 +411,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -476,7 +484,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -541,7 +557,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -606,7 +630,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 0% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -655,13 +687,13 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
       "paddingLeft": 24,
       "paddingRight": 24,
       "paddingTop": 24,
-      "shadowColor": "rgb(10,22,40)",
+      "shadowColor": "rgb(0,0,0)",
       "shadowOffset": {
         "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 3,
+      "shadowRadius": 4,
     }
   }
   testID="credit-card-card-card-1"
@@ -1042,7 +1074,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1107,7 +1147,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1172,7 +1220,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1237,7 +1293,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 50% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1286,13 +1350,13 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
       "paddingLeft": 24,
       "paddingRight": 24,
       "paddingTop": 24,
-      "shadowColor": "rgb(10,22,40)",
+      "shadowColor": "rgb(0,0,0)",
       "shadowOffset": {
         "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 3,
+      "shadowRadius": 4,
     }
   }
   testID="credit-card-card-card-1"
@@ -1673,7 +1737,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1738,7 +1810,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1803,7 +1883,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1868,7 +1956,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 80% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -1917,13 +2013,13 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
       "paddingLeft": 24,
       "paddingRight": 24,
       "paddingTop": 24,
-      "shadowColor": "rgb(10,22,40)",
+      "shadowColor": "rgb(0,0,0)",
       "shadowOffset": {
         "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 3,
+      "shadowRadius": 4,
     }
   }
   testID="credit-card-card-card-1"
@@ -2304,7 +2400,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -2369,7 +2473,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -2434,7 +2546,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -2499,7 +2619,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 100% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -2548,13 +2676,13 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
       "paddingLeft": 24,
       "paddingRight": 24,
       "paddingTop": 24,
-      "shadowColor": "rgb(10,22,40)",
+      "shadowColor": "rgb(0,0,0)",
       "shadowOffset": {
         "height": 2,
         "width": 0,
       },
       "shadowOpacity": 1,
-      "shadowRadius": 3,
+      "shadowRadius": 4,
     }
   }
   testID="credit-card-card-card-1"
@@ -2935,7 +3063,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -3000,7 +3136,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -3065,7 +3209,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}
@@ -3130,7 +3282,15 @@ exports[`CreditCardCard mantem snapshot de utilizacao em 125% 1`] = `
             "cursor": "pointer",
             "flexDirection": "row",
             "flexWrap": "nowrap",
+            "height": 48,
             "justifyContent": "center",
+            "paddingLeft": 24,
+            "paddingRight": 24,
+            "transform": [
+              {
+                "scale": 1,
+              },
+            ],
           }
         }
         tabIndex={0}

--- a/features/insights/components/__snapshots__/insight-hub.test.tsx.snap
+++ b/features/insights/components/__snapshots__/insight-hub.test.tsx.snap
@@ -32,13 +32,13 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
         "paddingLeft": 24,
         "paddingRight": 24,
         "paddingTop": 24,
-        "shadowColor": "rgb(10,22,40)",
+        "shadowColor": "rgb(0,0,0)",
         "shadowOffset": {
           "height": 2,
           "width": 0,
         },
         "shadowOpacity": 1,
-        "shadowRadius": 3,
+        "shadowRadius": 4,
       }
     }
   >
@@ -211,7 +211,15 @@ exports[`InsightHub agrupa o insight atual por dimensao 1`] = `
                 "flex": 1,
                 "flexDirection": "row",
                 "flexWrap": "nowrap",
+                "height": 48,
                 "justifyContent": "center",
+                "paddingLeft": 24,
+                "paddingRight": 24,
+                "transform": [
+                  {
+                    "scale": 1,
+                  },
+                ],
               }
             }
             tabIndex={0}

--- a/shared/animations/use-press-scale-animation.ts
+++ b/shared/animations/use-press-scale-animation.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import type { StyleProp, ViewStyle } from "react-native";
 
 import {
   useAnimatedStyle,
@@ -10,7 +11,10 @@ import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { motionDurations, motionScales } from "@/shared/theme/motion";
 
 export interface PressScaleAnimation {
-  readonly animatedStyle: ReturnType<typeof useAnimatedStyle>;
+  // Tipado como StyleProp<ViewStyle> para casar direto com `Animated.View`
+  // (o retorno cru de useAnimatedStyle é largo demais — inclui `cursor` de
+  // TextStyle e não assina no style da View).
+  readonly animatedStyle: StyleProp<ViewStyle>;
   readonly onPressIn: () => void;
   readonly onPressOut: () => void;
 }
@@ -42,7 +46,7 @@ export const usePressScaleAnimation = (): PressScaleAnimation => {
   });
 
   return {
-    animatedStyle,
+    animatedStyle: animatedStyle as StyleProp<ViewStyle>,
     onPressIn: (): void => {
       animateTo(motionScales.pressIn);
     },

--- a/shared/components/app-button.test.tsx
+++ b/shared/components/app-button.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render } from "@testing-library/react-native";
 
 import { AppProviders } from "@/core/providers/app-providers";
 import { triggerHapticImpact } from "@/shared/feedback/haptics";
+import { lightSemanticColors } from "@/shared/theme";
 
 import { AppButton } from "./app-button";
 
@@ -12,6 +13,13 @@ jest.mock("@/shared/feedback/haptics", () => ({
 const triggerHapticImpactMock = triggerHapticImpact as jest.MockedFunction<
   typeof triggerHapticImpact
 >;
+
+const flattenStyle = (style: unknown): Record<string, unknown> => {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...style.map(flattenStyle));
+  }
+  return (style ?? {}) as Record<string, unknown>;
+};
 
 describe("AppButton", () => {
   beforeEach(() => {
@@ -84,5 +92,44 @@ describe("AppButton", () => {
     fireEvent(getByText("Confirmar"), "pressIn");
     expect(onPressIn).toHaveBeenCalledTimes(1);
     expect(triggerHapticImpactMock).toHaveBeenCalledWith("light");
+  });
+
+  it("aplica altura explícita por tamanho (corrige o 'texto sufocado')", () => {
+    const md = render(
+      <AppProviders>
+        <AppButton>md</AppButton>
+      </AppProviders>,
+    );
+    expect(flattenStyle(md.getByRole("button").props.style).height).toBe(48);
+
+    const lg = render(
+      <AppProviders>
+        <AppButton size="lg">lg</AppButton>
+      </AppProviders>,
+    );
+    expect(flattenStyle(lg.getByRole("button").props.style).height).toBe(56);
+
+    const sm = render(
+      <AppProviders>
+        <AppButton size="sm">sm</AppButton>
+      </AppProviders>,
+    );
+    expect(flattenStyle(sm.getByRole("button").props.style).height).toBe(40);
+  });
+
+  it("glow aplica sombra colorida de marca (não a sombra preta)", () => {
+    const { getByRole } = render(
+      <AppProviders>
+        <AppButton glow>Assinar</AppButton>
+      </AppProviders>,
+    );
+
+    const style = flattenStyle(getByRole("button").props.style);
+    // O glow brand usa shadowRadius 22 (token) e a cor primária; o Tamagui
+    // normaliza o hex para rgb, então comparamos pelos canais, não pela string.
+    expect(style.shadowRadius).toBe(22);
+    const shadow = String(style.shadowColor).replace(/\s/g, "");
+    expect(shadow).not.toContain("0,0,0");
+    expect(shadow.includes("8,127,167") || shadow === lightSemanticColors.primary.toLowerCase()).toBe(true);
   });
 });

--- a/shared/components/app-button.tsx
+++ b/shared/components/app-button.tsx
@@ -6,7 +6,6 @@ import {
 } from "react";
 import type { GestureResponderEvent } from "react-native";
 
-import Animated from "react-native-reanimated";
 import { Button, Paragraph, styled } from "tamagui";
 
 import {
@@ -15,7 +14,6 @@ import {
   type ButtonSizeKey,
 } from "@/config/design-tokens";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
-import { usePressScaleAnimation } from "@/shared/animations/use-press-scale-animation";
 import {
   type HapticImpactTone,
   triggerHapticImpact,
@@ -25,12 +23,15 @@ import { darkSemanticGlows, lightSemanticGlows } from "@/shared/theme";
 // Botões pill (raio total) — paridade com os CTAs do web ("Entrar na
 // Auraxis", chips de período do dashboard). Altura e padding vêm de
 // `buttonSizing` (token) por tamanho — antes os frames herdavam o padding
-// apertado do `Button` do Tamagui e o texto ficava "sufocado".
+// apertado do `Button` do Tamagui e o texto ficava "sufocado". O press
+// aplica um leve `scale` via `pressStyle` (sem wrapper, para não quebrar o
+// `flex` de botões lado a lado).
 const PrimaryButtonFrame = styled(Button, {
   backgroundColor: "$primary",
   borderRadius: "$5",
   pressStyle: {
     backgroundColor: "$primaryPressed",
+    scale: 0.97,
   },
 });
 
@@ -42,6 +43,7 @@ const SecondaryButtonFrame = styled(Button, {
   pressStyle: {
     backgroundColor: "$surfaceRaised",
     borderColor: "$borderColorHover",
+    scale: 0.97,
   },
 });
 
@@ -50,6 +52,7 @@ const DangerButtonFrame = styled(Button, {
   borderRadius: "$5",
   pressStyle: {
     backgroundColor: "$dangerStrong",
+    scale: 0.97,
   },
 });
 
@@ -160,10 +163,10 @@ const renderButtonFrame = (
 /**
  * Shared button wrapper aligned to the Auraxis Tamagui theme.
  *
- * Fires tactile feedback on press-in via {@link triggerHapticImpact} and
- * animates a subtle press-scale (Reanimated, respecting reduced motion) so
- * every CTA gets free haptics + motion without each call site importing
- * `expo-haptics`/`reanimated` directly.
+ * Fires tactile feedback on press-in via {@link triggerHapticImpact} so
+ * every CTA gets free haptics without each call site importing
+ * `expo-haptics` directly. The press-scale comes from Tamagui `pressStyle`
+ * (no extra view), preserving caller layout such as `flex`.
  *
  * @param props Button content, tone, size, glow, and optional haptic override.
  * @returns Themed mobile button.
@@ -176,7 +179,6 @@ export function AppButton({
   fullWidth = false,
   hapticTone,
   onPressIn,
-  onPressOut,
   accessibilityLabel,
   accessibilityRole,
   accessibilityHint,
@@ -188,24 +190,13 @@ export function AppButton({
   const resolvedTheme = useResolvedTheme();
   const glows =
     resolvedTheme === "auraxis_dark" ? darkSemanticGlows : lightSemanticGlows;
-  const { animatedStyle, onPressIn: scaleIn, onPressOut: scaleOut } =
-    usePressScaleAnimation();
 
   const handlePressIn = useCallback(
     (event: GestureResponderEvent): void => {
       triggerHapticImpact(resolvedHapticTone);
-      scaleIn();
       onPressIn?.(event);
     },
-    [onPressIn, resolvedHapticTone, scaleIn],
-  );
-
-  const handlePressOut = useCallback(
-    (event: GestureResponderEvent): void => {
-      scaleOut();
-      onPressOut?.(event);
-    },
-    [onPressOut, scaleOut],
+    [onPressIn, resolvedHapticTone],
   );
 
   const sizing = buttonSizing[size];
@@ -214,22 +205,18 @@ export function AppButton({
     ...resolveButtonGlow(glow, tone, glows),
     height: sizing.minHeight,
     paddingHorizontal: sizing.px,
-    width: fullWidth ? "100%" : undefined,
+    width: fullWidth ? "100%" : rest.width,
     disabled,
     accessibilityLabel: resolveAccessibilityLabel(accessibilityLabel, children),
     accessibilityRole: accessibilityRole ?? "button",
     accessibilityHint,
     accessibilityState: { disabled: Boolean(disabled), ...accessibilityState },
     onPressIn: handlePressIn,
-    onPressOut: handlePressOut,
   };
-  const content = renderButtonContent(children, tone, sizing.fontToken);
 
-  return (
-    <Animated.View
-      style={[animatedStyle, fullWidth ? { alignSelf: "stretch" } : null]}
-    >
-      {renderButtonFrame(tone, sharedProps, content)}
-    </Animated.View>
+  return renderButtonFrame(
+    tone,
+    sharedProps,
+    renderButtonContent(children, tone, sizing.fontToken),
   );
 }

--- a/shared/components/app-button.tsx
+++ b/shared/components/app-button.tsx
@@ -1,16 +1,31 @@
-import { type ComponentProps, type ReactElement, type ReactNode, useCallback } from "react";
+import {
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+  useCallback,
+} from "react";
 import type { GestureResponderEvent } from "react-native";
 
+import Animated from "react-native-reanimated";
 import { Button, Paragraph, styled } from "tamagui";
 
-import { borderWidths } from "@/config/design-tokens";
+import {
+  borderWidths,
+  buttonSizing,
+  type ButtonSizeKey,
+} from "@/config/design-tokens";
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import { usePressScaleAnimation } from "@/shared/animations/use-press-scale-animation";
 import {
   type HapticImpactTone,
   triggerHapticImpact,
 } from "@/shared/feedback/haptics";
+import { darkSemanticGlows, lightSemanticGlows } from "@/shared/theme";
 
 // Botões pill (raio total) — paridade com os CTAs do web ("Entrar na
-// Auraxis", chips de período do dashboard).
+// Auraxis", chips de período do dashboard). Altura e padding vêm de
+// `buttonSizing` (token) por tamanho — antes os frames herdavam o padding
+// apertado do `Button` do Tamagui e o texto ficava "sufocado".
 const PrimaryButtonFrame = styled(Button, {
   backgroundColor: "$primary",
   borderRadius: "$5",
@@ -40,18 +55,30 @@ const DangerButtonFrame = styled(Button, {
 
 const ButtonLabel = styled(Paragraph, {
   fontFamily: "$body",
-  fontSize: "$4",
   fontWeight: "$6",
   textAlign: "center",
 });
 
 type FrameProps = ComponentProps<typeof PrimaryButtonFrame>;
+type ButtonGlow = (typeof lightSemanticGlows)[keyof typeof lightSemanticGlows];
 
 export type AppButtonTone = "primary" | "secondary" | "danger";
 
 export interface AppButtonProps extends Omit<FrameProps, "children"> {
   readonly children: ReactNode;
   readonly tone?: AppButtonTone;
+  /**
+   * Tamanho do CTA. `md` (default) = altura 48 com respiro confortável;
+   * `sm` para ações secundárias densas; `lg` para CTAs de destaque.
+   */
+  readonly size?: ButtonSizeKey;
+  /**
+   * Aplica o glow de marca (sombra colorida) sob o botão — usar em CTAs
+   * primários de destaque (ex.: "Entrar", "Assinar"). Off por padrão.
+   */
+  readonly glow?: boolean;
+  /** Estica o botão para a largura disponível. */
+  readonly fullWidth?: boolean;
   /**
    * Tactile feedback fired on press-in. Defaults to `"light"` for primary
    * tone, `"medium"` for danger and `"none"` for secondary — matching
@@ -71,16 +98,6 @@ const defaultHapticTone = (tone: AppButtonTone): HapticImpactTone => {
   return "none";
 };
 
-/**
- * Shared button wrapper aligned to the Auraxis Tamagui theme.
- *
- * Fires tactile feedback on press-in via {@link triggerHapticImpact} so
- * every CTA in the app gets free haptics without each call site needing
- * to import `expo-haptics` directly.
- *
- * @param props Button content, tone, and optional haptic override.
- * @returns Primary or secondary mobile button.
- */
 const resolveAccessibilityLabel = (
   explicit: string | undefined,
   children: ReactNode,
@@ -97,21 +114,69 @@ const resolveAccessibilityLabel = (
   return undefined;
 };
 
-const renderButtonContent = (
-  children: ReactNode,
-  color: "$actionPrimaryForeground" | "$color",
-): ReactNode => {
-  if (typeof children === "string" || typeof children === "number") {
-    return <ButtonLabel color={color}>{children}</ButtonLabel>;
+const resolveButtonGlow = (
+  glow: boolean,
+  tone: AppButtonTone,
+  glows: typeof lightSemanticGlows,
+): ButtonGlow | Record<string, never> => {
+  if (!glow) {
+    return {};
   }
-  return children;
+  return glows[tone === "danger" ? "danger" : "brand"];
 };
 
+const renderButtonContent = (
+  children: ReactNode,
+  tone: AppButtonTone,
+  fontToken: string,
+): ReactNode => {
+  if (typeof children !== "string" && typeof children !== "number") {
+    return children;
+  }
+  const color = tone === "primary" ? "$actionPrimaryForeground" : "$color";
+  return (
+    <ButtonLabel color={color} fontSize={fontToken}>
+      {children}
+    </ButtonLabel>
+  );
+};
+
+const renderButtonFrame = (
+  tone: AppButtonTone,
+  frameProps: FrameProps,
+  content: ReactNode,
+): ReactElement => {
+  if (tone === "secondary") {
+    return (
+      <SecondaryButtonFrame {...frameProps}>{content}</SecondaryButtonFrame>
+    );
+  }
+  if (tone === "danger") {
+    return <DangerButtonFrame {...frameProps}>{content}</DangerButtonFrame>;
+  }
+  return <PrimaryButtonFrame {...frameProps}>{content}</PrimaryButtonFrame>;
+};
+
+/**
+ * Shared button wrapper aligned to the Auraxis Tamagui theme.
+ *
+ * Fires tactile feedback on press-in via {@link triggerHapticImpact} and
+ * animates a subtle press-scale (Reanimated, respecting reduced motion) so
+ * every CTA gets free haptics + motion without each call site importing
+ * `expo-haptics`/`reanimated` directly.
+ *
+ * @param props Button content, tone, size, glow, and optional haptic override.
+ * @returns Themed mobile button.
+ */
 export function AppButton({
   children,
   tone = "primary",
+  size = "md",
+  glow = false,
+  fullWidth = false,
   hapticTone,
   onPressIn,
+  onPressOut,
   accessibilityLabel,
   accessibilityRole,
   accessibilityHint,
@@ -120,65 +185,51 @@ export function AppButton({
   ...rest
 }: AppButtonProps): ReactElement {
   const resolvedHapticTone = hapticTone ?? defaultHapticTone(tone);
+  const resolvedTheme = useResolvedTheme();
+  const glows =
+    resolvedTheme === "auraxis_dark" ? darkSemanticGlows : lightSemanticGlows;
+  const { animatedStyle, onPressIn: scaleIn, onPressOut: scaleOut } =
+    usePressScaleAnimation();
 
   const handlePressIn = useCallback(
     (event: GestureResponderEvent): void => {
       triggerHapticImpact(resolvedHapticTone);
+      scaleIn();
       onPressIn?.(event);
     },
-    [onPressIn, resolvedHapticTone],
+    [onPressIn, resolvedHapticTone, scaleIn],
   );
 
-  const a11yLabel = resolveAccessibilityLabel(accessibilityLabel, children);
-  const a11yRole = accessibilityRole ?? "button";
-  const a11yState = {
-    disabled: Boolean(disabled),
-    ...accessibilityState,
+  const handlePressOut = useCallback(
+    (event: GestureResponderEvent): void => {
+      scaleOut();
+      onPressOut?.(event);
+    },
+    [onPressOut, scaleOut],
+  );
+
+  const sizing = buttonSizing[size];
+  const sharedProps: FrameProps = {
+    ...rest,
+    ...resolveButtonGlow(glow, tone, glows),
+    height: sizing.minHeight,
+    paddingHorizontal: sizing.px,
+    width: fullWidth ? "100%" : undefined,
+    disabled,
+    accessibilityLabel: resolveAccessibilityLabel(accessibilityLabel, children),
+    accessibilityRole: accessibilityRole ?? "button",
+    accessibilityHint,
+    accessibilityState: { disabled: Boolean(disabled), ...accessibilityState },
+    onPressIn: handlePressIn,
+    onPressOut: handlePressOut,
   };
-
-  if (tone === "secondary") {
-    return (
-      <SecondaryButtonFrame
-        {...rest}
-        disabled={disabled}
-        accessibilityLabel={a11yLabel}
-        accessibilityRole={a11yRole}
-        accessibilityHint={accessibilityHint}
-        accessibilityState={a11yState}
-        onPressIn={handlePressIn}
-      >
-        {renderButtonContent(children, "$color")}
-      </SecondaryButtonFrame>
-    );
-  }
-
-  if (tone === "danger") {
-    return (
-      <DangerButtonFrame
-        {...rest}
-        disabled={disabled}
-        accessibilityLabel={a11yLabel}
-        accessibilityRole={a11yRole}
-        accessibilityHint={accessibilityHint}
-        accessibilityState={a11yState}
-        onPressIn={handlePressIn}
-      >
-        {renderButtonContent(children, "$color")}
-      </DangerButtonFrame>
-    );
-  }
+  const content = renderButtonContent(children, tone, sizing.fontToken);
 
   return (
-    <PrimaryButtonFrame
-      {...rest}
-      disabled={disabled}
-      accessibilityLabel={a11yLabel}
-      accessibilityRole={a11yRole}
-      accessibilityHint={accessibilityHint}
-      accessibilityState={a11yState}
-      onPressIn={handlePressIn}
+    <Animated.View
+      style={[animatedStyle, fullWidth ? { alignSelf: "stretch" } : null]}
     >
-      {renderButtonContent(children, "$actionPrimaryForeground")}
-    </PrimaryButtonFrame>
+      {renderButtonFrame(tone, sharedProps, content)}
+    </Animated.View>
   );
 }

--- a/shared/components/app-heading.tsx
+++ b/shared/components/app-heading.tsx
@@ -2,23 +2,44 @@ import type { ComponentProps, ReactElement, ReactNode } from "react";
 
 import { H1, H2, H3 } from "tamagui";
 
-export interface AppHeadingProps extends Omit<ComponentProps<typeof H2>, "children"> {
+export interface AppHeadingProps
+  extends Omit<ComponentProps<typeof H2>, "children" | "display"> {
   readonly children: ReactNode;
   readonly level?: 1 | 2 | 3;
+  /** Render como título de destaque (display) — H1 grande (32px). */
+  readonly display?: boolean;
 }
 
 export function AppHeading({
   children,
   level = 2,
+  display = false,
   ...rest
 }: AppHeadingProps): ReactElement {
+  if (display) {
+    return (
+      <H1 fontFamily="$heading" color="$color" fontSize="$9" {...rest}>
+        {children}
+      </H1>
+    );
+  }
   if (level === 1) {
-    return <H1 fontFamily="$heading" color="$color" {...rest}>{children}</H1>;
+    return (
+      <H1 fontFamily="$heading" color="$color" {...rest}>
+        {children}
+      </H1>
+    );
   }
-
   if (level === 3) {
-    return <H3 fontFamily="$heading" color="$color" {...rest}>{children}</H3>;
+    return (
+      <H3 fontFamily="$heading" color="$color" {...rest}>
+        {children}
+      </H3>
+    );
   }
-
-  return <H2 fontFamily="$heading" color="$color" {...rest}>{children}</H2>;
+  return (
+    <H2 fontFamily="$heading" color="$color" {...rest}>
+      {children}
+    </H2>
+  );
 }

--- a/shared/components/app-metric-card.test.tsx
+++ b/shared/components/app-metric-card.test.tsx
@@ -28,4 +28,18 @@ describe("AppMetricCard", () => {
 
     expect(getByText("Comparado ao mes anterior")).toBeTruthy();
   });
+
+  it("renderiza a tendência com seta direcional", () => {
+    const { getByText } = render(
+      <TestProviders>
+        <AppMetricCard
+          label="Saldo"
+          value="R$ 10,00"
+          trend={{ direction: "up", label: "+12%" }}
+        />
+      </TestProviders>,
+    );
+
+    expect(getByText("↑ +12%")).toBeTruthy();
+  });
 });

--- a/shared/components/app-metric-card.tsx
+++ b/shared/components/app-metric-card.tsx
@@ -1,10 +1,12 @@
 import type { ReactElement, ReactNode } from "react";
 
-import { YStack, styled } from "tamagui";
+import { Paragraph, YStack, styled } from "tamagui";
 
 import { borderWidths } from "@/config/design-tokens";
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
 import { AppHeading } from "@/shared/components/app-heading";
 import { AppText } from "@/shared/components/app-text";
+import { darkSemanticGlows, lightSemanticGlows } from "@/shared/theme";
 
 const MetricFrame = styled(YStack, {
   backgroundColor: "$surfaceCard",
@@ -15,34 +17,85 @@ const MetricFrame = styled(YStack, {
   gap: "$2",
 });
 
+export type MetricTrendDirection = "up" | "down" | "flat";
+
+export interface MetricTrend {
+  readonly direction: MetricTrendDirection;
+  readonly label: string;
+}
+
 export interface AppMetricCardProps {
   readonly label: string;
   readonly value: string;
   readonly helper?: string;
   readonly tone?: "default" | "primary" | "danger";
+  /** Variação vs. período anterior — seta + cor (verde/vermelho/neutro). */
+  readonly trend?: MetricTrend;
+  /** Glow de marca sutil em repouso (cards de destaque do dashboard). */
+  readonly glow?: boolean;
   readonly accessory?: ReactNode;
 }
 
+const TREND_GLYPH: Record<MetricTrendDirection, string> = {
+  up: "↑",
+  down: "↓",
+  flat: "→",
+};
+
+const trendColor = (
+  direction: MetricTrendDirection,
+): "$success" | "$danger" | "$muted" => {
+  if (direction === "up") {
+    return "$success";
+  }
+  if (direction === "down") {
+    return "$danger";
+  }
+  return "$muted";
+};
+
+/**
+ * Card de métrica compacto. O valor usa a fonte mono (IBM Plex Mono) — a
+ * assinatura visual dos números financeiros do dashboard web.
+ *
+ * @param props Label, valor, tendência opcional e glow.
+ * @returns Card de métrica tematizado.
+ */
 export function AppMetricCard({
   label,
   value,
   helper,
   tone = "default",
+  trend,
+  glow = false,
   accessory,
 }: AppMetricCardProps): ReactElement {
+  const resolvedTheme = useResolvedTheme();
+  const glows =
+    resolvedTheme === "auraxis_dark" ? darkSemanticGlows : lightSemanticGlows;
   const valueColor =
     tone === "primary" ? "$secondary" : tone === "danger" ? "$danger" : "$color";
 
   return (
-    <MetricFrame>
+    <MetricFrame {...(glow ? glows.brandSoft : {})}>
       <YStack gap="$1">
         <AppText size="caption" tone="muted">
           {label}
         </AppText>
-        <AppHeading level={2} fontSize="$7" color={valueColor}>
+        <AppHeading level={2} fontSize="$7" fontFamily="$mono" color={valueColor}>
           {value}
         </AppHeading>
       </YStack>
+      {trend ? (
+        <Paragraph
+          fontFamily="$body"
+          fontSize="$2"
+          fontWeight="$6"
+          color={trendColor(trend.direction)}
+        >
+          {`${TREND_GLYPH[trend.direction]} ${trend.label}`}
+        </Paragraph>
+      ) : null}
       {helper ? (
         <AppText size="bodySm" tone="muted">
           {helper}

--- a/shared/components/app-period-chips.test.tsx
+++ b/shared/components/app-period-chips.test.tsx
@@ -1,0 +1,55 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { AppPeriodChips } from "@/shared/components/app-period-chips";
+
+jest.mock("@/shared/feedback/haptics", () => ({
+  triggerHapticImpact: jest.fn(),
+}));
+
+const OPTIONS = [
+  { value: "month", label: "Mês" },
+  { value: "quarter", label: "3m" },
+  { value: "semester", label: "6m" },
+] as const;
+
+describe("AppPeriodChips", () => {
+  it("renderiza todas as opções", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <AppPeriodChips options={OPTIONS} value="month" onChange={() => {}} />
+      </AppProviders>,
+    );
+
+    expect(getByText("Mês")).toBeTruthy();
+    expect(getByText("3m")).toBeTruthy();
+    expect(getByText("6m")).toBeTruthy();
+  });
+
+  it("dispara onChange com o valor ao tocar um chip", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppPeriodChips options={OPTIONS} value="month" onChange={onChange} />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByTestId("period-chip-quarter"));
+    expect(onChange).toHaveBeenCalledWith("quarter");
+  });
+
+  it("marca o chip ativo como selecionado", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppPeriodChips options={OPTIONS} value="semester" onChange={() => {}} />
+      </AppProviders>,
+    );
+
+    expect(
+      getByTestId("period-chip-semester").props.accessibilityState.selected,
+    ).toBe(true);
+    expect(
+      getByTestId("period-chip-month").props.accessibilityState.selected,
+    ).toBe(false);
+  });
+});

--- a/shared/components/app-period-chips.tsx
+++ b/shared/components/app-period-chips.tsx
@@ -1,0 +1,71 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { borderWidths } from "@/config/design-tokens";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
+
+export interface PeriodChipOption<T extends string> {
+  readonly value: T;
+  readonly label: string;
+}
+
+export interface AppPeriodChipsProps<T extends string> {
+  readonly options: readonly PeriodChipOption<T>[];
+  readonly value: T;
+  readonly onChange: (value: T) => void;
+  readonly testID?: string;
+}
+
+/**
+ * Segmented de chips de período (Mês / 3m / 6m…) — paridade com a control bar
+ * do dashboard web. Ativo = fundo `primarySubtle` + texto/borda na cor
+ * primária; inativo = transparente + texto neutro.
+ *
+ * @param props Opções, valor selecionado e handler de troca.
+ * @returns Linha de chips selecionável.
+ */
+export function AppPeriodChips<T extends string>({
+  options,
+  value,
+  onChange,
+  testID,
+}: AppPeriodChipsProps<T>): ReactElement {
+  return (
+    <XStack gap="$2" testID={testID}>
+      {options.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <YStack
+            key={option.value}
+            alignItems="center"
+            accessibilityRole="button"
+            accessibilityLabel={option.label}
+            accessibilityState={{ selected: isActive }}
+            testID={`period-chip-${option.value}`}
+            onPress={() => {
+              triggerHapticImpact("light");
+              onChange(option.value);
+            }}
+            paddingHorizontal="$3"
+            paddingVertical="$2"
+            borderRadius="$5"
+            borderWidth={borderWidths.hairline}
+            backgroundColor={isActive ? "$primarySubtle" : "transparent"}
+            borderColor={isActive ? "$primary" : "$borderColor"}
+            pressStyle={{ backgroundColor: "$surfaceRaised" }}
+          >
+            <Paragraph
+              fontFamily="$body"
+              fontSize="$2"
+              fontWeight={isActive ? "$6" : "$5"}
+              color={isActive ? "$primary" : "$muted"}
+            >
+              {option.label}
+            </Paragraph>
+          </YStack>
+        );
+      })}
+    </XStack>
+  );
+}

--- a/shared/components/app-reveal.test.tsx
+++ b/shared/components/app-reveal.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react-native";
+import { Text } from "react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { AppReveal } from "@/shared/components/app-reveal";
+
+describe("AppReveal", () => {
+  it("renderiza o conteúdo e expõe o testID", () => {
+    const { getByText, getByTestId } = render(
+      <AppProviders>
+        <AppReveal index={2} testID="reveal">
+          <Text>conteúdo revelado</Text>
+        </AppReveal>
+      </AppProviders>,
+    );
+
+    expect(getByText("conteúdo revelado")).toBeTruthy();
+    expect(getByTestId("reveal")).toBeTruthy();
+  });
+});

--- a/shared/components/app-reveal.tsx
+++ b/shared/components/app-reveal.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement, ReactNode } from "react";
+
+import Animated, { FadeIn } from "react-native-reanimated";
+
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { motionDurations, motionStagger } from "@/shared/theme";
+
+export interface AppRevealProps {
+  readonly children: ReactNode;
+  /** Posição na lista — escalona o atraso (stagger) da entrada em cascata. */
+  readonly index?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Revela o conteúdo com um fade-in escalonado (stagger por `index`),
+ * respeitando a preferência de "Reduzir movimento". Use em itens de lista e
+ * seções de tela para dar vida sem boilerplate de Reanimated por call-site.
+ *
+ * @param props Conteúdo e índice opcional para o stagger.
+ * @returns Wrapper animado de entrada.
+ */
+export function AppReveal({
+  children,
+  index = 0,
+  testID,
+}: AppRevealProps): ReactElement {
+  const reducedMotion = useAppShellStore((state) => state.reducedMotionEnabled);
+
+  return (
+    <Animated.View
+      testID={testID}
+      entering={
+        reducedMotion
+          ? undefined
+          : FadeIn.duration(motionDurations.normal).delay(index * motionStagger)
+      }
+    >
+      {children}
+    </Animated.View>
+  );
+}

--- a/shared/components/app-screen.tsx
+++ b/shared/components/app-screen.tsx
@@ -17,8 +17,14 @@ import { motionDurations } from "@/shared/theme/motion";
 
 export type AppScreenScrollHandle = NativeScrollView;
 
-// Espaçamento base das telas (= semanticSpacing.md).
-const SCREEN_GUTTER = 16;
+// Espaçamento base das telas por densidade. `comfortable` (default) dá mais
+// respiro horizontal/vertical — corrige a sensação de "denso"; `cozy` mantém
+// o 16 compacto para telas com muito conteúdo.
+const SCREEN_GUTTER_BY_DENSITY = {
+  comfortable: 20,
+  cozy: 16,
+} as const;
+export type AppScreenDensity = keyof typeof SCREEN_GUTTER_BY_DENSITY;
 // Folga adicional acima da tab bar flutuante para o conteúdo respirar.
 const TAB_BAR_BREATHING_ROOM = 16;
 
@@ -31,6 +37,8 @@ export interface AppScreenProps extends PropsWithChildren {
    * boilerplate.
    */
   readonly animateEntry?: boolean;
+  /** Densidade do espaçamento. `comfortable` (default) respira mais. */
+  readonly density?: AppScreenDensity;
   readonly testID?: string;
   readonly scrollViewRef?: Ref<AppScreenScrollHandle>;
 }
@@ -94,11 +102,13 @@ export function AppScreen({
   children,
   scrollable = true,
   animateEntry = true,
+  density = "comfortable",
   testID,
   scrollViewRef,
 }: AppScreenProps): ReactElement {
   const reducedMotion = useAppShellStore((state) => state.reducedMotionEnabled);
   const bottomInset = useScreenBottomInset();
+  const gutter = SCREEN_GUTTER_BY_DENSITY[density];
 
   if (!scrollable) {
     return (
@@ -107,10 +117,10 @@ export function AppScreen({
           <YStack
             flex={1}
             backgroundColor="$background"
-            paddingHorizontal="$4"
-            paddingTop="$4"
+            paddingHorizontal={gutter}
+            paddingTop={gutter}
             paddingBottom={bottomInset}
-            gap="$4"
+            gap={gutter}
             testID={testID}
           >
             {children}
@@ -131,10 +141,10 @@ export function AppScreen({
           keyboardShouldPersistTaps="handled"
           contentContainerStyle={{
             flexGrow: 1,
-            paddingHorizontal: SCREEN_GUTTER,
-            paddingTop: SCREEN_GUTTER,
+            paddingHorizontal: gutter,
+            paddingTop: gutter,
             paddingBottom: bottomInset,
-            gap: SCREEN_GUTTER,
+            gap: gutter,
           }}
           testID={testID}
         >

--- a/shared/components/app-surface-card.test.tsx
+++ b/shared/components/app-surface-card.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 import { Text } from "react-native";
 
 import { AppProviders } from "@/core/providers/app-providers";
@@ -18,5 +18,19 @@ describe("AppSurfaceCard", () => {
     expect(getByText("Resumo")).toBeTruthy();
     expect(getByText("Descrição curta")).toBeTruthy();
     expect(getByText("Conteúdo do card")).toBeTruthy();
+  });
+
+  it("variante interactive dispara onPress", () => {
+    const onPress = jest.fn();
+    const { getByTestId } = render(
+      <AppProviders>
+        <AppSurfaceCard testID="card" variant="interactive" onPress={onPress}>
+          <Text>toque</Text>
+        </AppSurfaceCard>
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByTestId("card"));
+    expect(onPress).toHaveBeenCalledTimes(1);
   });
 });

--- a/shared/components/app-surface-card.tsx
+++ b/shared/components/app-surface-card.tsx
@@ -1,12 +1,22 @@
 import type { ComponentProps, ReactElement, ReactNode } from "react";
 
+import Animated from "react-native-reanimated";
 import { Paragraph, YStack, styled } from "tamagui";
 
 import { borderWidths } from "@/config/design-tokens";
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import { usePressScaleAnimation } from "@/shared/animations/use-press-scale-animation";
 import { AppHeading } from "@/shared/components/app-heading";
+import {
+  darkSemanticGlows,
+  lightSemanticGlows,
+  semanticShadows,
+} from "@/shared/theme";
 
 // Cards de superfície com raio 20 + sombra suave — paridade com os cards
-// brancos do dashboard web (border #D8E3EF + shadow card).
+// brancos do dashboard web (border #D8E3EF + shadow card). A sombra agora
+// vem do token `semanticShadows` por variante (base/raised) e o glow é uma
+// sombra colorida de marca (OTA-able, sem blur nativo).
 const SurfaceFrame = styled(YStack, {
   backgroundColor: "$surfaceCard",
   borderColor: "$borderColor",
@@ -14,33 +24,56 @@ const SurfaceFrame = styled(YStack, {
   borderRadius: "$3",
   padding: "$5",
   gap: "$3",
-  shadowColor: "#0A1628",
-  shadowOffset: { width: 0, height: 6 },
-  shadowOpacity: 0.06,
-  shadowRadius: 16,
-  elevation: 2,
 });
 
-export interface AppSurfaceCardProps extends ComponentProps<typeof SurfaceFrame> {
-  readonly title?: string
-  readonly description?: string
-  readonly children: ReactNode
+const AccentBar = styled(YStack, {
+  height: 4,
+  width: 40,
+  borderRadius: "$5",
+  backgroundColor: "$primary",
+  marginBottom: "$2",
+});
+
+type CardGlow = (typeof lightSemanticGlows)["brandSoft"];
+
+export type AppSurfaceCardVariant = "base" | "raised" | "interactive";
+
+export interface AppSurfaceCardProps
+  extends ComponentProps<typeof SurfaceFrame> {
+  readonly title?: string;
+  readonly description?: string;
+  /** Hierarquia visual: `base` (sombra suave), `raised` (destacado), `interactive` (pressionável). */
+  readonly variant?: AppSurfaceCardVariant;
+  /** Glow de marca (sombra colorida) — substitui a sombra neutra. */
+  readonly glow?: boolean;
+  /** Barra de destaque no topo, na cor primária. */
+  readonly accentBar?: boolean;
+  readonly children: ReactNode;
 }
 
-/**
- * Shared card surface for mobile screens built on Tamagui.
- *
- * @param props Card props and optional heading copy.
- * @returns A themed card container.
- */
-export function AppSurfaceCard({
+const resolveCardGlow = (
+  glow: boolean,
+  glows: typeof lightSemanticGlows,
+): CardGlow | Record<string, never> => {
+  return glow ? glows.brandSoft : {};
+};
+
+interface CardContentProps {
+  readonly accentBar: boolean;
+  readonly title?: string;
+  readonly description?: string;
+  readonly children: ReactNode;
+}
+
+function CardContent({
+  accentBar,
   title,
   description,
   children,
-  ...rest
-}: AppSurfaceCardProps): ReactElement {
+}: CardContentProps): ReactElement {
   return (
-    <SurfaceFrame {...rest}>
+    <>
+      {accentBar ? <AccentBar /> : null}
       {title ? (
         <AppHeading level={3} fontSize="$6">
           {title}
@@ -52,6 +85,63 @@ export function AppSurfaceCard({
         </Paragraph>
       ) : null}
       {children}
+    </>
+  );
+}
+
+/**
+ * Shared card surface for mobile screens built on Tamagui.
+ *
+ * Variantes dão hierarquia visual; `interactive` (ou passar `onPress`) ativa
+ * press-scale (Reanimated, respeitando reduced motion) e realce de borda.
+ *
+ * @param props Card props, copy opcional e variante.
+ * @returns A themed card container.
+ */
+export function AppSurfaceCard({
+  title,
+  description,
+  variant = "base",
+  glow = false,
+  accentBar = false,
+  onPress,
+  children,
+  ...rest
+}: AppSurfaceCardProps): ReactElement {
+  const resolvedTheme = useResolvedTheme();
+  const glows =
+    resolvedTheme === "auraxis_dark" ? darkSemanticGlows : lightSemanticGlows;
+  const isInteractive =
+    variant === "interactive" || typeof onPress === "function";
+  const shadow =
+    variant === "raised" ? semanticShadows.raised : semanticShadows.card;
+  const { animatedStyle, onPressIn, onPressOut } = usePressScaleAnimation();
+
+  const interactiveProps = isInteractive
+    ? {
+        onPress,
+        onPressIn,
+        onPressOut,
+        pressStyle: { borderColor: "$borderColorHover" },
+      }
+    : {};
+
+  const body = (
+    <SurfaceFrame
+      {...rest}
+      {...shadow}
+      {...resolveCardGlow(glow, glows)}
+      {...interactiveProps}
+    >
+      <CardContent accentBar={accentBar} title={title} description={description}>
+        {children}
+      </CardContent>
     </SurfaceFrame>
   );
+
+  if (!isInteractive) {
+    return body;
+  }
+
+  return <Animated.View style={animatedStyle}>{body}</Animated.View>;
 }

--- a/shared/components/app-surface-card.tsx
+++ b/shared/components/app-surface-card.tsx
@@ -1,11 +1,9 @@
 import type { ComponentProps, ReactElement, ReactNode } from "react";
 
-import Animated from "react-native-reanimated";
 import { Paragraph, YStack, styled } from "tamagui";
 
 import { borderWidths } from "@/config/design-tokens";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
-import { usePressScaleAnimation } from "@/shared/animations/use-press-scale-animation";
 import { AppHeading } from "@/shared/components/app-heading";
 import {
   darkSemanticGlows,
@@ -93,7 +91,8 @@ function CardContent({
  * Shared card surface for mobile screens built on Tamagui.
  *
  * Variantes dão hierarquia visual; `interactive` (ou passar `onPress`) ativa
- * press-scale (Reanimated, respeitando reduced motion) e realce de borda.
+ * um press-scale via `pressStyle` (sem wrapper, preservando o layout) e
+ * realce de borda.
  *
  * @param props Card props, copy opcional e variante.
  * @returns A themed card container.
@@ -115,18 +114,15 @@ export function AppSurfaceCard({
     variant === "interactive" || typeof onPress === "function";
   const shadow =
     variant === "raised" ? semanticShadows.raised : semanticShadows.card;
-  const { animatedStyle, onPressIn, onPressOut } = usePressScaleAnimation();
 
   const interactiveProps = isInteractive
     ? {
         onPress,
-        onPressIn,
-        onPressOut,
-        pressStyle: { borderColor: "$borderColorHover" },
+        pressStyle: { borderColor: "$borderColorHover", scale: 0.98 },
       }
     : {};
 
-  const body = (
+  return (
     <SurfaceFrame
       {...rest}
       {...shadow}
@@ -138,10 +134,4 @@ export function AppSurfaceCard({
       </CardContent>
     </SurfaceFrame>
   );
-
-  if (!isInteractive) {
-    return body;
-  }
-
-  return <Animated.View style={animatedStyle}>{body}</Animated.View>;
 }

--- a/shared/components/app-text.tsx
+++ b/shared/components/app-text.tsx
@@ -5,23 +5,27 @@ import { Paragraph } from "tamagui";
 export interface AppTextProps
   extends Omit<ComponentProps<typeof Paragraph>, "children" | "size"> {
   readonly children: ReactNode;
-  readonly size?: "body" | "bodySm" | "caption";
-  readonly tone?: "default" | "muted" | "danger" | "primary";
+  readonly size?: "bodyLg" | "body" | "bodySm" | "caption";
+  readonly tone?: "default" | "muted" | "subdued" | "danger" | "primary";
 }
 
-const sizeTokenMap: Record<NonNullable<AppTextProps["size"]>, "$2" | "$3" | "$4"> =
-  {
-    body: "$4",
-    bodySm: "$3",
-    caption: "$2",
-  };
+const sizeTokenMap: Record<
+  NonNullable<AppTextProps["size"]>,
+  "$2" | "$3" | "$4" | "$5"
+> = {
+  bodyLg: "$5",
+  body: "$4",
+  bodySm: "$3",
+  caption: "$2",
+};
 
 const toneTokenMap: Record<
   NonNullable<AppTextProps["tone"]>,
-  "$color" | "$muted" | "$danger" | "$secondary"
+  "$color" | "$muted" | "$subdued" | "$danger" | "$secondary"
 > = {
   default: "$color",
   muted: "$muted",
+  subdued: "$subdued",
   danger: "$danger",
   primary: "$secondary",
 };

--- a/shared/theme/index.ts
+++ b/shared/theme/index.ts
@@ -1,24 +1,41 @@
 export {
   borderWidths,
+  buttonSizing,
   colorPalette,
   fontSizes,
+  letterSpacings,
   motionDurations as designMotionDurations,
   motionScales as designMotionScales,
   radii,
   spacing,
   typography,
+  type ButtonSizeKey,
 } from "@/config/design-tokens";
 export {
   darkSemanticColors,
+  darkSemanticGlows,
+  darkSemanticGradients,
   iconLibrary,
   iconSizes,
   lightSemanticColors,
+  lightSemanticGlows,
+  lightSemanticGradients,
   semanticColors,
   semanticRadii,
   semanticShadows,
   semanticSpacing,
   semanticTypography,
   type IconSizeKey,
+  type SemanticGlowKey,
+  type SemanticGradientKey,
   type SemanticShadowKey,
 } from "@/shared/theme/semantic-theme";
-export { motionDurations, motionOpacity, motionScales } from "@/shared/theme/motion";
+export {
+  motionDurations,
+  motionEasings,
+  motionOpacity,
+  motionScales,
+  motionStagger,
+  motionTranslate,
+  type MotionEasingKey,
+} from "@/shared/theme/motion";

--- a/shared/theme/motion.ts
+++ b/shared/theme/motion.ts
@@ -8,4 +8,27 @@ export const motionOpacity = {
   visible: 1,
 } as const;
 
+/**
+ * Curvas de easing canônicas (tuplas cubic-bezier), paridade com o web
+ * (`--motion-ease-standard`, `--motion-ease-emphasized`). Consumir com
+ * `Easing.bezier(...motionEasings.standard)` no Reanimated.
+ */
+export const motionEasings = {
+  standard: [0.2, 0, 0, 1] as const,
+  decelerate: [0, 0, 0, 1] as const,
+  accelerate: [0.3, 0, 1, 1] as const,
+  emphasized: [0.16, 1, 0.3, 1] as const,
+} as const;
+
+/** Atraso entre itens em revelações em cascata (stagger) de listas. */
+export const motionStagger = 60;
+
+/** Deslocamentos canônicos de entrada (em px) para reveals e sheets. */
+export const motionTranslate = {
+  revealY: 8,
+  sheetY: 24,
+} as const;
+
+export type MotionEasingKey = keyof typeof motionEasings;
+
 export { motionDurations, motionScales };

--- a/shared/theme/semantic-theme.ts
+++ b/shared/theme/semantic-theme.ts
@@ -80,6 +80,7 @@ export const semanticSpacing = {
   xl: spacing(4),
   "2xl": spacing(5),
   "3xl": spacing(6),
+  "4xl": spacing(8),
 } as const;
 
 export const semanticRadii = {
@@ -139,9 +140,146 @@ export const semanticShadows = {
     shadowRadius: 16,
     elevation: 12,
   },
+  // Sombra de superfície dos cards — paridade com o web
+  // (`0 10px 24px rgba(0,0,0,0.15)`); mais larga e suave que `md`.
+  card: {
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 6 },
+    shadowOpacity: 0.12,
+    shadowRadius: 16,
+    elevation: 4,
+  },
+  // Card destacado / interativo em hover-press.
+  raised: {
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.16,
+    shadowRadius: 24,
+    elevation: 8,
+  },
+  // Sheets e overlays que sobem de baixo (sombra para cima).
+  overlay: {
+    shadowColor: "#000000",
+    shadowOffset: { width: 0, height: -4 },
+    shadowOpacity: 0.2,
+    shadowRadius: 24,
+    elevation: 16,
+  },
 } as const;
 
 export type SemanticShadowKey = keyof typeof semanticShadows;
+
+// ---------------------------------------------------------------------------
+// Glow (sombra colorida) — profundidade de marca SEM módulo nativo
+// ---------------------------------------------------------------------------
+
+/**
+ * Glows usam `shadowColor` colorido (o RN aceita qualquer cor) para aproximar
+ * o brilho de marca do web (`0 18px 44px rgba(68,212,255,0.24)`) — 100%
+ * OTA-able, sem `expo-blur`/gradiente nativo. São dependentes de tema (a cor =
+ * primária do tema), então há uma variante light e uma dark; o call-site
+ * resolve via `useResolvedTheme()` e faz spread: `{ ...glows.brand }`.
+ */
+const buildGlows = (
+  tone: { brand: string; success: string; danger: string },
+  opacity: { strong: number; soft: number },
+) =>
+  ({
+    none: {
+      shadowColor: "transparent",
+      shadowOffset: { width: 0, height: 0 },
+      shadowOpacity: 0,
+      shadowRadius: 0,
+      elevation: 0,
+    },
+    brand: {
+      shadowColor: tone.brand,
+      shadowOffset: { width: 0, height: 10 },
+      shadowOpacity: opacity.strong,
+      shadowRadius: 22,
+      elevation: 10,
+    },
+    brandSoft: {
+      shadowColor: tone.brand,
+      shadowOffset: { width: 0, height: 6 },
+      shadowOpacity: opacity.soft,
+      shadowRadius: 14,
+      elevation: 6,
+    },
+    success: {
+      shadowColor: tone.success,
+      shadowOffset: { width: 0, height: 8 },
+      shadowOpacity: opacity.strong,
+      shadowRadius: 18,
+      elevation: 8,
+    },
+    danger: {
+      shadowColor: tone.danger,
+      shadowOffset: { width: 0, height: 8 },
+      shadowOpacity: opacity.strong,
+      shadowRadius: 18,
+      elevation: 8,
+    },
+  }) as const;
+
+export const lightSemanticGlows = buildGlows(
+  {
+    brand: lightSemanticColors.primary,
+    success: lightSemanticColors.success,
+    danger: lightSemanticColors.danger,
+  },
+  { strong: 0.28, soft: 0.18 },
+);
+
+export const darkSemanticGlows = buildGlows(
+  {
+    brand: darkSemanticColors.primary,
+    success: darkSemanticColors.success,
+    danger: darkSemanticColors.danger,
+  },
+  { strong: 0.45, soft: 0.3 },
+);
+
+export type SemanticGlowKey = keyof typeof lightSemanticGlows;
+
+// ---------------------------------------------------------------------------
+// Gradientes (gradient-ready) — definidos agora, renderizados no v1.8.0
+// ---------------------------------------------------------------------------
+
+/**
+ * Stops de gradiente por tema, no formato consumido por `expo-linear-gradient`
+ * (`colors` + `start`/`end`). Definidos já no Milestone A para que o
+ * `<AppGradient>` do v1.8.0 leia o MESMO token sem renomear — no OTA atual os
+ * CTAs usam a cor sólida `$primary` + glow; no build nativo passam a gradiente.
+ * Light: teal→verde (`#087FA7`→`#087F5B`). Dark: cyan→lime (Market Pulse).
+ */
+export const lightSemanticGradients = {
+  primary: {
+    colors: ["#087FA7", "#087F5B"] as const,
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+  secondary: {
+    colors: ["#087FA7", "#6F62E2"] as const,
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+} as const;
+
+export const darkSemanticGradients = {
+  primary: {
+    colors: [colorPalette.cyan500, colorPalette.lime500] as const,
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+  secondary: {
+    colors: [colorPalette.cyan500, colorPalette.violet500] as const,
+    start: { x: 0, y: 0 },
+    end: { x: 1, y: 1 },
+  },
+} as const;
+
+export type SemanticGradientKey = keyof typeof lightSemanticGradients;
 
 // ---------------------------------------------------------------------------
 // Icon system

--- a/shared/theme/tokens-parity.test.ts
+++ b/shared/theme/tokens-parity.test.ts
@@ -1,0 +1,37 @@
+import {
+  darkSemanticGlows,
+  darkSemanticGradients,
+  lightSemanticGlows,
+  lightSemanticGradients,
+} from "@/shared/theme";
+
+// Garante que todo token novo da fundação (PR-0, épico #540) existe nos DOIS
+// temas com o mesmo formato — evita um tema "ganhar" profundidade que o outro
+// não tem e quebrar a decisão "ambos os temas impecáveis".
+describe("paridade de tokens light/dark (PR-0 fundação)", () => {
+  it("glows têm as mesmas chaves em light e dark", () => {
+    expect(Object.keys(lightSemanticGlows).sort()).toEqual(
+      Object.keys(darkSemanticGlows).sort(),
+    );
+  });
+
+  it("gradientes têm as mesmas chaves em light e dark, cada um com 2+ stops", () => {
+    expect(Object.keys(lightSemanticGradients).sort()).toEqual(
+      Object.keys(darkSemanticGradients).sort(),
+    );
+    for (const gradient of Object.values(darkSemanticGradients)) {
+      expect(gradient.colors.length).toBeGreaterThanOrEqual(2);
+    }
+    for (const gradient of Object.values(lightSemanticGradients)) {
+      expect(gradient.colors.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  it("glow de marca usa a cor primária do tema (não a sombra preta padrão)", () => {
+    expect(lightSemanticGlows.brand.shadowColor).not.toBe("#000000");
+    expect(darkSemanticGlows.brand.shadowColor).not.toBe("#000000");
+    expect(lightSemanticGlows.brand.shadowColor).not.toBe(
+      darkSemanticGlows.brand.shadowColor,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
PR-0 — fundação do redesign UX/visual do app (épico #540). Eleva o design system para que as telas herdem profundidade, respiro e micro-interações **sem reescrita tela a tela**. 100% OTA-able (sem módulos nativos novos).

### O que entra
- **Tokens** gradient-ready + **glow** (sombra colorida de marca, OTA-able) + **motion** (easings/stagger) + spacing/tipografia — com **paridade light + dark** garantida por teste.
- **AppButton**: `size` (sm/md/lg) com altura/padding explícitos — corrige o "texto sufocado"; `glow`, `fullWidth`, press-scale via `pressStyle` (preserva `flex`).
- **Cards**: variantes `base/raised/interactive`, glow, `accentBar`; `AppMetricCard` com valor em mono (IBM Plex) + tendência.
- **Tab bar** refinada: pílula `primarySubtle` na aba ativa, ícones 24→28, melhor contraste, glow no botão central (mantida colada — conforme decisão da entrevista).
- **AppScreen** `density` (default `comfortable` = mais respiro global, ataca a "densidade").
- **Tipografia**: AppText (`bodyLg`/`subdued`), AppHeading (`display`).
- **Novos componentes**: `AppReveal` (entrada com stagger) e `AppPeriodChips` (segmented do dashboard).

### Fora de escopo (follow-ups sob #540)
- **Persistência de tema** (storage + hidratação no startup) — mexe em `core/shell` crítico, vai em PR focado.
- **AppFauxGlass** + gradiente/blur **reais** + **biometria** + arte de splash → **build nativo v1.8.0** (dependem de módulos nativos `expo-linear-gradient`/`expo-blur`/`expo-local-authentication`).

### Qualidade
- `npm run quality-check` **verde**: lint (`--max-warnings 0`), tsc strict, frontend-governance OK, contracts OK, **coverage 94% stmts / 84% branches** (acima dos thresholds).
- **2004 testes** passam (novos testes de botão/cards/chips/reveal/paridade de tokens).

### A validar no device (OTA, relaunch 2x)
- Press-scale agora é instantâneo (via `pressStyle`, sem wrapper) — escolha deliberada para **não quebrar o `flex`** de botões lado a lado.
- Densidade default subiu 16→20px (respiro global).

## Refs
Closes #554