### PR TITLE
feat(transactions): linha compacta com swipe + header colapsado (OTA)

### DIFF
--- a/features/transactions/components/transaction-action-sheet.test.tsx
+++ b/features/transactions/components/transaction-action-sheet.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { TransactionActionSheet } from "@/features/transactions/components/transaction-action-sheet";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+
+const buildTx = (
+  overrides: Partial<TransactionViewModel> = {},
+): TransactionViewModel => ({
+  id: "tx-1",
+  title: "Internet",
+  amount: "120.00",
+  type: "expense",
+  dueDate: "2026-06-10",
+  status: "pending",
+  description: "Vivo Fibra",
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  installmentGroupId: null,
+  installmentNumber: null,
+  ...overrides,
+});
+
+const noop = (): void => {};
+
+const renderSheet = (
+  tx: TransactionViewModel | null,
+  overrides: Partial<Parameters<typeof TransactionActionSheet>[0]> = {},
+) =>
+  render(
+    <AppProviders>
+      <TransactionActionSheet
+        transaction={tx}
+        isPaying={false}
+        isDuplicating={false}
+        isDeleting={false}
+        onClose={noop}
+        onMarkPaid={noop}
+        onEdit={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+        onShowInstallmentGroup={noop}
+        {...overrides}
+      />
+    </AppProviders>,
+  );
+
+describe("TransactionActionSheet", () => {
+  it("mostra Pagar para transacao nao paga e dispara onMarkPaid", () => {
+    const onMarkPaid = jest.fn();
+    const { getByTestId } = renderSheet(buildTx(), { onMarkPaid });
+
+    fireEvent.press(getByTestId("action-mark-paid"));
+
+    expect(onMarkPaid).toHaveBeenCalledWith("tx-1");
+  });
+
+  it("oculta Pagar quando a transacao ja esta paga", () => {
+    const { queryByTestId } = renderSheet(buildTx({ status: "paid" }));
+
+    expect(queryByTestId("action-mark-paid")).toBeNull();
+  });
+
+  it("dispara onDelete ao tocar em Excluir", () => {
+    const onDelete = jest.fn();
+    const { getByTestId } = renderSheet(buildTx(), { onDelete });
+
+    fireEvent.press(getByTestId("action-delete"));
+
+    expect(onDelete).toHaveBeenCalledWith("tx-1");
+  });
+});

--- a/features/transactions/components/transaction-action-sheet.tsx
+++ b/features/transactions/components/transaction-action-sheet.tsx
@@ -1,0 +1,147 @@
+import { type ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { TransactionBottomSheet } from "@/features/transactions/components/transaction-bottom-sheet";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+import {
+  formatStatusLabel,
+  getInstallmentLabel,
+  statusTone,
+} from "@/features/transactions/utils/transaction-presentation";
+import { AppBadge } from "@/shared/components/app-badge";
+import { AppButton } from "@/shared/components/app-button";
+import { formatShortDate } from "@/shared/utils/formatters";
+
+export interface TransactionActionSheetProps {
+  readonly transaction: TransactionViewModel | null;
+  readonly isPaying: boolean;
+  readonly isDuplicating: boolean;
+  readonly isDeleting: boolean;
+  readonly onClose: () => void;
+  readonly onMarkPaid: (txId: string) => void;
+  readonly onEdit: (txId: string) => void;
+  readonly onDuplicate: (txId: string) => void;
+  readonly onDelete: (txId: string) => void;
+  readonly onShowInstallmentGroup: (installmentGroupId: string) => void;
+}
+
+interface ActionSheetHeaderProps {
+  readonly transaction: TransactionViewModel;
+}
+
+/** Cabeçalho do sheet: título, descrição, valor, status e vencimento. */
+function ActionSheetHeader({ transaction }: ActionSheetHeaderProps): ReactElement {
+  const installmentLabel = getInstallmentLabel(transaction);
+  return (
+    <YStack gap="$1">
+      <Paragraph fontFamily="$body" fontWeight="$7" fontSize="$6" color="$color">
+        {transaction.title}
+      </Paragraph>
+      {transaction.description ? (
+        <Paragraph fontFamily="$body" fontSize="$3" color="$muted">
+          {transaction.description}
+        </Paragraph>
+      ) : null}
+      <XStack alignItems="center" gap="$2" marginTop="$1">
+        <Paragraph
+          fontFamily="$body"
+          fontWeight="$7"
+          fontSize="$7"
+          color={transaction.type === "income" ? "$success" : "$danger"}
+        >
+          {transaction.type === "income" ? "+" : "-"}
+          {transaction.amount}
+        </Paragraph>
+        <AppBadge tone={statusTone(transaction.status)}>
+          {formatStatusLabel(transaction.status)}
+        </AppBadge>
+      </XStack>
+      <Paragraph fontFamily="$body" fontSize="$3" color="$muted">
+        Vence {formatShortDate(transaction.dueDate)}
+        {installmentLabel ? ` · ${installmentLabel}` : ""}
+      </Paragraph>
+    </YStack>
+  );
+}
+
+/**
+ * Action sheet das transações: aberto ao tocar numa linha, traz o detalhe
+ * e TODAS as ações (Pagar, Editar, Duplicar, ver parcelas, Excluir). É o
+ * caminho acessível — cobre o que o swipe faz como atalho.
+ */
+export function TransactionActionSheet({
+  transaction,
+  isPaying,
+  isDuplicating,
+  isDeleting,
+  onClose,
+  onMarkPaid,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  onShowInstallmentGroup,
+}: TransactionActionSheetProps): ReactElement {
+  const isBusy = isPaying || isDuplicating || isDeleting;
+  const installmentGroupId = transaction?.installmentGroupId ?? null;
+
+  return (
+    <TransactionBottomSheet
+      visible={Boolean(transaction)}
+      onClose={onClose}
+      testID="transaction-action-sheet"
+    >
+      {transaction ? (
+        <YStack gap="$3">
+          <ActionSheetHeader transaction={transaction} />
+          {transaction.status !== "paid" ? (
+            <AppButton
+              glow
+              onPress={() => onMarkPaid(transaction.id)}
+              disabled={isBusy}
+              testID="action-mark-paid"
+            >
+              {isPaying ? "Pagando..." : "Pagar"}
+            </AppButton>
+          ) : null}
+          <AppButton
+            tone="secondary"
+            onPress={() => onEdit(transaction.id)}
+            disabled={isBusy}
+          >
+            Editar
+          </AppButton>
+          <AppButton
+            tone="secondary"
+            onPress={() => onDuplicate(transaction.id)}
+            disabled={isBusy}
+          >
+            {isDuplicating ? "Duplicando..." : "Duplicar"}
+          </AppButton>
+          {installmentGroupId ? (
+            <AppButton
+              tone="secondary"
+              onPress={() => {
+                onShowInstallmentGroup(installmentGroupId);
+                onClose();
+              }}
+            >
+              Ver outras parcelas
+            </AppButton>
+          ) : null}
+          <AppButton
+            tone="danger"
+            onPress={() => onDelete(transaction.id)}
+            disabled={isBusy}
+            testID="action-delete"
+          >
+            {isDeleting ? "Excluindo..." : "Excluir"}
+          </AppButton>
+          <AppButton tone="secondary" onPress={onClose}>
+            Fechar
+          </AppButton>
+        </YStack>
+      ) : null}
+    </TransactionBottomSheet>
+  );
+}

--- a/features/transactions/components/transaction-bottom-sheet.tsx
+++ b/features/transactions/components/transaction-bottom-sheet.tsx
@@ -1,0 +1,57 @@
+import { type ReactNode, type ReactElement } from "react";
+
+import { Modal, Pressable } from "react-native";
+import { YStack } from "tamagui";
+
+// Backdrop em variável (não literal inline no objeto/JSX) — paridade com os
+// overlays existentes; mantém o sheet 100% OTA sem libs de bottom-sheet.
+const SHEET_BACKDROP = "rgba(0,0,0,0.45)";
+const SHEET_RADIUS = 24;
+
+export interface TransactionBottomSheetProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+  readonly children: ReactNode;
+  readonly testID?: string;
+}
+
+/**
+ * Bottom sheet reutilizável da feature de transações: `Modal` nativo que
+ * sobe de baixo, backdrop tocável para fechar e container com cantos
+ * superiores arredondados. Base do action sheet (ações da linha) e do
+ * filter sheet — sem dependência nativa nova (usa o `Modal` do RN).
+ */
+export function TransactionBottomSheet({
+  visible,
+  onClose,
+  children,
+  testID,
+}: TransactionBottomSheetProps): ReactElement {
+  return (
+    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
+      <Pressable
+        style={{ flex: 1 }}
+        accessibilityRole="button"
+        accessibilityLabel="Fechar"
+        onPress={onClose}
+      >
+        <YStack flex={1} backgroundColor={SHEET_BACKDROP} justifyContent="flex-end">
+          {/* Pressable interno absorve o toque para não fechar ao tocar no conteúdo. */}
+          <Pressable>
+            <YStack
+              testID={testID}
+              backgroundColor="$background"
+              padding="$4"
+              paddingBottom="$6"
+              gap="$3"
+              borderTopLeftRadius={SHEET_RADIUS}
+              borderTopRightRadius={SHEET_RADIUS}
+            >
+              {children}
+            </YStack>
+          </Pressable>
+        </YStack>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/features/transactions/components/transaction-filters.tsx
+++ b/features/transactions/components/transaction-filters.tsx
@@ -67,13 +67,13 @@ function FilterChip({ label, selected, onPress }: FilterChipProps): ReactElement
   );
 }
 
-interface PeriodNavigatorProps {
+export interface PeriodNavigatorProps {
   readonly periodLabel: string;
   readonly onPreviousMonth: () => void;
   readonly onNextMonth: () => void;
 }
 
-function PeriodNavigator({
+export function PeriodNavigator({
   periodLabel,
   onPreviousMonth,
   onNextMonth,
@@ -143,29 +143,31 @@ function TagFilterRow({
   );
 }
 
+export interface TransactionFilterControlsProps {
+  readonly typeFilter: TransactionsTypeFilter;
+  readonly onTypeFilterChange: (filter: TransactionsTypeFilter) => void;
+  readonly statusFilter: TransactionsStatusFilter;
+  readonly onStatusFilterChange: (filter: TransactionsStatusFilter) => void;
+  readonly tagFilter: TransactionsTagFilter;
+  readonly onTagFilterChange: (filter: TransactionsTagFilter) => void;
+  readonly onClearFilters: () => void;
+}
+
 /**
- * Filter bar for the transactions screen: monthly period navigation, type,
- * status and tag filters plus a reset action. Mirrors the web filters.
+ * Chips de tipo, status e tags + limpar — sem o navegador de período (que
+ * fica no cabeçalho colapsado). Renderizado dentro do filter sheet.
  */
-export function TransactionFilters({
+export function TransactionFilterControls({
   typeFilter,
   onTypeFilterChange,
   statusFilter,
   onStatusFilterChange,
   tagFilter,
   onTagFilterChange,
-  periodLabel,
-  onPreviousMonth,
-  onNextMonth,
   onClearFilters,
-}: TransactionFiltersProps): ReactElement {
+}: TransactionFilterControlsProps): ReactElement {
   return (
     <YStack gap="$3">
-      <PeriodNavigator
-        periodLabel={periodLabel}
-        onPreviousMonth={onPreviousMonth}
-        onNextMonth={onNextMonth}
-      />
       <XStack gap="$2" flexWrap="wrap">
         {TYPE_ORDER.map((filter) => (
           <FilterChip
@@ -190,6 +192,43 @@ export function TransactionFilters({
       <AppButton tone="secondary" onPress={onClearFilters}>
         Limpar filtros
       </AppButton>
+    </YStack>
+  );
+}
+
+/**
+ * Filter bar completa (período + controles). Mirrors the web filters.
+ * Mantida para retrocompat; o cabeçalho novo usa PeriodNavigator +
+ * TransactionFilterControls diretamente.
+ */
+export function TransactionFilters({
+  typeFilter,
+  onTypeFilterChange,
+  statusFilter,
+  onStatusFilterChange,
+  tagFilter,
+  onTagFilterChange,
+  periodLabel,
+  onPreviousMonth,
+  onNextMonth,
+  onClearFilters,
+}: TransactionFiltersProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      <PeriodNavigator
+        periodLabel={periodLabel}
+        onPreviousMonth={onPreviousMonth}
+        onNextMonth={onNextMonth}
+      />
+      <TransactionFilterControls
+        typeFilter={typeFilter}
+        onTypeFilterChange={onTypeFilterChange}
+        statusFilter={statusFilter}
+        onStatusFilterChange={onStatusFilterChange}
+        tagFilter={tagFilter}
+        onTagFilterChange={onTagFilterChange}
+        onClearFilters={onClearFilters}
+      />
     </YStack>
   );
 }

--- a/features/transactions/components/transaction-row.test.tsx
+++ b/features/transactions/components/transaction-row.test.tsx
@@ -1,0 +1,109 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { AppProviders } from "@/core/providers/app-providers";
+import { TransactionRow } from "@/features/transactions/components/transaction-row";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+
+// Mocka o ReanimatedSwipeable: renderiza as right actions (com um `close`
+// stub) ao lado dos children, para exercitar Pagar/Excluir e o tap no teste.
+jest.mock("react-native-gesture-handler/ReanimatedSwipeable", () => {
+  const ReactInner = require("react");
+  const { View } = require("react-native");
+  const Swipeable = ({
+    children,
+    renderRightActions,
+  }: {
+    readonly children: React.ReactNode;
+    readonly renderRightActions?: (
+      progress: unknown,
+      translation: unknown,
+      methods: { close: () => void },
+    ) => React.ReactNode;
+  }): React.ReactNode =>
+    ReactInner.createElement(
+      View,
+      null,
+      renderRightActions
+        ? renderRightActions({ value: 0 }, { value: 0 }, { close: () => undefined })
+        : null,
+      children,
+    );
+  return { __esModule: true, default: Swipeable };
+});
+
+const buildTx = (
+  overrides: Partial<TransactionViewModel> = {},
+): TransactionViewModel => ({
+  id: "tx-1",
+  title: "Internet",
+  amount: "120.00",
+  type: "expense",
+  dueDate: "2026-06-10",
+  status: "pending",
+  description: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  installmentGroupId: null,
+  installmentNumber: null,
+  ...overrides,
+});
+
+const noop = (): void => {};
+
+describe("TransactionRow", () => {
+  it("abre o action sheet ao tocar na linha", () => {
+    const onOpenActions = jest.fn();
+    const { getByTestId } = render(
+      <AppProviders>
+        <TransactionRow
+          tx={buildTx()}
+          onOpenActions={onOpenActions}
+          onMarkPaid={noop}
+          onDelete={noop}
+        />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByTestId("transaction-row-tx-1"));
+
+    expect(onOpenActions).toHaveBeenCalledTimes(1);
+  });
+
+  it("revela Pagar e Excluir no swipe e dispara os callbacks", () => {
+    const onMarkPaid = jest.fn();
+    const onDelete = jest.fn();
+    const { getByLabelText } = render(
+      <AppProviders>
+        <TransactionRow
+          tx={buildTx()}
+          onOpenActions={noop}
+          onMarkPaid={onMarkPaid}
+          onDelete={onDelete}
+        />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByLabelText("Pagar Internet"));
+    expect(onMarkPaid).toHaveBeenCalledWith("tx-1");
+
+    fireEvent.press(getByLabelText("Excluir Internet"));
+    expect(onDelete).toHaveBeenCalledWith("tx-1");
+  });
+
+  it("nao oferece Pagar quando a transacao ja esta paga", () => {
+    const { queryByLabelText } = render(
+      <AppProviders>
+        <TransactionRow
+          tx={buildTx({ status: "paid" })}
+          onOpenActions={noop}
+          onMarkPaid={noop}
+          onDelete={noop}
+        />
+      </AppProviders>,
+    );
+
+    expect(queryByLabelText("Pagar Internet")).toBeNull();
+  });
+});

--- a/features/transactions/components/transaction-row.tsx
+++ b/features/transactions/components/transaction-row.tsx
@@ -1,0 +1,187 @@
+import { memo, type ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Pressable, type AccessibilityActionEvent } from "react-native";
+import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+import {
+  formatStatusLabel,
+  getInstallmentLabel,
+  statusTone,
+} from "@/features/transactions/utils/transaction-presentation";
+import { colorPalette, darkSemanticColors, lightSemanticColors } from "@/shared/theme";
+import { AppBadge } from "@/shared/components/app-badge";
+import { formatShortDate } from "@/shared/utils/formatters";
+
+const ACTION_WIDTH = 84;
+
+export interface TransactionRowProps {
+  readonly tx: TransactionViewModel;
+  readonly onOpenActions: (tx: TransactionViewModel) => void;
+  readonly onMarkPaid: (txId: string) => void;
+  readonly onDelete: (txId: string) => void;
+}
+
+interface SwipeActionProps {
+  readonly label: string;
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly backgroundColor: string;
+  readonly accessibilityLabel: string;
+  readonly onPress: () => void;
+}
+
+function SwipeAction({
+  label,
+  icon,
+  backgroundColor,
+  accessibilityLabel,
+  onPress,
+}: SwipeActionProps): ReactElement {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={{
+        width: ACTION_WIDTH,
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 4,
+        backgroundColor,
+      }}
+    >
+      <MaterialCommunityIcons name={icon} size={22} color={colorPalette.white} />
+      <Paragraph color={colorPalette.white} fontFamily="$body" fontSize="$2" fontWeight="$6">
+        {label}
+      </Paragraph>
+    </Pressable>
+  );
+}
+
+interface RowContentProps {
+  readonly tx: TransactionViewModel;
+}
+
+/** Conteúdo visível da linha: título/descrição à esquerda, valor/status à direita. */
+function RowContent({ tx }: RowContentProps): ReactElement {
+  const installmentLabel = getInstallmentLabel(tx);
+  const secondaryLine =
+    tx.description ?? `Vence ${formatShortDate(tx.dueDate)}`;
+  return (
+    <XStack
+      backgroundColor="$surfaceCard"
+      paddingVertical="$3"
+      paddingHorizontal="$4"
+      gap="$3"
+      alignItems="center"
+    >
+      <YStack flex={1} gap="$1">
+        <Paragraph
+          numberOfLines={1}
+          color="$color"
+          fontFamily="$body"
+          fontSize="$4"
+          fontWeight="$6"
+        >
+          {tx.title}
+        </Paragraph>
+        <Paragraph numberOfLines={1} color="$muted" fontFamily="$body" fontSize="$2">
+          {secondaryLine}
+          {installmentLabel ? ` · ${installmentLabel}` : ""}
+        </Paragraph>
+      </YStack>
+      <YStack alignItems="flex-end" gap="$1">
+        <Paragraph
+          color={tx.type === "income" ? "$success" : "$danger"}
+          fontFamily="$body"
+          fontSize="$4"
+          fontWeight="$6"
+        >
+          {tx.type === "income" ? "+" : "-"}
+          {tx.amount}
+        </Paragraph>
+        <AppBadge tone={statusTone(tx.status)}>{formatStatusLabel(tx.status)}</AppBadge>
+      </YStack>
+    </XStack>
+  );
+}
+
+/**
+ * Linha compacta de transação (paridade web — épico #540 / #569). Toque
+ * abre o action sheet com todas as ações; arrastar para a esquerda revela
+ * Pagar/Excluir. As ações também ficam disponíveis ao leitor de tela via
+ * `accessibilityActions`. Pagar/Excluir reusam os fluxos de confirmação.
+ */
+function TransactionRowComponent({
+  tx,
+  onOpenActions,
+  onMarkPaid,
+  onDelete,
+}: TransactionRowProps): ReactElement {
+  const isDark = useResolvedTheme() === "auraxis_dark";
+  const palette = isDark ? darkSemanticColors : lightSemanticColors;
+  const canPay = tx.status !== "paid";
+
+  const handleAccessibilityAction = (event: AccessibilityActionEvent): void => {
+    if (event.nativeEvent.actionName === "pay") {
+      onMarkPaid(tx.id);
+    } else if (event.nativeEvent.actionName === "delete") {
+      onDelete(tx.id);
+    }
+  };
+
+  return (
+    <ReanimatedSwipeable
+      friction={1.6}
+      rightThreshold={40}
+      overshootRight={false}
+      renderRightActions={(_progress, _translation, methods) => (
+        <XStack>
+          {canPay ? (
+            <SwipeAction
+              label="Pagar"
+              icon="check"
+              backgroundColor={palette.success}
+              accessibilityLabel={`Pagar ${tx.title}`}
+              onPress={() => {
+                methods.close();
+                onMarkPaid(tx.id);
+              }}
+            />
+          ) : null}
+          <SwipeAction
+            label="Excluir"
+            icon="trash-can-outline"
+            backgroundColor={palette.danger}
+            accessibilityLabel={`Excluir ${tx.title}`}
+            onPress={() => {
+              methods.close();
+              onDelete(tx.id);
+            }}
+          />
+        </XStack>
+      )}
+    >
+      <Pressable
+        testID={`transaction-row-${tx.id}`}
+        accessibilityRole="button"
+        accessibilityLabel={`${tx.title}, ${formatStatusLabel(tx.status)}, ${
+          tx.type === "income" ? "receita" : "despesa"
+        } de ${tx.amount}, vence ${formatShortDate(tx.dueDate)}. Toque para ações.`}
+        accessibilityActions={[
+          ...(canPay ? [{ name: "pay", label: "Pagar" }] : []),
+          { name: "delete", label: "Excluir" },
+        ]}
+        onAccessibilityAction={handleAccessibilityAction}
+        onPress={() => onOpenActions(tx)}
+      >
+        <RowContent tx={tx} />
+      </Pressable>
+    </ReanimatedSwipeable>
+  );
+}
+
+export const TransactionRow = memo(TransactionRowComponent);

--- a/features/transactions/hooks/use-transactions-screen-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.test.ts
@@ -422,3 +422,56 @@ describe("useTransactionsScreenController quick-create intent (tab [+])", () => 
     (useLocalSearchParams as jest.Mock).mockReturnValue({});
   });
 });
+
+describe("useTransactionsScreenController period balance + active filters", () => {
+  it("expoe a descricao no view model", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        transactions: [buildRecord({ id: "a", description: "Conta de luz" })],
+        pagination: { total: 1 },
+      },
+    } as never);
+
+    const { result } = renderHook(() => useTransactionsScreenController());
+
+    expect(result.current.transactions[0]).toEqual(
+      expect.objectContaining({ description: "Conta de luz" }),
+    );
+  });
+
+  it("computa o saldo do periodo (receitas - despesas, ignorando canceladas)", () => {
+    mockedUseQuery.mockReturnValue({
+      data: {
+        transactions: [
+          buildRecord({ id: "a", type: "income", amount: "1000.00" }),
+          buildRecord({ id: "b", type: "expense", amount: "300.50" }),
+          buildRecord({
+            id: "c",
+            type: "expense",
+            amount: "999.99",
+            status: "cancelled",
+          }),
+        ],
+        pagination: { total: 3 },
+      },
+    } as never);
+
+    const { result } = renderHook(() => useTransactionsScreenController());
+
+    expect(result.current.monthBalance).toBeCloseTo(699.5, 2);
+  });
+
+  it("hasActiveFilters reflete filtros de tipo, status e tag", () => {
+    mockedUseQuery.mockReturnValue({
+      data: { transactions: [], pagination: { total: 0 } },
+    } as never);
+
+    const { result } = renderHook(() => useTransactionsScreenController());
+    expect(result.current.hasActiveFilters).toBe(false);
+
+    act(() => {
+      result.current.setStatusFilter("pending");
+    });
+    expect(result.current.hasActiveFilters).toBe(true);
+  });
+});

--- a/features/transactions/hooks/use-transactions-screen-controller.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.ts
@@ -37,6 +37,7 @@ export interface TransactionViewModel {
   readonly type: "income" | "expense";
   readonly dueDate: string;
   readonly status: string;
+  readonly description: string | null;
   readonly isRecurring: boolean;
   readonly isInstallment: boolean;
   readonly installmentCount: number | null;
@@ -53,6 +54,10 @@ export interface TransactionsScreenController {
   readonly transactionsQuery: ReturnType<typeof useTransactionsQuery>;
   readonly transactions: readonly TransactionViewModel[];
   readonly total: number;
+  /** Net do período carregado (receitas − despesas, ignora canceladas). */
+  readonly monthBalance: number;
+  /** True quando algum filtro de tipo/status/tag está ativo. */
+  readonly hasActiveFilters: boolean;
   readonly typeFilter: TransactionsTypeFilter;
   readonly setTypeFilter: (filter: TransactionsTypeFilter) => void;
   readonly statusFilter: TransactionsStatusFilter;
@@ -98,6 +103,7 @@ const toViewModel = (
   type: record.type,
   dueDate: record.dueDate,
   status: record.status,
+  description: record.description,
   isRecurring: record.isRecurring,
   isInstallment: record.isInstallment,
   installmentCount: record.installmentCount,
@@ -404,6 +410,39 @@ function useTransactionsActions({
   };
 }
 
+const computeMonthBalance = (records: readonly TransactionRecord[]): number =>
+  records.reduce((sum, record) => {
+    if (record.status === "cancelled") {
+      return sum;
+    }
+    const value = Number.parseFloat(record.amount);
+    if (Number.isNaN(value)) {
+      return sum;
+    }
+    return record.type === "income" ? sum + value : sum - value;
+  }, 0);
+
+interface TransactionsDerived {
+  readonly monthBalance: number;
+  readonly hasActiveFilters: boolean;
+}
+
+/** Deriva o saldo do período (net) e se há filtro de tipo/status/tag ativo. */
+function useTransactionsDerived(
+  transactionsQuery: ReturnType<typeof useTransactionsQuery>,
+  filters: TransactionsFiltersState,
+): TransactionsDerived {
+  const monthBalance = useMemo<number>(
+    () => computeMonthBalance(transactionsQuery.data?.transactions ?? []),
+    [transactionsQuery.data],
+  );
+  const hasActiveFilters =
+    filters.typeFilter !== "all" ||
+    filters.statusFilter !== "all" ||
+    filters.tagFilter !== "all";
+  return { monthBalance, hasActiveFilters };
+}
+
 /**
  * Canonical controller for the transactions screen. Owns the create/edit
  * form state machine, server-side filters (type, status, tag and monthly
@@ -411,6 +450,7 @@ function useTransactionsActions({
  * mutations. The screen remains view-only.
  */
  
+// eslint-disable-next-line max-lines-per-function -- agregador: mapeia ~35 campos do controller
 export function useTransactionsScreenController(): TransactionsScreenController {
   const filters = useTransactionsFilters();
   const transactionsQuery = useTransactionsQuery(filters.listQuery);
@@ -447,10 +487,14 @@ export function useTransactionsScreenController(): TransactionsScreenController 
       .map((record) => toViewModel(record, installmentNumbers.get(record.id) ?? null));
   }, [installmentGroupFilter, transactionsQuery.data, filters.typeFilter]);
 
+  const derived = useTransactionsDerived(transactionsQuery, filters);
+
   return {
     transactionsQuery,
     transactions,
     total: transactionsQuery.data?.pagination.total ?? 0,
+    monthBalance: derived.monthBalance,
+    hasActiveFilters: derived.hasActiveFilters,
     typeFilter: filters.typeFilter,
     setTypeFilter: filters.setTypeFilter,
     statusFilter: filters.statusFilter,

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -1,12 +1,14 @@
 import { useCallback, useMemo, useState, type ReactElement } from "react";
 
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { FlashList } from "@shopify/flash-list";
 import { useRouter } from "expo-router";
-import { Modal, RefreshControl } from "react-native";
+import { Modal, Pressable, RefreshControl } from "react-native";
 import { Paragraph, XStack, YStack } from "tamagui";
 
 import { appRoutes } from "@/core/navigation/routes";
 import { queryKeys } from "@/core/query/query-keys";
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
 import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
 import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
 import { FinancialCalendar } from "@/features/transactions/components/financial-calendar";
@@ -16,35 +18,31 @@ import {
   type DeleteTarget,
   type MarkPaidTarget,
 } from "@/features/transactions/components/transaction-action-modals";
-import { TransactionFilters } from "@/features/transactions/components/transaction-filters";
+import { TransactionActionSheet } from "@/features/transactions/components/transaction-action-sheet";
+import { TransactionBottomSheet } from "@/features/transactions/components/transaction-bottom-sheet";
+import {
+  PeriodNavigator,
+  TransactionFilterControls,
+} from "@/features/transactions/components/transaction-filters";
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
+import { TransactionRow } from "@/features/transactions/components/transaction-row";
 import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
 import {
   useTransactionsScreenController,
   type TransactionsScreenController,
-  type TransactionsViewMode,
   type TransactionViewModel,
 } from "@/features/transactions/hooks/use-transactions-screen-controller";
-import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
-import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
-import { useListRefresh } from "@/shared/hooks/use-list-refresh";
 import { isFeatureEnabled } from "@/shared/feature-flags";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
 import { useT } from "@/shared/i18n";
 import { TransactionListSkeleton } from "@/shared/skeletons";
-import { formatShortDate } from "@/shared/utils/formatters";
-
-const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
-  paid: "primary",
-  pending: "default",
-  overdue: "danger",
-  cancelled: "default",
-  postponed: "default",
-};
+import { darkSemanticColors, lightSemanticColors } from "@/shared/theme";
+import { formatCurrency } from "@/shared/utils/formatters";
 
 const TRANSACTIONS_REFRESH_KEYS = [
   queryKeys.transactions.list(),
@@ -54,11 +52,10 @@ const TRANSACTIONS_REFRESH_KEYS = [
 /**
  * Canonical transactions screen composition for the mobile app.
  *
- * @returns List with filters and create/edit/delete actions or active form.
+ * @returns List with collapsed header and swipe/tap actions, or active form.
  */
 export function TransactionsScreen(): ReactElement {
   const controller = useTransactionsScreenController();
-  const router = useRouter();
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -82,10 +79,7 @@ export function TransactionsScreen(): ReactElement {
   const listHeader = (
     <YStack gap="$4" paddingBottom="$2">
       <FilterHeader controller={controller} />
-      <AiInsightSurface
-        dimension="transactions"
-        onOpenHub={() => router.push(appRoutes.private.insights)}
-      />
+      <AiInsightSurface dimension="transactions" />
     </YStack>
   );
 
@@ -98,8 +92,8 @@ export function TransactionsScreen(): ReactElement {
     );
   }
 
-  // Lista: filtros + insight rolam JUNTO com os itens (ListHeaderComponent),
-  // em vez de ficarem fixos comendo a viewport.
+  // Lista: filtros colapsados + insight rolam JUNTO com os itens
+  // (ListHeaderComponent), deixando as transações visíveis na dobra.
   return (
     <AppScreen scrollable={false}>
       <TransactionsListCard controller={controller} listHeader={listHeader} />
@@ -111,10 +105,118 @@ interface ControllerProps {
   readonly controller: TransactionsScreenController;
 }
 
+interface HeaderIconButtonProps {
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly accessibilityLabel: string;
+  readonly color: string;
+  readonly onPress: () => void;
+  readonly badgeColor?: string;
+}
+
+/** Botão só-ícone do cabeçalho (44×44), com dot opcional de filtro ativo. */
+function HeaderIconButton({
+  icon,
+  accessibilityLabel,
+  color,
+  onPress,
+  badgeColor,
+}: HeaderIconButtonProps): ReactElement {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={{ width: 44, height: 44, alignItems: "center", justifyContent: "center" }}
+    >
+      <MaterialCommunityIcons name={icon} size={24} color={color} />
+      {badgeColor ? (
+        <YStack
+          position="absolute"
+          top={9}
+          right={9}
+          width={9}
+          height={9}
+          borderRadius={9}
+          backgroundColor={badgeColor}
+        />
+      ) : null}
+    </Pressable>
+  );
+}
+
+interface HeaderActionsRowProps extends ControllerProps {
+  readonly iconColor: string;
+  readonly badgeColor: string;
+  readonly onOpenFilters: () => void;
+  readonly onOpenExport: () => void;
+}
+
+/** Saldo do período (esquerda) + ações em ícones (direita). */
+function HeaderActionsRow({
+  controller,
+  iconColor,
+  badgeColor,
+  onOpenFilters,
+  onOpenExport,
+}: HeaderActionsRowProps): ReactElement {
+  const positive = controller.monthBalance >= 0;
+  return (
+    <XStack alignItems="center" justifyContent="space-between">
+      <YStack>
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+          Saldo do período
+        </Paragraph>
+        <Paragraph
+          color={positive ? "$success" : "$danger"}
+          fontFamily="$body"
+          fontSize="$6"
+          fontWeight="$7"
+        >
+          {formatCurrency(controller.monthBalance)}
+        </Paragraph>
+      </YStack>
+      <XStack alignItems="center">
+        <HeaderIconButton
+          icon={
+            controller.viewMode === "list"
+              ? "calendar-month-outline"
+              : "format-list-bulleted"
+          }
+          accessibilityLabel={
+            controller.viewMode === "list" ? "Ver calendário" : "Ver lista"
+          }
+          color={iconColor}
+          onPress={() =>
+            controller.setViewMode(
+              controller.viewMode === "list" ? "calendar" : "list",
+            )
+          }
+        />
+        <HeaderIconButton
+          icon="filter-variant"
+          accessibilityLabel="Filtros"
+          color={iconColor}
+          onPress={onOpenFilters}
+          badgeColor={controller.hasActiveFilters ? badgeColor : undefined}
+        />
+        <HeaderIconButton
+          icon="tray-arrow-up"
+          accessibilityLabel="Exportar"
+          color={iconColor}
+          onPress={onOpenExport}
+        />
+      </XStack>
+    </XStack>
+  );
+}
+
 function FilterHeader({ controller }: ControllerProps): ReactElement {
   const { t } = useT();
   const router = useRouter();
+  const isDark = useResolvedTheme() === "auraxis_dark";
+  const palette = isDark ? darkSemanticColors : lightSemanticColors;
   const [exportSheetOpen, setExportSheetOpen] = useState<boolean>(false);
+  const [filterSheetOpen, setFilterSheetOpen] = useState<boolean>(false);
   const exportRunner = useTransactionsExport();
   const importEnabled = isFeatureEnabled(IMPORT_FEATURE_FLAG_KEY);
 
@@ -125,23 +227,35 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
     },
     [exportRunner],
   );
-  const handleOpenImport = useCallback(() => {
-    router.push(appRoutes.private.importTransactions);
-  }, [router]);
 
   return (
-    <AppSurfaceCard
-      title="Transacoes"
-      description={`${controller.total} registradas`}
-    >
-      <FilterHeaderControls
+    <YStack gap="$3">
+      <PeriodNavigator
+        periodLabel={controller.periodLabel}
+        onPreviousMonth={controller.goToPreviousMonth}
+        onNextMonth={controller.goToNextMonth}
+      />
+      <HeaderActionsRow
         controller={controller}
-        importEnabled={importEnabled}
-        listLabel={t("transactions.view.list")}
-        calendarLabel={t("transactions.view.calendar")}
-        exportLabel={t("transactions.export.title")}
+        iconColor={palette.mutedForeground}
+        badgeColor={palette.primary}
+        onOpenFilters={() => setFilterSheetOpen(true)}
         onOpenExport={() => setExportSheetOpen(true)}
-        onOpenImport={handleOpenImport}
+      />
+      {importEnabled ? (
+        <AppButton
+          tone="secondary"
+          size="sm"
+          onPress={() => router.push(appRoutes.private.importTransactions)}
+        >
+          Importar planilha
+        </AppButton>
+      ) : null}
+      <InstallmentGroupFilterNotice controller={controller} />
+      <FilterSheet
+        visible={filterSheetOpen}
+        controller={controller}
+        onClose={() => setFilterSheetOpen(false)}
       />
       <Modal
         visible={exportSheetOpen}
@@ -158,63 +272,36 @@ function FilterHeader({ controller }: ControllerProps): ReactElement {
           translate={t}
         />
       </Modal>
-    </AppSurfaceCard>
+    </YStack>
   );
 }
 
-interface FilterHeaderControlsProps extends ControllerProps {
-  readonly importEnabled: boolean;
-  readonly listLabel: string;
-  readonly calendarLabel: string;
-  readonly exportLabel: string;
-  readonly onOpenExport: () => void;
-  readonly onOpenImport: () => void;
+interface FilterSheetProps extends ControllerProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
 }
 
-function FilterHeaderControls({
-  controller,
-  importEnabled,
-  listLabel,
-  calendarLabel,
-  exportLabel,
-  onOpenExport,
-  onOpenImport,
-}: FilterHeaderControlsProps): ReactElement {
+function FilterSheet({ visible, controller, onClose }: FilterSheetProps): ReactElement {
   return (
-    <YStack gap="$3">
-      <ViewToggle
-        mode={controller.viewMode}
-        onChange={controller.setViewMode}
-        listLabel={listLabel}
-        calendarLabel={calendarLabel}
-      />
-      <TransactionFilters
+    <TransactionBottomSheet
+      visible={visible}
+      onClose={onClose}
+      testID="transaction-filter-sheet"
+    >
+      <Paragraph fontFamily="$body" fontWeight="$7" fontSize="$5" color="$color">
+        Filtros
+      </Paragraph>
+      <TransactionFilterControls
         typeFilter={controller.typeFilter}
         onTypeFilterChange={controller.setTypeFilter}
         statusFilter={controller.statusFilter}
         onStatusFilterChange={controller.setStatusFilter}
         tagFilter={controller.tagFilter}
         onTagFilterChange={controller.setTagFilter}
-        periodLabel={controller.periodLabel}
-        onPreviousMonth={controller.goToPreviousMonth}
-        onNextMonth={controller.goToNextMonth}
         onClearFilters={controller.clearFilters}
       />
-      <XStack gap="$2">
-        <AppButton flex={1} glow onPress={controller.handleOpenCreate}>
-          Nova transacao
-        </AppButton>
-        <AppButton flex={1} tone="secondary" onPress={onOpenExport}>
-          {exportLabel}
-        </AppButton>
-      </XStack>
-      {importEnabled ? (
-        <AppButton tone="secondary" onPress={onOpenImport}>
-          Importar planilha
-        </AppButton>
-      ) : null}
-      <InstallmentGroupFilterNotice controller={controller} />
-    </YStack>
+      <AppButton onPress={onClose}>Aplicar</AppButton>
+    </TransactionBottomSheet>
   );
 }
 
@@ -230,43 +317,12 @@ function InstallmentGroupFilterNotice({
       <Paragraph color="$muted" flex={1} fontFamily="$body" fontSize="$2">
         Mostrando parcelas da mesma compra.
       </Paragraph>
-      <AppButton tone="secondary" onPress={controller.handleClearInstallmentGroupFilter}>
+      <AppButton
+        tone="secondary"
+        size="sm"
+        onPress={controller.handleClearInstallmentGroupFilter}
+      >
         Mostrar todas
-      </AppButton>
-    </XStack>
-  );
-}
-
-interface ViewToggleProps {
-  readonly mode: TransactionsViewMode;
-  readonly onChange: (mode: TransactionsViewMode) => void;
-  readonly listLabel: string;
-  readonly calendarLabel: string;
-}
-
-function ViewToggle({
-  mode,
-  onChange,
-  listLabel,
-  calendarLabel,
-}: ViewToggleProps): ReactElement {
-  return (
-    <XStack gap="$2">
-      <AppButton
-        flex={1}
-        tone={mode === "list" ? "primary" : "secondary"}
-        onPress={() => onChange("list")}
-        accessibilityState={{ selected: mode === "list" }}
-      >
-        {listLabel}
-      </AppButton>
-      <AppButton
-        flex={1}
-        tone={mode === "calendar" ? "primary" : "secondary"}
-        onPress={() => onChange("calendar")}
-        accessibilityState={{ selected: mode === "calendar" }}
-      >
-        {calendarLabel}
       </AppButton>
     </XStack>
   );
@@ -359,8 +415,6 @@ function TransactionsListCard({
 }: TransactionsListCardProps): ReactElement {
   const query = controller.transactionsQuery;
 
-  // Estado mostrado pela FlashList quando não há itens (header de filtros
-  // sempre visível via ListHeaderComponent, então tudo rola junto).
   const listEmptyComponent = useMemo((): ReactElement => {
     if (query.isPending) {
       return <TransactionListSkeleton rows={5} />;
@@ -378,14 +432,10 @@ function TransactionsListCard({
       <AppEmptyState
         illustration="transactions"
         title="Nenhuma transacao no filtro atual"
-        description="Crie uma nova transacao ou troque o filtro acima para visualizar movimentos."
-        cta={{
-          label: "Nova transacao",
-          onPress: controller.handleOpenCreate,
-        }}
+        description="Crie uma nova transacao no botao central ou troque o filtro para visualizar movimentos."
       />
     );
-  }, [query.isPending, query.isError, query.error, controller.handleOpenCreate]);
+  }, [query.isPending, query.isError, query.error]);
 
   return (
     <TransactionsList
@@ -408,30 +458,30 @@ function TransactionsList({
   listEmptyComponent,
 }: TransactionsListProps): ReactElement {
   const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
-  const [detailTransactionId, setDetailTransactionId] = useState<string | null>(null);
+  const [actionTarget, setActionTarget] = useState<TransactionViewModel | null>(null);
   const [payTarget, setPayTarget] = useState<MarkPaidTarget | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
-  const detailTransaction = useMemo(
-    () => controller.transactions.find((item) => item.id === detailTransactionId) ?? null,
-    [controller.transactions, detailTransactionId],
-  );
 
-  const handleEdit = useCallback(
-    (txId: string): void => {
-      const record = controller.transactionsQuery.data?.transactions.find(
-        (item) => item.id === txId,
-      );
-      if (record) {
-        controller.handleOpenEdit(record);
-      }
-    },
-    [controller],
-  );
+  const openActions = useCallback((tx: TransactionViewModel): void => {
+    setActionTarget(tx);
+  }, []);
 
-  const handleDelete = useCallback(
+  const requestPay = useCallback(
     (txId: string): void => {
       const tx = controller.transactions.find((item) => item.id === txId);
       if (tx) {
+        setActionTarget(null);
+        setPayTarget({ id: tx.id, title: tx.title });
+      }
+    },
+    [controller.transactions],
+  );
+
+  const requestDelete = useCallback(
+    (txId: string): void => {
+      const tx = controller.transactions.find((item) => item.id === txId);
+      if (tx) {
+        setActionTarget(null);
         setDeleteTarget({
           id: tx.id,
           title: tx.title,
@@ -442,55 +492,45 @@ function TransactionsList({
     [controller.transactions],
   );
 
-  const handleMarkPaid = useCallback(
+  const handleEdit = useCallback(
     (txId: string): void => {
-      const tx = controller.transactions.find((item) => item.id === txId);
-      if (tx) {
-        setPayTarget({ id: tx.id, title: tx.title });
+      const record = controller.transactionsQuery.data?.transactions.find(
+        (item) => item.id === txId,
+      );
+      if (record) {
+        setActionTarget(null);
+        controller.handleOpenEdit(record);
       }
     },
-    [controller.transactions],
+    [controller],
   );
 
   const handleDuplicate = useCallback(
     (txId: string): void => {
+      setActionTarget(null);
       void controller.handleDuplicate(txId);
     },
     [controller],
   );
 
-  const handleDetails = useCallback((txId: string): void => {
-    setDetailTransactionId(txId);
-  }, []);
-
-  const handleCloseDetails = useCallback((): void => {
-    setDetailTransactionId(null);
-  }, []);
+  const handleShowInstallmentGroup = useCallback(
+    (installmentGroupId: string): void => {
+      setActionTarget(null);
+      controller.handleShowInstallmentGroup(installmentGroupId);
+    },
+    [controller],
+  );
 
   const renderItem = useCallback(
     ({ item }: { readonly item: TransactionViewModel }) => (
       <TransactionRow
         tx={item}
-        isDeleting={controller.deletingTransactionId === item.id}
-        isDuplicating={controller.duplicatingTransactionId === item.id}
-        isPaying={controller.payingTransactionId === item.id}
-        onDetails={handleDetails}
-        onEdit={handleEdit}
-        onDelete={handleDelete}
-        onMarkPaid={handleMarkPaid}
-        onDuplicate={handleDuplicate}
+        onOpenActions={openActions}
+        onMarkPaid={requestPay}
+        onDelete={requestDelete}
       />
     ),
-    [
-      controller.deletingTransactionId,
-      controller.duplicatingTransactionId,
-      controller.payingTransactionId,
-      handleDelete,
-      handleDetails,
-      handleDuplicate,
-      handleEdit,
-      handleMarkPaid,
-    ],
+    [openActions, requestPay, requestDelete],
   );
 
   return (
@@ -502,17 +542,24 @@ function TransactionsList({
         ListHeaderComponent={listHeader}
         ListEmptyComponent={listEmptyComponent}
         contentContainerStyle={listContainerStyle}
-        ItemSeparatorComponent={ListSeparator}
+        ItemSeparatorComponent={RowSeparator}
         refreshControl={
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         }
         showsVerticalScrollIndicator={false}
         testID="transactions-flashlist"
       />
-      <TransactionDetailModal
-        transaction={detailTransaction}
-        onClose={handleCloseDetails}
-        onShowInstallmentGroup={controller.handleShowInstallmentGroup}
+      <TransactionActionSheet
+        transaction={actionTarget}
+        isPaying={controller.payingTransactionId !== null}
+        isDuplicating={controller.duplicatingTransactionId !== null}
+        isDeleting={controller.deletingTransactionId !== null}
+        onClose={() => setActionTarget(null)}
+        onMarkPaid={requestPay}
+        onEdit={handleEdit}
+        onDuplicate={handleDuplicate}
+        onDelete={requestDelete}
+        onShowInstallmentGroup={handleShowInstallmentGroup}
       />
       <MarkPaidConfirmModal
         target={payTarget}
@@ -540,174 +587,6 @@ const extractTransactionKey = (item: TransactionViewModel): string => item.id;
 
 const listContainerStyle = { paddingBottom: 24 } as const;
 
-function ListSeparator(): ReactElement {
-  return <YStack height="$2" />;
+function RowSeparator(): ReactElement {
+  return <YStack height={1} backgroundColor="$borderColor" />;
 }
-
-interface TransactionRowProps {
-  readonly tx: TransactionViewModel;
-  readonly isDeleting: boolean;
-  readonly isDuplicating: boolean;
-  readonly isPaying: boolean;
-  readonly onDetails: (txId: string) => void;
-  readonly onEdit: (txId: string) => void;
-  readonly onDelete: (txId: string) => void;
-  readonly onMarkPaid: (txId: string) => void;
-  readonly onDuplicate: (txId: string) => void;
-}
-
- 
-const TransactionRow = function TransactionRow({
-  tx,
-  isDeleting,
-  isDuplicating,
-  isPaying,
-  onDetails,
-  onEdit,
-  onDelete,
-  onMarkPaid,
-  onDuplicate,
-}: TransactionRowProps): ReactElement {
-  const installmentLabel = getInstallmentLabel(tx);
-  const isBusy = isDeleting || isDuplicating || isPaying;
-  const handleDetails = useCallback(() => {
-    onDetails(tx.id);
-  }, [onDetails, tx.id]);
-
-  const handleEdit = useCallback(() => {
-    onEdit(tx.id);
-  }, [onEdit, tx.id]);
-
-  const handleDelete = useCallback(() => {
-    onDelete(tx.id);
-  }, [onDelete, tx.id]);
-
-  const handleMarkPaid = useCallback(() => {
-    onMarkPaid(tx.id);
-  }, [onMarkPaid, tx.id]);
-
-  const handleDuplicate = useCallback(() => {
-    onDuplicate(tx.id);
-  }, [onDuplicate, tx.id]);
-
-  return (
-    <YStack gap="$2">
-      <AppKeyValueRow
-        label={tx.title}
-        value={
-          <XStack alignItems="center" gap="$2">
-            <YStack alignItems="flex-end" gap="$1">
-              <Paragraph
-                color={tx.type === "income" ? "$success" : "$danger"}
-                fontFamily="$body"
-                fontSize="$4"
-              >
-                {tx.type === "income" ? "+" : "-"}
-                {tx.amount}
-              </Paragraph>
-              <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
-                {formatShortDate(tx.dueDate)}
-              </Paragraph>
-              {installmentLabel ? (
-                <AppBadge tone="default">{installmentLabel}</AppBadge>
-              ) : null}
-            </YStack>
-            <AppBadge tone={STATUS_TONE[tx.status] ?? "default"}>{tx.status}</AppBadge>
-          </XStack>
-        }
-      />
-      <XStack gap="$2" flexWrap="wrap">
-        <AppButton tone="secondary" onPress={handleDetails} disabled={isBusy}>
-          Detalhes
-        </AppButton>
-        {tx.status !== "paid" ? (
-          <AppButton onPress={handleMarkPaid} disabled={isBusy}>
-            {isPaying ? "Pagando..." : "Pagar"}
-          </AppButton>
-        ) : null}
-        <AppButton tone="secondary" onPress={handleEdit} disabled={isBusy}>
-          Editar
-        </AppButton>
-        <AppButton tone="secondary" onPress={handleDuplicate} disabled={isBusy}>
-          {isDuplicating ? "Duplicando..." : "Duplicar"}
-        </AppButton>
-        <AppButton tone="secondary" onPress={handleDelete} disabled={isBusy}>
-          {isDeleting ? "Excluindo..." : "Excluir"}
-        </AppButton>
-      </XStack>
-    </YStack>
-  );
-};
-
-interface TransactionDetailModalProps {
-  readonly transaction: TransactionViewModel | null;
-  readonly onClose: () => void;
-  readonly onShowInstallmentGroup: (installmentGroupId: string) => void;
-}
-
-function TransactionDetailModal({
-  transaction,
-  onClose,
-  onShowInstallmentGroup,
-}: TransactionDetailModalProps): ReactElement {
-  const installmentLabel = transaction ? getInstallmentLabel(transaction) : null;
-  const installmentGroupId = transaction?.installmentGroupId ?? null;
-  const visible = Boolean(transaction);
-
-  return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="slide"
-      onRequestClose={onClose}
-    >
-      <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
-        <YStack
-          backgroundColor="$background"
-          padding="$4"
-          gap="$3"
-          borderTopLeftRadius="$3"
-          borderTopRightRadius="$3"
-        >
-          {transaction ? (
-            <AppSurfaceCard title="Detalhes da transacao" description={transaction.title}>
-              <YStack gap="$3">
-                <AppKeyValueRow
-                  label="Valor"
-                  value={`${transaction.type === "income" ? "+" : "-"}${transaction.amount}`}
-                  helperText={formatShortDate(transaction.dueDate)}
-                />
-                <AppKeyValueRow label="Status" value={transaction.status} />
-                {installmentLabel ? (
-                  <AppKeyValueRow label="Parcelamento" value={installmentLabel} />
-                ) : null}
-                {installmentGroupId ? (
-                  <AppButton
-                    tone="secondary"
-                    onPress={() => {
-                      onShowInstallmentGroup(installmentGroupId);
-                      onClose();
-                    }}
-                  >
-                    Ver outras parcelas
-                  </AppButton>
-                ) : null}
-                <AppButton onPress={onClose}>Fechar</AppButton>
-              </YStack>
-            </AppSurfaceCard>
-          ) : null}
-        </YStack>
-      </YStack>
-    </Modal>
-  );
-}
-
-const getInstallmentLabel = (tx: TransactionViewModel): string | null => {
-  if (!tx.isInstallment || !tx.installmentCount) {
-    return null;
-  }
-  if (tx.installmentNumber) {
-    return `Parcela ${tx.installmentNumber}/${tx.installmentCount}`;
-  }
-  return `Parcelado em ${tx.installmentCount}x`;
-};

--- a/features/transactions/utils/transaction-presentation.test.ts
+++ b/features/transactions/utils/transaction-presentation.test.ts
@@ -1,0 +1,62 @@
+import {
+  formatStatusLabel,
+  getInstallmentLabel,
+  statusTone,
+} from "@/features/transactions/utils/transaction-presentation";
+
+describe("transaction-presentation", () => {
+  describe("statusTone", () => {
+    it("mapeia os estados conhecidos", () => {
+      expect(statusTone("paid")).toBe("primary");
+      expect(statusTone("overdue")).toBe("danger");
+      expect(statusTone("pending")).toBe("default");
+    });
+
+    it("usa default para estado desconhecido", () => {
+      expect(statusTone("weird")).toBe("default");
+    });
+  });
+
+  describe("formatStatusLabel", () => {
+    it("traduz os estados conhecidos para pt-BR", () => {
+      expect(formatStatusLabel("paid")).toBe("Pago");
+      expect(formatStatusLabel("overdue")).toBe("Vencido");
+    });
+
+    it("faz fallback para o valor cru quando desconhecido", () => {
+      expect(formatStatusLabel("weird")).toBe("weird");
+    });
+  });
+
+  describe("getInstallmentLabel", () => {
+    it("retorna null quando nao e parcelada", () => {
+      expect(
+        getInstallmentLabel({
+          isInstallment: false,
+          installmentCount: null,
+          installmentNumber: null,
+        }),
+      ).toBeNull();
+    });
+
+    it("formata 'Parcela X/Y' quando ha numero da parcela", () => {
+      expect(
+        getInstallmentLabel({
+          isInstallment: true,
+          installmentCount: 12,
+          installmentNumber: 3,
+        }),
+      ).toBe("Parcela 3/12");
+    });
+
+    it("formata 'Parcelado em Yx' quando nao ha numero da parcela", () => {
+      expect(
+        getInstallmentLabel({
+          isInstallment: true,
+          installmentCount: 6,
+          installmentNumber: null,
+        }),
+      ).toBe("Parcelado em 6x");
+    });
+  });
+});

--- a/features/transactions/utils/transaction-presentation.ts
+++ b/features/transactions/utils/transaction-presentation.ts
@@ -1,0 +1,45 @@
+/** Tom do badge de status por estado da transação. */
+export const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
+  paid: "primary",
+  pending: "default",
+  overdue: "danger",
+  cancelled: "default",
+  postponed: "default",
+};
+
+/** Rótulo pt-BR do status (o backend devolve em inglês). */
+export const STATUS_LABEL_PT: Record<string, string> = {
+  paid: "Pago",
+  pending: "Pendente",
+  overdue: "Vencido",
+  cancelled: "Cancelado",
+  postponed: "Adiado",
+};
+
+/** Resolve o tom do badge, com fallback seguro. */
+export const statusTone = (status: string): "default" | "primary" | "danger" =>
+  STATUS_TONE[status] ?? "default";
+
+/** Resolve o rótulo pt-BR do status, com fallback para o valor cru. */
+export const formatStatusLabel = (status: string): string =>
+  STATUS_LABEL_PT[status] ?? status;
+
+interface InstallmentInfo {
+  readonly isInstallment: boolean;
+  readonly installmentCount: number | null;
+  readonly installmentNumber: number | null;
+}
+
+/**
+ * Rótulo de parcelamento ("Parcela 2/12" ou "Parcelado em 12x") ou null
+ * quando a transação não é parcelada.
+ */
+export const getInstallmentLabel = (tx: InstallmentInfo): string | null => {
+  if (!tx.isInstallment || !tx.installmentCount) {
+    return null;
+  }
+  if (tx.installmentNumber) {
+    return `Parcela ${tx.installmentNumber}/${tx.installmentCount}`;
+  }
+  return `Parcelado em ${tx.installmentCount}x`;
+};


### PR DESCRIPTION
## Summary
Redesenha a tela de transações no app para densidade e fluidez (épico #540), 100% OTA. Substitui as linhas pesadas (5 botões, ~150px) e o header que empurrava a lista pra fora da dobra.

### Linha (mecanismo escolhido: híbrido swipe + tap)
- **Linha compacta ~64px** (`TransactionRow`): título + descrição (ou vencimento) à esquerda, valor + badge de status à direita.
- **Swipe ←** revela **Pagar** (oculto se já paga) e **Excluir** — reusam os modais de confirmação existentes (data de pagamento; escopo ocorrência/série).
- **Tap** abre um **action sheet** (`TransactionActionSheet`) com Pagar, Editar, Duplicar, ver parcelas e Excluir — caminho acessível que cobre tudo que o swipe faz.
- **Acessibilidade**: a linha tem `accessibilityActions` (Pagar/Excluir) para leitor de tela + label descritivo; tap targets ≥44px.

### Header colapsado
- Cabeçalho enxuto: navegador de mês (`‹ Junho 2026 ›`) + **saldo do período** + ícones (alternar lista/calendário, filtro com dot de "ativo", exportar).
- **Filtros** (tipo/status/tags + limpar) movidos para um **filter sheet** atrás do ícone de filtro — a lista aparece imediatamente.

### Reuso e infra
- Novo `TransactionBottomSheet` (Modal nativo, backdrop tocável) — sem dependência nova.
- `transaction-presentation` centraliza tom/rótulo PT de status e label de parcela.
- Controller expõe `description`, `monthBalance` (net do período) e `hasActiveFilters`.
- `react-native-gesture-handler` (`ReanimatedSwipeable`) e `GestureHandlerRootView` já presentes no binário → swipe via OTA.

## Test plan
- `npm run quality-check` verde: lint + typecheck + policy + contracts + codegen + **2028 testes** (coverage ≥ 85%).
- TDD: controller (description/saldo/filtros), util de apresentação, action sheet (Pagar condicional, Excluir) e linha (tap→sheet, swipe→pagar/excluir).
- Validação no device via OTA (relaunch 2x), claro e escuro.

## Refs
Closes #569
Parent: #540