### PR TITLE
[APP] Persistir preferência de tema (light/dark/system) entre reinícios

### DIFF
--- a/core/shell/theme-preference-storage.test.ts
+++ b/core/shell/theme-preference-storage.test.ts
@@ -1,0 +1,60 @@
+import * as SecureStore from "expo-secure-store";
+
+import {
+  THEME_PREFERENCE_STORAGE_KEY,
+  loadPersistedThemePreference,
+  persistThemePreference,
+} from "@/core/shell/theme-preference-storage";
+
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn(),
+  setItemAsync: jest.fn(),
+}));
+
+const getItemAsync = SecureStore.getItemAsync as jest.MockedFunction<
+  typeof SecureStore.getItemAsync
+>;
+const setItemAsync = SecureStore.setItemAsync as jest.MockedFunction<
+  typeof SecureStore.setItemAsync
+>;
+
+describe("theme-preference-storage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("retorna a preferência persistida quando válida", async () => {
+    getItemAsync.mockResolvedValue("dark");
+    await expect(loadPersistedThemePreference()).resolves.toBe("dark");
+    expect(getItemAsync).toHaveBeenCalledWith(THEME_PREFERENCE_STORAGE_KEY);
+  });
+
+  it("cai no default (light) quando não há valor", async () => {
+    getItemAsync.mockResolvedValue(null);
+    await expect(loadPersistedThemePreference()).resolves.toBe("light");
+  });
+
+  it("cai no default quando o valor é inválido", async () => {
+    getItemAsync.mockResolvedValue("rainbow");
+    await expect(loadPersistedThemePreference()).resolves.toBe("light");
+  });
+
+  it("cai no default quando o storage falha na leitura", async () => {
+    getItemAsync.mockRejectedValue(new Error("unavailable"));
+    await expect(loadPersistedThemePreference()).resolves.toBe("light");
+  });
+
+  it("persiste a preferência escolhida", async () => {
+    setItemAsync.mockResolvedValue(undefined);
+    await persistThemePreference("system");
+    expect(setItemAsync).toHaveBeenCalledWith(
+      THEME_PREFERENCE_STORAGE_KEY,
+      "system",
+    );
+  });
+
+  it("não propaga erro se o storage falhar ao persistir", async () => {
+    setItemAsync.mockRejectedValue(new Error("unavailable"));
+    await expect(persistThemePreference("dark")).resolves.toBeUndefined();
+  });
+});

--- a/core/shell/theme-preference-storage.ts
+++ b/core/shell/theme-preference-storage.ts
@@ -1,0 +1,62 @@
+import * as SecureStore from "expo-secure-store";
+
+import {
+  appShellStateDefaults,
+  type ThemePreference,
+} from "@/core/shell/app-shell-store";
+
+/** Chave canônica da preferência de tema no SecureStore. */
+export const THEME_PREFERENCE_STORAGE_KEY = "auraxis.theme-preference";
+
+const THEME_PREFERENCE_VALUES: readonly ThemePreference[] = [
+  "system",
+  "light",
+  "dark",
+];
+
+const isThemePreference = (
+  value: string | null,
+): value is ThemePreference => {
+  return (
+    value !== null &&
+    (THEME_PREFERENCE_VALUES as readonly string[]).includes(value)
+  );
+};
+
+/**
+ * Lê a preferência de tema persistida. Cai no default (`light`, paridade web)
+ * quando ausente, inválida ou se o SecureStore estiver indisponível — nunca
+ * lança, para não travar o boot.
+ *
+ * @returns Preferência de tema resolvida.
+ */
+export const loadPersistedThemePreference =
+  async (): Promise<ThemePreference> => {
+    try {
+      const stored = await SecureStore.getItemAsync(
+        THEME_PREFERENCE_STORAGE_KEY,
+      );
+      if (isThemePreference(stored)) {
+        return stored;
+      }
+    } catch {
+      return appShellStateDefaults.themePreference;
+    }
+    return appShellStateDefaults.themePreference;
+  };
+
+/**
+ * Persiste a preferência de tema escolhida. Best-effort: se o storage falhar,
+ * a escolha simplesmente não sobrevive ao reinício (sem erro propagado).
+ *
+ * @param preference Preferência a persistir.
+ */
+export const persistThemePreference = async (
+  preference: ThemePreference,
+): Promise<void> => {
+  try {
+    await SecureStore.setItemAsync(THEME_PREFERENCE_STORAGE_KEY, preference);
+  } catch {
+    // Storage indisponível — a preferência não persiste neste turno.
+  }
+};

