### PR TITLE
[APP] P0 fix: OTA quebrava login — eas update sem --environment (bundle ia pra localhost)

### DIFF
--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -64,7 +64,13 @@ jobs:
           if [ -z "${MESSAGE:-}" ]; then
             MESSAGE="$(git log -1 --pretty=%s)"
           fi
+          # `--environment` é OBRIGATÓRIO: o Expo inlina `EXPO_PUBLIC_*` em
+          # build-time. Sem ele, o bundle do OTA sai com essas envs `undefined`
+          # (incl. EXPO_PUBLIC_API_URL → fallback localhost), quebrando todas as
+          # chamadas à API no device. O `--environment` puxa as EAS env vars do
+          # ambiente correspondente ao canal. Ver issue #564.
           eas update \
             --channel "$CHANNEL" \
+            --environment "$CHANNEL" \
             --message "$MESSAGE" \
             --non-interactive


### PR DESCRIPTION
Closes #564

## Root cause
`EXPO_PUBLIC_*` são inlinados em build-time. O `ota-update.yml` rodava `eas update` sem `--environment` → bundle do OTA saía com `EXPO_PUBLIC_API_URL=undefined` → fallback `http://localhost:5000` (`shared/config/runtime.ts:28`; app.json sem `extra.apiUrl`) → todas as chamadas à API falhavam no device (login incluso). Build nativo 1.0.0 tinha a env correta; os OTAs a substituíram por localhost.

## Evidências
- API `/healthz` 200 + `/auth/login` (creds falsas) → 401 `{"message":"Invalid credentials"}` (backend ok)
- SSL pinning: SPKI atual casa com os pins (ok)
- Única mudança no path de auth = OTAs

## Fix
`eas update --environment "$CHANNEL"` puxa as EAS env vars do ambiente (per-canal). OTA corrigido já disparado do branch via `--ref` para destravar o app live.