### PR TITLE
[APP] Sweep visual: CTAs hero (login + transações) com glow

### DIFF
--- a/features/auth/screens/login-screen.tsx
+++ b/features/auth/screens/login-screen.tsx
@@ -73,6 +73,8 @@ export function LoginScreen(): ReactElement {
           </XStack>
 
           <AppButton
+            glow
+            size="lg"
             onPress={() => {
               void controller.handleSubmit();
             }}

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -201,7 +201,7 @@ function FilterHeaderControls({
         onClearFilters={controller.clearFilters}
       />
       <XStack gap="$2">
-        <AppButton flex={1} onPress={controller.handleOpenCreate}>
+        <AppButton flex={1} glow onPress={controller.handleOpenCreate}>
           Nova transacao
         </AppButton>
         <AppButton flex={1} tone="secondary" onPress={onOpenExport}>


### PR DESCRIPTION
## Summary
Parte de #540. Hero treatment nos CTAs principais (paridade com os CTAs de destaque da web):
- **Login** — "Entrar na Auraxis" com `glow` + `size="lg"`.
- **Transações** — "Nova transação" com `glow` (mantendo `flex={1}` — valida que glow e flex coexistem sem wrapper).

OTA-able. `npm run quality-check` verde · coverage 94%/84% · 2010 testes.

## Refs
Closes #561