--- a/core/shell/use-app-startup.test.tsx
+++ b/core/shell/use-app-startup.test.tsx
@@ -34,6 +34,11 @@ jest.mock("expo-splash-screen", () => ({
   hideAsync: jest.fn().mockResolvedValue(undefined),
 }));
 
+jest.mock("expo-secure-store", () => ({
+  getItemAsync: jest.fn().mockResolvedValue(null),
+  setItemAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
 describe("useAppStartup", () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/core/shell/use-app-startup.ts
+++ b/core/shell/use-app-startup.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import {
   IBMPlexMono_400Regular,
@@ -22,6 +22,7 @@ import {
 } from "@/core/performance/performance-tracker";
 import { runDeviceIntegrityCheck } from "@/core/security/integrity-check";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { loadPersistedThemePreference } from "@/core/shell/theme-preference-storage";
 import { useSessionStore } from "@/core/session/session-store";
 import { startupLogger } from "@/core/telemetry/domain-loggers";
 import { initI18n } from "@/shared/i18n";
@@ -94,6 +95,10 @@ export const useAppStartup = (): AppStartupState => {
   const setStartupReady = useAppShellStore((state) => state.setStartupReady);
   const bootstrapSession = useSessionStore((state) => state.bootstrapSession);
   const hydrated = useSessionStore((state) => state.hydrated);
+  const setThemePreference = useAppShellStore(
+    (state) => state.setThemePreference,
+  );
+  const [themeHydrated, setThemeHydrated] = useState(false);
   const startupMeasurementStarted = useRef(false);
   const [fontsLoaded] = useFonts({
     Inter_400Regular,
@@ -127,7 +132,23 @@ export const useAppStartup = (): AppStartupState => {
     setFontsReady(fontsLoaded);
   }, [fontsLoaded, setFontsReady]);
 
-  const ready = fontsLoaded && hydrated;
+  // Hidrata a preferência de tema persistida ANTES de `ready` para evitar um
+  // flash de tema (claro → escuro) no cold start de quem escolheu dark.
+  useEffect(() => {
+    let active = true;
+    void loadPersistedThemePreference().then((preference) => {
+      if (!active) {
+        return;
+      }
+      setThemePreference(preference);
+      setThemeHydrated(true);
+    });
+    return () => {
+      active = false;
+    };
+  }, [setThemePreference]);
+
+  const ready = fontsLoaded && hydrated && themeHydrated;
 
   useEffect(() => {
     setStartupReady(ready);

--- a/features/user-profile/components/appearance-section.tsx
+++ b/features/user-profile/components/appearance-section.tsx
@@ -6,6 +6,7 @@ import {
   type ThemePreference,
   useAppShellStore,
 } from "@/core/shell/app-shell-store";
+import { persistThemePreference } from "@/core/shell/theme-preference-storage";
 import { AppButton } from "@/shared/components/app-button";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { useT } from "@/shared/i18n";
@@ -55,6 +56,13 @@ export function AppearanceSection(): ReactElement {
   const setThemePreference = useAppShellStore(
     (state) => state.setThemePreference,
   );
+  const handleSelect = useCallback(
+    (preference: ThemePreference): void => {
+      setThemePreference(preference);
+      void persistThemePreference(preference);
+    },
+    [setThemePreference],
+  );
 
   return (
     <AppSurfaceCard
@@ -69,7 +77,7 @@ export function AppearanceSection(): ReactElement {
               option={option.value}
               label={t(option.key)}
               isActive={themePreference === option.value}
-              onSelect={setThemePreference}
+              onSelect={handleSelect}
             />
           ))}
         </XStack>


### PR DESCRIPTION
## Summary
Fecha o "ambos os temas impecáveis" (épico #540): a preferência de tema (Perfil → Aparência) agora **persiste entre reinícios** e é hidratada no boot **antes de `ready`** (sem flash de tema claro→escuro no cold start de quem escolheu dark).

- **`core/shell/theme-preference-storage.ts`** — load/persist via `expo-secure-store` (key `auraxis.theme-preference`, default `light`), best-effort, nunca lança (não trava o boot). **TDD: 6 testes** (válido/ausente/inválido/falha de leitura/persist/falha de persist).
- **`use-app-startup`** — hidrata a preferência e faz gate do `ready` no `themeHydrated`.
- **`appearance-section`** — persiste no side-effect ao trocar de tema.

## Qualidade
`npm run quality-check` **verde** · coverage **94% / 84%** · **2010 testes**. OTA-able (sem módulo nativo novo).

## Refs
Closes #556