### PR TITLE
chore(security): ignora credenciais de submit do EAS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,10 @@ repos/
 # Stryker mutation testing artifacts
 reports/mutation/
 .stryker-tmp/
+
+# EAS submit credentials — NUNCA commitar
+*.p8
+AuthKey_*.p8
+gen-lang-client-*.json
+*service-account*.json
+*.keystore


### PR DESCRIPTION
## O que muda

Adiciona ao `.gitignore` os padrões das credenciais de submit do EAS (App Store Connect `.p8`, service-account JSON do Google, keystores), que não estavam cobertos.

## Contexto

Restauração da publicação após perda do iCloud. As credenciais ficam guardadas no EAS (nuvem); os arquivos locais não devem ir para o git.

Closes #581

🤖 Generated with [Claude Code](https://claude.com/claude-code)