### PR TITLE
feat(transactions): redesign da tela de Transações (feed Fácil/Analítico)

### DIFF
--- a/features/transactions/components/transaction-feed-list.tsx
+++ b/features/transactions/components/transaction-feed-list.tsx
@@ -1,0 +1,183 @@
+import { useCallback, useMemo, useState, type ReactElement } from "react";
+
+import { FlashList } from "@shopify/flash-list";
+import { RefreshControl } from "react-native";
+import { YStack } from "tamagui";
+
+import { queryKeys } from "@/core/query/query-keys";
+import {
+  DeleteConfirmModal,
+  MarkPaidConfirmModal,
+} from "@/features/transactions/components/transaction-action-modals";
+import { TransactionActionSheet } from "@/features/transactions/components/transaction-action-sheet";
+import { TransactionFeedToolbar } from "@/features/transactions/components/transaction-feed-toolbar";
+import { TxCard } from "@/features/transactions/components/tx-card";
+import {
+  useTransactionFeedActions,
+  type FeedItemActionHandlers,
+} from "@/features/transactions/hooks/use-transaction-feed-actions";
+import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import type { TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+import { AppEmptyState } from "@/shared/components/app-empty-state";
+import { AppQueryState } from "@/shared/components/app-query-state";
+import { useListRefresh } from "@/shared/hooks/use-list-refresh";
+import { TransactionListSkeleton } from "@/shared/skeletons";
+
+const TRANSACTIONS_REFRESH_KEYS = [
+  queryKeys.transactions.list(),
+  queryKeys.transactions.summary(),
+] as const;
+
+const listContainerStyle = { paddingBottom: 24 } as const;
+
+const extractKey = (item: TransactionFeedItem): string => item.id;
+
+function FeedSeparator(): ReactElement {
+  return <YStack height="$2" />;
+}
+
+/** Lista do feed em FlashList de `TxCard`, com cabeçalho e estado vazio. */
+function FeedList({
+  controller,
+  header,
+  handlers,
+}: {
+  readonly controller: TransactionsFeedController;
+  readonly header: ReactElement;
+  readonly handlers: FeedItemActionHandlers;
+}): ReactElement {
+  const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
+
+  const renderItem = useCallback(
+    ({ item }: { readonly item: TransactionFeedItem }) => (
+      <TxCard
+        item={item}
+        analytic={controller.viewMode === "analitico"}
+        onPress={handlers.openActions}
+        onMarkPaid={handlers.requestPay}
+        onDelete={handlers.requestDelete}
+      />
+    ),
+    [controller.viewMode, handlers],
+  );
+
+  const emptyComponent = useMemo(
+    (): ReactElement => (
+      <AppEmptyState
+        illustration="transactions"
+        title="Nenhuma transação no filtro atual"
+        description="Crie uma nova transação no botão central ou troque o filtro para visualizar movimentos."
+      />
+    ),
+    [],
+  );
+
+  return (
+    <FlashList
+      data={controller.feedItems}
+      keyExtractor={extractKey}
+      renderItem={renderItem}
+      ListHeaderComponent={header}
+      ListEmptyComponent={emptyComponent}
+      contentContainerStyle={listContainerStyle}
+      ItemSeparatorComponent={FeedSeparator}
+      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}
+      showsVerticalScrollIndicator={false}
+      testID="transactions-flashlist"
+    />
+  );
+}
+
+/** Props do corpo do feed. */
+export interface TransactionFeedProps {
+  readonly controller: TransactionsFeedController;
+}
+
+/**
+ * Corpo do feed de "Transações": estados de query (loading/erro/vazio) + a
+ * lista de cards com o action sheet e os modais de pagar/excluir. Preserva
+ * TODA a fiação de ações do controller (via `useTransactionFeedActions`):
+ * tocar abre o action sheet (pagar/editar/duplicar/excluir/ver parcelas);
+ * arrastar revela Pagar/Excluir.
+ *
+ * @param props Controller do feed.
+ * @returns Lista do feed com sheets e modais de ação.
+ */
+export function TransactionFeed({ controller }: TransactionFeedProps): ReactElement {
+  const [filterOpen, setFilterOpen] = useState<boolean>(false);
+  const [exportOpen, setExportOpen] = useState<boolean>(false);
+  const actions = useTransactionFeedActions(controller);
+
+  const header = (
+    <TransactionFeedToolbar
+      controller={controller}
+      filterOpen={filterOpen}
+      setFilterOpen={setFilterOpen}
+      exportOpen={exportOpen}
+      setExportOpen={setExportOpen}
+    />
+  );
+
+  return (
+    <>
+      <AppQueryState
+        query={controller.transactionsQuery}
+        options={{
+          loading: { title: "Carregando transações", description: "Buscando seus lançamentos." },
+          empty: {
+            title: "Nenhuma transação no filtro atual",
+            description: "Troque o filtro ou crie uma nova transação.",
+          },
+          error: {
+            fallbackTitle: "Não foi possível carregar as transações",
+            fallbackDescription: "Tente novamente em instantes.",
+          },
+          isEmpty: () => controller.feedItems.length === 0,
+        }}
+        loadingComponent={
+          <YStack gap="$4">
+            {header}
+            <TransactionListSkeleton rows={5} />
+          </YStack>
+        }
+        emptyComponent={
+          <FeedList controller={controller} header={header} handlers={actions.handlers} />
+        }
+      >
+        {() => (
+          <FeedList controller={controller} header={header} handlers={actions.handlers} />
+        )}
+      </AppQueryState>
+      <TransactionActionSheet
+        transaction={actions.actionTarget}
+        isPaying={controller.payingTransactionId !== null}
+        isDuplicating={controller.duplicatingTransactionId !== null}
+        isDeleting={controller.deletingTransactionId !== null}
+        onClose={actions.closeActions}
+        onMarkPaid={actions.handlers.requestPay}
+        onEdit={actions.handleEdit}
+        onDuplicate={actions.handleDuplicate}
+        onDelete={actions.handlers.requestDelete}
+        onShowInstallmentGroup={actions.handleShowInstallmentGroup}
+      />
+      <MarkPaidConfirmModal
+        target={actions.payTarget}
+        isSubmitting={controller.payingTransactionId !== null}
+        onConfirm={(txId, paidAt) => {
+          void controller.handleMarkPaid(txId, paidAt);
+          actions.closePay();
+        }}
+        onClose={actions.closePay}
+      />
+      <DeleteConfirmModal
+        target={actions.deleteTarget}
+        isDeleting={controller.deletingTransactionId !== null}
+        onConfirm={(txId, scope) => {
+          void controller.handleDelete(txId, scope);
+          actions.closeDelete();
+        }}
+        onClose={actions.closeDelete}
+      />
+    </>
+  );
+}

--- a/features/transactions/components/transaction-feed-toolbar.tsx
+++ b/features/transactions/components/transaction-feed-toolbar.tsx
@@ -1,0 +1,207 @@
+import { useCallback, type ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { useRouter } from "expo-router";
+import { Modal, Pressable } from "react-native";
+import { YStack, useTheme } from "tamagui";
+
+import { appRoutes } from "@/core/navigation/routes";
+import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
+import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import { PeriodNavigator } from "@/features/transactions/components/transaction-filters";
+import {
+  ExportSheet,
+  FilterSheet,
+  InstallmentGroupFilterNotice,
+} from "@/features/transactions/components/transaction-screen-sheets";
+import { TxCategoryBreakdown } from "@/features/transactions/components/tx-category-breakdown";
+import { TxModeToggle } from "@/features/transactions/components/tx-mode-toggle";
+import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
+import { AppButton } from "@/shared/components/app-button";
+import { isFeatureEnabled } from "@/shared/feature-flags";
+import { useT } from "@/shared/i18n";
+import { iconSizes } from "@/shared/theme";
+
+interface ToolbarButtonProps {
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly accessibilityLabel: string;
+  readonly color: string;
+  readonly onPress: () => void;
+  readonly badgeColor?: string;
+  readonly testID?: string;
+}
+
+/** Botão só-ícone (44×44) da barra de ferramentas, com dot opcional. */
+function ToolbarButton({
+  icon,
+  accessibilityLabel,
+  color,
+  onPress,
+  badgeColor,
+  testID,
+}: ToolbarButtonProps): ReactElement {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      testID={testID}
+      style={{ width: 44, height: 44, alignItems: "center", justifyContent: "center" }}
+    >
+      <MaterialCommunityIcons name={icon} size={iconSizes.lg} color={color} />
+      {badgeColor ? (
+        <YStack
+          position="absolute"
+          top={9}
+          right={9}
+          width={9}
+          height={9}
+          borderRadius="$5"
+          backgroundColor={badgeColor}
+        />
+      ) : null}
+    </Pressable>
+  );
+}
+
+interface FeedToolbarProps {
+  readonly controller: TransactionsFeedController;
+  readonly onOpenFilters: () => void;
+  readonly onOpenExport: () => void;
+}
+
+/**
+ * Cabeçalho do feed (rola junto com a lista): navegação de período, segmented
+ * Fácil/Analítico, ações secundárias (filtros/exportar/lixeira), botão de
+ * importar (se habilitado), aviso de parcelas, o painel "Gastos por categoria"
+ * (modo Analítico) e o insight de IA.
+ */
+function FeedToolbar({
+  controller,
+  onOpenFilters,
+  onOpenExport,
+}: FeedToolbarProps): ReactElement {
+  const router = useRouter();
+  const theme = useTheme();
+  const importEnabled = isFeatureEnabled(IMPORT_FEATURE_FLAG_KEY);
+  const iconColor = theme.muted?.val ?? theme.color?.val ?? "#000000";
+  const badgeColor = theme.primary?.val ?? iconColor;
+
+  return (
+    <YStack gap="$4" paddingBottom="$2">
+      <PeriodNavigator
+        periodLabel={controller.periodLabel}
+        onPreviousMonth={controller.goToPreviousMonth}
+        onNextMonth={controller.goToNextMonth}
+      />
+      <TxModeToggle value={controller.viewMode} onChange={controller.setViewMode} />
+      <YStack alignItems="flex-end">
+        <YStack flexDirection="row">
+          <ToolbarButton
+            icon="filter-variant"
+            accessibilityLabel="Filtros"
+            color={iconColor}
+            badgeColor={controller.hasActiveFilters ? badgeColor : undefined}
+            testID="transactions-filter-button"
+            onPress={onOpenFilters}
+          />
+          <ToolbarButton
+            icon="tray-arrow-up"
+            accessibilityLabel="Exportar"
+            color={iconColor}
+            testID="transactions-export-button"
+            onPress={onOpenExport}
+          />
+          <ToolbarButton
+            icon="trash-can-outline"
+            accessibilityLabel="Lixeira de transações"
+            color={iconColor}
+            testID="transactions-trash-button"
+            onPress={() => router.push(appRoutes.private.transactionsTrash)}
+          />
+        </YStack>
+      </YStack>
+      {importEnabled ? (
+        <AppButton
+          tone="secondary"
+          size="sm"
+          onPress={() => router.push(appRoutes.private.importTransactions)}
+        >
+          Importar planilha
+        </AppButton>
+      ) : null}
+      <InstallmentGroupFilterNotice controller={controller} />
+      {controller.viewMode === "analitico" ? (
+        <TxCategoryBreakdown categories={controller.categoryBars} />
+      ) : null}
+      <AiInsightSurface dimension="transactions" />
+    </YStack>
+  );
+}
+
+/** Props do cabeçalho do feed com os sheets de filtro/exportação. */
+export interface TransactionFeedToolbarProps {
+  readonly controller: TransactionsFeedController;
+  readonly filterOpen: boolean;
+  readonly setFilterOpen: (open: boolean) => void;
+  readonly exportOpen: boolean;
+  readonly setExportOpen: (open: boolean) => void;
+}
+
+/**
+ * Cabeçalho do feed + os sheets de filtro/exportação. Mantém o fluxo de
+ * exportação (CSV/PDF) e os controles de filtro existentes — só a fonte do
+ * controller mudou para o feed.
+ *
+ * @param props Controller do feed e o estado de abertura dos sheets.
+ * @returns Cabeçalho do feed com os modais.
+ */
+export function TransactionFeedToolbar({
+  controller,
+  filterOpen,
+  setFilterOpen,
+  exportOpen,
+  setExportOpen,
+}: TransactionFeedToolbarProps): ReactElement {
+  const { t } = useT();
+  const exportRunner = useTransactionsExport();
+
+  const handleExportFormat = useCallback(
+    async (format: "csv" | "pdf"): Promise<void> => {
+      await exportRunner.exportNow({ format });
+      setExportOpen(false);
+    },
+    [exportRunner, setExportOpen],
+  );
+
+  return (
+    <>
+      <FeedToolbar
+        controller={controller}
+        onOpenFilters={() => setFilterOpen(true)}
+        onOpenExport={() => setExportOpen(true)}
+      />
+      <FilterSheet
+        visible={filterOpen}
+        controller={controller}
+        onClose={() => setFilterOpen(false)}
+      />
+      <Modal
+        visible={exportOpen}
+        transparent
+        animationType="slide"
+        onRequestClose={() => setExportOpen(false)}
+      >
+        <ExportSheet
+          onClose={() => setExportOpen(false)}
+          onExport={handleExportFormat}
+          isExporting={exportRunner.isExporting}
+          error={exportRunner.error}
+          dismissError={exportRunner.dismissError}
+          translate={t}
+        />
+      </Modal>
+    </>
+  );
+}

--- a/features/transactions/components/transaction-screen-sheets.tsx
+++ b/features/transactions/components/transaction-screen-sheets.tsx
@@ -1,0 +1,163 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { TransactionBottomSheet } from "@/features/transactions/components/transaction-bottom-sheet";
+import { TransactionFilterControls } from "@/features/transactions/components/transaction-filters";
+import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import { AppButton } from "@/shared/components/app-button";
+import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+
+/** Props compartilhadas que recebem o controller do feed. */
+export interface FeedControllerProps {
+  readonly controller: TransactionsFeedController;
+}
+
+/** Props do bottom sheet de filtros. */
+export interface FilterSheetProps extends FeedControllerProps {
+  readonly visible: boolean;
+  readonly onClose: () => void;
+}
+
+/**
+ * Bottom sheet com os controles de filtro (tipo/status/tag) — reusa os
+ * controles existentes; só muda a fonte do controller (feed).
+ *
+ * @param props Visibilidade, controller e handler de fechar.
+ * @returns Sheet de filtros.
+ */
+export function FilterSheet({
+  visible,
+  controller,
+  onClose,
+}: FilterSheetProps): ReactElement {
+  return (
+    <TransactionBottomSheet
+      visible={visible}
+      onClose={onClose}
+      testID="transaction-filter-sheet"
+    >
+      <Paragraph fontFamily="$body" fontWeight="$7" fontSize="$5" color="$color">
+        Filtros
+      </Paragraph>
+      <TransactionFilterControls
+        typeFilter={controller.typeFilter}
+        onTypeFilterChange={controller.setTypeFilter}
+        statusFilter={controller.statusFilter}
+        onStatusFilterChange={controller.setStatusFilter}
+        tagFilter={controller.tagFilter}
+        onTagFilterChange={controller.setTagFilter}
+        onClearFilters={controller.clearFilters}
+      />
+      <AppButton onPress={onClose}>Aplicar</AppButton>
+    </TransactionBottomSheet>
+  );
+}
+
+/** Aviso de filtro por grupo de parcelas ("mesma compra"). */
+export function InstallmentGroupFilterNotice({
+  controller,
+}: FeedControllerProps): ReactElement | null {
+  if (!controller.installmentGroupFilter) {
+    return null;
+  }
+  return (
+    <XStack alignItems="center" gap="$2">
+      <Paragraph color="$muted" flex={1} fontFamily="$body" fontSize="$2">
+        Mostrando parcelas da mesma compra.
+      </Paragraph>
+      <AppButton
+        tone="secondary"
+        size="sm"
+        onPress={controller.handleClearInstallmentGroupFilter}
+      >
+        Mostrar todas
+      </AppButton>
+    </XStack>
+  );
+}
+
+/** Props do sheet de exportação. */
+export interface ExportSheetProps {
+  readonly onClose: () => void;
+  readonly onExport: (format: "csv" | "pdf") => Promise<void>;
+  readonly isExporting: boolean;
+  readonly error: unknown | null;
+  readonly dismissError: () => void;
+  readonly translate: (key: string) => string;
+}
+
+/**
+ * Sheet de exportação (CSV/PDF) — preserva o fluxo existente de export.
+ *
+ * @param props Handlers, estado de export e tradutor.
+ * @returns Sheet de exportação.
+ */
+export function ExportSheet({
+  onClose,
+  onExport,
+  isExporting,
+  error,
+  dismissError,
+  translate,
+}: ExportSheetProps): ReactElement {
+  return (
+    <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
+      <YStack
+        backgroundColor="$background"
+        padding="$4"
+        gap="$3"
+        borderTopLeftRadius="$3"
+        borderTopRightRadius="$3"
+      >
+        <AppSurfaceCard
+          title={translate("transactions.export.title")}
+          description={translate("transactions.export.description")}
+        >
+          <YStack gap="$3">
+            <XStack gap="$2">
+              <AppButton
+                flex={1}
+                onPress={() => {
+                  void onExport("csv");
+                }}
+                disabled={isExporting}
+              >
+                {translate("transactions.export.csv")}
+              </AppButton>
+              <AppButton
+                flex={1}
+                onPress={() => {
+                  void onExport("pdf");
+                }}
+                disabled={isExporting}
+              >
+                {translate("transactions.export.pdf")}
+              </AppButton>
+            </XStack>
+            {isExporting ? (
+              <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+                {translate("transactions.export.submitting")}
+              </Paragraph>
+            ) : null}
+            {error ? (
+              <AppErrorNotice
+                error={error}
+                fallbackTitle={translate("transactions.export.errorTitle")}
+                fallbackDescription={translate(
+                  "transactions.export.errorDescription",
+                )}
+                secondaryActionLabel="Fechar"
+                onSecondaryAction={dismissError}
+              />
+            ) : null}
+            <AppButton tone="secondary" onPress={onClose}>
+              Fechar
+            </AppButton>
+          </YStack>
+        </AppSurfaceCard>
+      </YStack>
+    </YStack>
+  );
+}

--- a/features/transactions/components/tx-card-body.tsx
+++ b/features/transactions/components/tx-card-body.tsx
@@ -1,0 +1,182 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Pressable } from "react-native";
+import { Paragraph, XStack, YStack, useTheme } from "tamagui";
+
+import type { TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+import { TxCategoryChip, TxStatusChip } from "@/features/transactions/components/tx-chips";
+import { AppMoneyText } from "@/shared/components/app-money-text";
+import { AppText } from "@/shared/components/app-text";
+import { colorPalette, iconSizes } from "@/shared/theme";
+
+/** Largura de cada ação revelada no swipe (px). */
+const ACTION_WIDTH = 84;
+/** Largura do trilho de cor da categoria na borda esquerda (px). */
+const RAIL_WIDTH = 4;
+
+/** Props de um botão de ação revelado ao arrastar o card. */
+export interface SwipeActionProps {
+  readonly label: string;
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly backgroundColor: string;
+  readonly accessibilityLabel: string;
+  readonly onPress: () => void;
+}
+
+/** Botão de ação revelado ao arrastar o card. */
+export function SwipeAction({
+  label,
+  icon,
+  backgroundColor,
+  accessibilityLabel,
+  onPress,
+}: SwipeActionProps): ReactElement {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      onPress={onPress}
+      style={{
+        width: ACTION_WIDTH,
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 4,
+        backgroundColor,
+      }}
+    >
+      <MaterialCommunityIcons name={icon} size={22} color={colorPalette.white} />
+      <Paragraph color={colorPalette.white} fontFamily="$body" fontSize="$2" fontWeight="$6">
+        {label}
+      </Paragraph>
+    </Pressable>
+  );
+}
+
+/** Rodapé extra do modo Analítico: categoria, pílulas e % do fluxo. */
+function AnalyticFooter({ item }: { readonly item: TransactionFeedItem }): ReactElement {
+  const flowLabel = item.type === "income" ? "do total" : "do gasto";
+  return (
+    <XStack alignItems="center" flexWrap="wrap" gap="$2" marginTop="$1">
+      <XStack alignItems="center" gap="$1">
+        <YStack width={8} height={8} borderRadius="$1" backgroundColor={item.categoryColor} />
+        <AppText size="caption" tone="muted" numberOfLines={1}>
+          {item.categoryName}
+        </AppText>
+      </XStack>
+      {item.isRecurring ? (
+        <Paragraph
+          fontFamily="$body"
+          fontWeight="$7"
+          fontSize="$1"
+          color="$primary"
+          backgroundColor="$primarySubtle"
+          paddingHorizontal="$2"
+          paddingVertical="$1"
+          borderRadius="$5"
+        >
+          Recorrente
+        </Paragraph>
+      ) : null}
+      {item.isInstallment ? (
+        <Paragraph
+          fontFamily="$body"
+          fontWeight="$7"
+          fontSize="$1"
+          color="$warning"
+          paddingHorizontal="$2"
+          paddingVertical="$1"
+          borderRadius="$5"
+          borderColor="$warning"
+          borderWidth={1}
+        >
+          Fixa
+        </Paragraph>
+      ) : null}
+      <AppText size="caption" tone="muted" marginLeft="auto">
+        {`${item.percentOfFlow}% ${flowLabel}`}
+      </AppText>
+    </XStack>
+  );
+}
+
+/** Props do conteúdo visível do card. */
+export interface TxCardBodyProps {
+  readonly item: TransactionFeedItem;
+  readonly analytic: boolean;
+}
+
+/**
+ * Conteúdo visível do card de transação: trilho de cor da categoria, chip de
+ * ícone, título + valor assinado (verde p/ receita, tinta p/ despesa),
+ * descrição (1 linha) e rodapé com status + data; no modo Analítico ganha o
+ * rodapé extra. Apresentacional — o swipe/press vive em `TxCard`.
+ *
+ * @param props Item do feed e flag de modo analítico.
+ * @returns Corpo do card.
+ */
+export function TxCardBody({ item, analytic }: TxCardBodyProps): ReactElement {
+  const theme = useTheme();
+  const mutedColor = theme.muted?.val ?? theme.color?.val ?? "#000000";
+  return (
+    <XStack
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$2"
+      padding="$3"
+      gap="$3"
+      overflow="hidden"
+    >
+      <YStack
+        position="absolute"
+        top={0}
+        left={0}
+        bottom={0}
+        width={RAIL_WIDTH}
+        backgroundColor={item.categoryColor}
+      />
+      <TxCategoryChip color={item.categoryColor} icon={item.categoryIcon} name={item.categoryName} />
+      <YStack flex={1} gap="$1">
+        <XStack alignItems="flex-start" justifyContent="space-between" gap="$2">
+          <Paragraph
+            flex={1}
+            numberOfLines={1}
+            color="$color"
+            fontFamily="$body"
+            fontWeight="$7"
+            fontSize="$4"
+          >
+            {item.title}
+          </Paragraph>
+          <AppMoneyText
+            fontSize="$4"
+            fontWeight="$7"
+            color={item.type === "income" ? "$success" : "$color"}
+          >
+            {item.signedDisplay}
+          </AppMoneyText>
+        </XStack>
+        {item.description ? (
+          <AppText size="bodySm" tone="muted" numberOfLines={1}>
+            {item.description}
+          </AppText>
+        ) : null}
+        <XStack alignItems="center" gap="$2" flexWrap="wrap">
+          <TxStatusChip status={item.status} type={item.type} />
+          <XStack alignItems="center" gap="$1">
+            <MaterialCommunityIcons
+              name="calendar-blank-outline"
+              size={iconSizes.xs}
+              color={mutedColor}
+            />
+            <AppText size="caption" tone="muted">
+              {item.dateDisplay}
+            </AppText>
+          </XStack>
+        </XStack>
+        {analytic ? <AnalyticFooter item={item} /> : null}
+      </YStack>
+    </XStack>
+  );
+}

--- a/features/transactions/components/tx-card.tsx
+++ b/features/transactions/components/tx-card.tsx
@@ -1,0 +1,104 @@
+import { memo, type ReactElement } from "react";
+
+import { Pressable, type AccessibilityActionEvent } from "react-native";
+import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
+import { XStack } from "tamagui";
+
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import { SwipeAction, TxCardBody } from "@/features/transactions/components/tx-card-body";
+import type { TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+import { darkSemanticColors, lightSemanticColors } from "@/shared/theme";
+
+/** Props do card de transação do feed. */
+export interface TxCardProps {
+  /** View-model do item do feed. */
+  readonly item: TransactionFeedItem;
+  /** True no modo Analítico (mostra rodapé extra). */
+  readonly analytic: boolean;
+  /** Abre o action sheet / detalhe ao tocar no card. */
+  readonly onPress: (id: string) => void;
+  /** Marca como pago (swipe / acessibilidade). */
+  readonly onMarkPaid: (id: string) => void;
+  /** Exclui (swipe / acessibilidade). */
+  readonly onDelete: (id: string) => void;
+}
+
+/**
+ * Card de transação do feed (variação "Feed" do design). Tocar abre o action
+ * sheet (ou edição) via `onPress`; arrastar para a esquerda revela
+ * Pagar/Excluir — preservando os fluxos existentes. As ações também ficam
+ * acessíveis ao leitor de tela via `accessibilityActions`. O visual do card
+ * vive em `TxCardBody`.
+ *
+ * @param props Item, modo analítico e handlers de tap/pagar/excluir.
+ * @returns Card swipeable e pressionável.
+ */
+function TxCardComponent({
+  item,
+  analytic,
+  onPress,
+  onMarkPaid,
+  onDelete,
+}: TxCardProps): ReactElement {
+  const isDark = useResolvedTheme() === "auraxis_dark";
+  const palette = isDark ? darkSemanticColors : lightSemanticColors;
+  const canPay = item.status !== "paid";
+
+  const handleAccessibilityAction = (event: AccessibilityActionEvent): void => {
+    if (event.nativeEvent.actionName === "pay") {
+      onMarkPaid(item.id);
+    } else if (event.nativeEvent.actionName === "delete") {
+      onDelete(item.id);
+    }
+  };
+
+  return (
+    <ReanimatedSwipeable
+      friction={1.6}
+      rightThreshold={40}
+      overshootRight={false}
+      renderRightActions={(_progress, _translation, methods) => (
+        <XStack>
+          {canPay ? (
+            <SwipeAction
+              label="Pagar"
+              icon="check"
+              backgroundColor={palette.success}
+              accessibilityLabel={`Pagar ${item.title}`}
+              onPress={() => {
+                methods.close();
+                onMarkPaid(item.id);
+              }}
+            />
+          ) : null}
+          <SwipeAction
+            label="Excluir"
+            icon="trash-can-outline"
+            backgroundColor={palette.danger}
+            accessibilityLabel={`Excluir ${item.title}`}
+            onPress={() => {
+              methods.close();
+              onDelete(item.id);
+            }}
+          />
+        </XStack>
+      )}
+    >
+      <Pressable
+        testID={`tx-card-${item.id}`}
+        accessibilityRole="button"
+        accessibilityLabel={`${item.title}, ${item.signedDisplay}, ${item.categoryName}. Toque para ações.`}
+        accessibilityActions={[
+          ...(canPay ? [{ name: "pay", label: "Pagar" }] : []),
+          { name: "delete", label: "Excluir" },
+        ]}
+        onAccessibilityAction={handleAccessibilityAction}
+        onPress={() => onPress(item.id)}
+      >
+        <TxCardBody item={item} analytic={analytic} />
+      </Pressable>
+    </ReanimatedSwipeable>
+  );
+}
+
+export const TxCard = memo(TxCardComponent);

--- a/features/transactions/components/tx-category-breakdown.tsx
+++ b/features/transactions/components/tx-category-breakdown.tsx
@@ -1,0 +1,56 @@
+import type { ReactElement } from "react";
+
+import { YStack } from "tamagui";
+
+import type { CategoryBar } from "@/features/transactions/model/transactions-feed";
+import { AppSectionHeader } from "@/shared/components/app-section-header";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import { AppText } from "@/shared/components/app-text";
+import { HBars, type HBarsDatum } from "@/shared/components/charts/h-bars";
+
+/** Quantidade máxima de categorias exibidas nas barras. */
+const MAX_BARS = 6;
+
+/** Props do card "Gastos por categoria" (modo Analítico). */
+export interface TxCategoryBreakdownProps {
+  /** Barras por categoria, já ordenadas por total desc (vêm do controller). */
+  readonly categories: readonly CategoryBar[];
+  readonly testID?: string;
+}
+
+const toDatum = (bar: CategoryBar): HBarsDatum => ({
+  id: bar.tagId ?? "uncategorized",
+  label: bar.name,
+  color: bar.color,
+  value: bar.total,
+});
+
+/**
+ * Card "Gastos por categoria" do modo Analítico: barras horizontais das maiores
+ * categorias de despesa (reusa o primitivo `HBars`). Mostra um aviso quando não
+ * há gastos categorizados. Apresentacional.
+ *
+ * @param props Barras por categoria.
+ * @returns Card com o breakdown de gastos.
+ */
+export function TxCategoryBreakdown({
+  categories,
+  testID,
+}: TxCategoryBreakdownProps): ReactElement {
+  const bars = categories.slice(0, MAX_BARS).map(toDatum);
+
+  return (
+    <AppSurfaceCard testID={testID ?? "tx-category-breakdown"}>
+      <YStack gap="$4">
+        <AppSectionHeader title="Gastos por categoria" />
+        {bars.length > 0 ? (
+          <HBars data={bars} />
+        ) : (
+          <AppText size="bodySm" tone="muted">
+            Sem gastos categorizados neste mês.
+          </AppText>
+        )}
+      </YStack>
+    </AppSurfaceCard>
+  );
+}

--- a/features/transactions/components/tx-chips.tsx
+++ b/features/transactions/components/tx-chips.tsx
@@ -1,0 +1,141 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, YStack, useTheme } from "tamagui";
+
+import type { TransactionType } from "@/features/transactions/contracts";
+import { resolveCategoryIcon } from "@/features/transactions/utils/category-icon";
+import {
+  formatStatusLabelForType,
+  statusVisual,
+  type StatusVisualTone,
+} from "@/features/transactions/utils/transaction-presentation";
+import { iconSizes } from "@/shared/theme";
+
+/** Fundo do chip de categoria como fração de opacidade da cor da categoria. */
+const CATEGORY_CHIP_BG_OPACITY = 0.13;
+
+/** Resolve a cor concreta de um tom de status a partir do tema atual. */
+const useStatusToneColor = (tone: StatusVisualTone): string => {
+  const theme = useTheme();
+  const fallback = theme.color?.val ?? "#000000";
+  const byTone: Record<StatusVisualTone, string | undefined> = {
+    success: theme.success?.val,
+    warning: theme.warning?.val,
+    danger: theme.danger?.val,
+    neutral: theme.muted?.val,
+  };
+  return byTone[tone] ?? fallback;
+};
+
+/** Props do chip de status do feed. */
+export interface TxStatusChipProps {
+  /** Estado cru da transação (inglês, vindo da API). */
+  readonly status: string;
+  /** Tipo da transação (define "Pago" vs "Recebido"). */
+  readonly type: TransactionType;
+}
+
+/**
+ * Chip de status (feed redesenhado): ícone + rótulo pt-BR sobre um fundo na cor
+ * semântica do estado (sucesso/atenção/perigo/neutro) com baixa opacidade. As
+ * cores vêm do tema resolvido — sem hex no `.tsx`.
+ *
+ * @param props Estado e tipo da transação.
+ * @returns Chip de status colorido.
+ */
+export function TxStatusChip({ status, type }: TxStatusChipProps): ReactElement {
+  const visual = statusVisual(status);
+  const toneColor = useStatusToneColor(visual.tone);
+  const label = formatStatusLabelForType(status, type);
+
+  return (
+    <XStack
+      alignItems="center"
+      gap="$1"
+      paddingHorizontal="$2"
+      paddingVertical="$1"
+      borderRadius="$5"
+      overflow="hidden"
+      testID={`tx-status-chip-${status}`}
+    >
+      <YStack
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        bottom={0}
+        backgroundColor={toneColor}
+        opacity={0.14}
+      />
+      <MaterialCommunityIcons
+        name={visual.icon as keyof typeof MaterialCommunityIcons.glyphMap}
+        size={iconSizes.xs}
+        color={toneColor}
+      />
+      <Paragraph fontFamily="$body" fontWeight="$7" fontSize="$1" color={toneColor}>
+        {label}
+      </Paragraph>
+    </XStack>
+  );
+}
+
+/** Props do chip de categoria (ícone sobre fundo colorido). */
+export interface TxCategoryChipProps {
+  /** Cor hexadecimal resolvida da categoria. */
+  readonly color: string;
+  /** Nome de ícone cru da Tag (ou null). */
+  readonly icon: string | null;
+  /** Nome da categoria (usado para inferir o ícone e a acessibilidade). */
+  readonly name: string;
+  /** Lado do chip em px (default 46, conforme o design). */
+  readonly size?: number;
+}
+
+/** Lado padrão do chip de categoria (design). */
+const DEFAULT_CHIP_SIZE = 46;
+
+/**
+ * Chip arredondado da categoria: um quadrado na cor da categoria com baixa
+ * opacidade, com o ícone da categoria centralizado em cor cheia por cima
+ * (padrão de "cor + alpha" dos Cartões, sem computar rgba). Geometria em px é
+ * permitida pela governança (não é token de estilo de tema).
+ *
+ * @param props Cor, ícone, nome e tamanho do chip.
+ * @returns Chip de ícone da categoria.
+ */
+export function TxCategoryChip({
+  color,
+  icon,
+  name,
+  size = DEFAULT_CHIP_SIZE,
+}: TxCategoryChipProps): ReactElement {
+  const glyph = resolveCategoryIcon(icon, name);
+  return (
+    <YStack
+      width={size}
+      height={size}
+      borderRadius="$2"
+      alignItems="center"
+      justifyContent="center"
+      accessibilityElementsHidden
+      importantForAccessibility="no-hide-descendants"
+    >
+      <YStack
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        bottom={0}
+        borderRadius="$2"
+        backgroundColor={color}
+        opacity={CATEGORY_CHIP_BG_OPACITY}
+      />
+      <MaterialCommunityIcons
+        name={glyph as keyof typeof MaterialCommunityIcons.glyphMap}
+        size={size * 0.46}
+        color={color}
+      />
+    </YStack>
+  );
+}

--- a/features/transactions/components/tx-components.test.tsx
+++ b/features/transactions/components/tx-components.test.tsx
@@ -1,0 +1,199 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { TestProviders } from "@/shared/testing/test-providers";
+
+import { TxCard } from "@/features/transactions/components/tx-card";
+import { TxCategoryBreakdown } from "@/features/transactions/components/tx-category-breakdown";
+import { TxHero } from "@/features/transactions/components/tx-hero";
+import { TxModeToggle } from "@/features/transactions/components/tx-mode-toggle";
+import { TxCategoryChip, TxStatusChip } from "@/features/transactions/components/tx-chips";
+import type { CategoryBar, TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+
+// Mocka o ReanimatedSwipeable: renderiza as right actions + os children, para
+// exercitar tap/Pagar/Excluir sem o wrapper nativo (mesmo padrão do row).
+jest.mock("react-native-gesture-handler/ReanimatedSwipeable", () => {
+  const ReactInner = require("react");
+  const { View } = require("react-native");
+  const Swipeable = ({
+    children,
+    renderRightActions,
+  }: {
+    readonly children: React.ReactNode;
+    readonly renderRightActions?: (
+      progress: unknown,
+      translation: unknown,
+      methods: { close: () => void },
+    ) => React.ReactNode;
+  }): React.ReactNode =>
+    ReactInner.createElement(
+      View,
+      null,
+      renderRightActions
+        ? renderRightActions({ value: 0 }, { value: 0 }, { close: () => undefined })
+        : null,
+      children,
+    );
+  return { __esModule: true, default: Swipeable };
+});
+
+const wrap = (node: React.ReactElement) =>
+  render(<TestProviders>{node}</TestProviders>);
+
+const kpis = { income: 27675.37, expense: 19906.3, result: 7769.07, count: 10 };
+
+const item: TransactionFeedItem = {
+  id: "tx-1",
+  title: "Impostos",
+  description: "Impostos do salário gringo",
+  amount: 2000,
+  type: "expense",
+  status: "pending",
+  isRecurring: true,
+  isInstallment: false,
+  categoryName: "Impostos",
+  categoryColor: "#E5484D",
+  categoryIcon: "tax",
+  relativeDate: "em 9 dias",
+  dateDisplay: "em 9 dias",
+  signedDisplay: "− R$ 2.000,00",
+  percentOfFlow: 10,
+};
+
+const incomeItem: TransactionFeedItem = {
+  ...item,
+  id: "tx-2",
+  title: "Salário gringo",
+  type: "income",
+  status: "paid",
+  signedDisplay: "+ R$ 27.675,37",
+  categoryColor: "#11A36B",
+  percentOfFlow: 100,
+};
+
+const bars: readonly CategoryBar[] = [
+  { tagId: "t1", name: "Cartão", color: "#FF8A3D", total: 11000 },
+  { tagId: "t2", name: "Financiamento", color: "#0E6376", total: 2650 },
+];
+
+describe("TxHero", () => {
+  it("mostra título, período + contagem e o resultado", () => {
+    const { getByText, getByTestId } = wrap(
+      <TxHero
+        periodLabel="Junho de 2026"
+        kpis={kpis}
+        isDark={false}
+        onToggleTheme={jest.fn()}
+        onToggleCalendar={jest.fn()}
+        calendarActive={false}
+      />,
+    );
+    expect(getByText("Transações")).toBeTruthy();
+    expect(getByText("Junho de 2026 · 10 lançamentos")).toBeTruthy();
+    expect(getByTestId("tx-hero-result")).toBeTruthy();
+  });
+
+  it("dispara os toggles de tema e calendário", () => {
+    const onToggleTheme = jest.fn();
+    const onToggleCalendar = jest.fn();
+    const { getByTestId } = wrap(
+      <TxHero
+        periodLabel="Junho de 2026"
+        kpis={kpis}
+        isDark={false}
+        onToggleTheme={onToggleTheme}
+        onToggleCalendar={onToggleCalendar}
+        calendarActive={false}
+      />,
+    );
+    fireEvent.press(getByTestId("tx-hero-theme-toggle"));
+    fireEvent.press(getByTestId("tx-hero-calendar-toggle"));
+    expect(onToggleTheme).toHaveBeenCalled();
+    expect(onToggleCalendar).toHaveBeenCalled();
+  });
+});
+
+describe("TxModeToggle", () => {
+  it("dispara onChange ao tocar em Analítico", () => {
+    const onChange = jest.fn();
+    const { getByTestId } = wrap(
+      <TxModeToggle value="facil" onChange={onChange} />,
+    );
+    fireEvent.press(getByTestId("tx-mode-toggle-analitico"));
+    expect(onChange).toHaveBeenCalledWith("analitico");
+  });
+});
+
+describe("TxCard", () => {
+  it("renderiza título, valor e abre ações ao tocar", () => {
+    const onPress = jest.fn();
+    const { getByText, getByTestId } = wrap(
+      <TxCard
+        item={item}
+        analytic={false}
+        onPress={onPress}
+        onMarkPaid={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(getByText("Impostos")).toBeTruthy();
+    expect(getByText("− R$ 2.000,00")).toBeTruthy();
+    fireEvent.press(getByTestId("tx-card-tx-1"));
+    expect(onPress).toHaveBeenCalledWith("tx-1");
+  });
+
+  it("no modo Analítico mostra categoria e % do gasto", () => {
+    const { getByText } = wrap(
+      <TxCard
+        item={item}
+        analytic
+        onPress={jest.fn()}
+        onMarkPaid={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(getByText("Recorrente")).toBeTruthy();
+    expect(getByText("10% do gasto")).toBeTruthy();
+  });
+
+  it("receita paga mostra 'Recebido' e % do total", () => {
+    const { getByText } = wrap(
+      <TxCard
+        item={incomeItem}
+        analytic
+        onPress={jest.fn()}
+        onMarkPaid={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(getByText("Recebido")).toBeTruthy();
+    expect(getByText("100% do total")).toBeTruthy();
+  });
+});
+
+describe("TxCategoryBreakdown", () => {
+  it("renderiza o título e as categorias", () => {
+    const { getByText } = wrap(<TxCategoryBreakdown categories={bars} />);
+    expect(getByText("Gastos por categoria")).toBeTruthy();
+    expect(getByText("Cartão")).toBeTruthy();
+  });
+
+  it("mostra aviso quando não há categorias", () => {
+    const { getByText } = wrap(<TxCategoryBreakdown categories={[]} />);
+    expect(getByText("Sem gastos categorizados neste mês.")).toBeTruthy();
+  });
+});
+
+describe("tx-chips", () => {
+  it("TxStatusChip mostra o rótulo do status", () => {
+    const { getByText } = wrap(<TxStatusChip status="overdue" type="expense" />);
+    expect(getByText("Vencido")).toBeTruthy();
+  });
+
+  it("TxCategoryChip renderiza sem erro", () => {
+    const { toJSON } = wrap(
+      <TxCategoryChip color="#E5484D" icon="tax" name="Impostos" />,
+    );
+    expect(toJSON()).toBeTruthy();
+  });
+});

--- a/features/transactions/components/tx-hero.tsx
+++ b/features/transactions/components/tx-hero.tsx
@@ -1,0 +1,199 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import { AppGradient } from "@/shared/components/app-gradient";
+import { AppMoneyText } from "@/shared/components/app-money-text";
+import type { FeedKpis } from "@/features/transactions/model/transactions-feed";
+import {
+  darkSemanticGradients,
+  iconSizes,
+  lightSemanticGradients,
+  onDarkSurfaceColors,
+} from "@/shared/theme";
+import {
+  formatCurrencyShort,
+  formatCurrencySigned,
+} from "@/shared/utils/formatters";
+
+/** Props do herói teal da tela de Transações. */
+export interface TxHeroProps {
+  /** Rótulo do período (ex.: "Junho de 2026"). */
+  readonly periodLabel: string;
+  /** KPIs agregados do período (receitas, despesas, resultado, contagem). */
+  readonly kpis: FeedKpis;
+  /** True quando o tema resolvido é escuro (controla o ícone do botão). */
+  readonly isDark: boolean;
+  /** Alterna o tema claro/escuro. */
+  readonly onToggleTheme: () => void;
+  /** Alterna entre lista e calendário. */
+  readonly onToggleCalendar: () => void;
+  /** True quando a visão de calendário está ativa (controla ícone/label). */
+  readonly calendarActive: boolean;
+}
+
+interface HeroRoundButtonProps {
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly accessibilityLabel: string;
+  readonly onPress: () => void;
+  readonly testID?: string;
+}
+
+/** Botão redondo translúcido (44×44) sobre o hero. */
+function HeroRoundButton({
+  icon,
+  accessibilityLabel,
+  onPress,
+  testID,
+}: HeroRoundButtonProps): ReactElement {
+  return (
+    <YStack
+      width={44}
+      height={44}
+      borderRadius="$5"
+      alignItems="center"
+      justifyContent="center"
+      backgroundColor={onDarkSurfaceColors.controlBackground}
+      pressStyle={{
+        backgroundColor: onDarkSurfaceColors.controlBackgroundPressed,
+      }}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+      onPress={onPress}
+    >
+      <MaterialCommunityIcons
+        name={icon}
+        size={iconSizes.md}
+        color={onDarkSurfaceColors.text}
+      />
+    </YStack>
+  );
+}
+
+interface FlowShortProps {
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly color: string;
+  readonly value: string;
+}
+
+/** Linha curta de fluxo (↑ receitas / ↓ despesas) no canto do hero. */
+function FlowShort({ icon, color, value }: FlowShortProps): ReactElement {
+  return (
+    <XStack alignItems="center" gap="$1" justifyContent="flex-end">
+      <MaterialCommunityIcons name={icon} size={iconSizes.xs} color={color} />
+      <AppMoneyText fontSize="$3" color={color}>
+        {value}
+      </AppMoneyText>
+    </XStack>
+  );
+}
+
+/** Linha do RESULTADO (mono assinado) + fluxos curtos (↑ receitas / ↓ despesas). */
+function HeroResultRow({ kpis }: { readonly kpis: FeedKpis }): ReactElement {
+  const resultColor =
+    kpis.result >= 0 ? onDarkSurfaceColors.positive : onDarkSurfaceColors.negative;
+  return (
+    <XStack alignItems="flex-end" justifyContent="space-between" gap="$3">
+      <YStack flex={1} gap="$1">
+        <Paragraph
+          fontFamily="$body"
+          fontWeight="$7"
+          fontSize="$1"
+          letterSpacing={1}
+          color={onDarkSurfaceColors.textSubtle}
+        >
+          RESULTADO
+        </Paragraph>
+        <AppMoneyText
+          fontSize="$9"
+          fontWeight="$7"
+          color={resultColor}
+          testID="tx-hero-result"
+        >
+          {formatCurrencySigned(kpis.result)}
+        </AppMoneyText>
+      </YStack>
+      <YStack gap="$1">
+        <FlowShort
+          icon="arrow-up"
+          color={onDarkSurfaceColors.positive}
+          value={formatCurrencyShort(kpis.income)}
+        />
+        <FlowShort
+          icon="arrow-down"
+          color={onDarkSurfaceColors.negative}
+          value={formatCurrencyShort(kpis.expense)}
+        />
+      </YStack>
+    </XStack>
+  );
+}
+
+/**
+ * Herói teal da tela de Transações: título, período + nº de lançamentos,
+ * RESULTADO (mono assinado, verde/vermelho) e, à direita, os fluxos curtos
+ * (↑ receitas / ↓ despesas). Inclui os botões de alternar tema e calendário.
+ * O gradiente segue o tema resolvido (mesmo padrão dos Cartões).
+ *
+ * @param props Período, KPIs, estado de tema/calendário e handlers.
+ * @returns Cabeçalho em gradiente.
+ */
+export function TxHero({
+  periodLabel,
+  kpis,
+  isDark,
+  onToggleTheme,
+  onToggleCalendar,
+  calendarActive,
+}: TxHeroProps): ReactElement {
+  const resolvedTheme = useResolvedTheme();
+  const heroGradient =
+    resolvedTheme === "auraxis_dark"
+      ? darkSemanticGradients.hero
+      : lightSemanticGradients.hero;
+  const subtitle = `${periodLabel} · ${kpis.count} lançamentos`;
+
+  return (
+    <AppGradient gradient={heroGradient} borderRadius="$3" testID="tx-hero">
+      <YStack padding="$5" gap="$4">
+        <XStack justifyContent="space-between" alignItems="flex-start" gap="$3">
+          <YStack flex={1} gap="$1">
+            <Paragraph
+              fontFamily="$heading"
+              fontWeight="$7"
+              fontSize="$8"
+              color={onDarkSurfaceColors.text}
+            >
+              Transações
+            </Paragraph>
+            <Paragraph
+              fontFamily="$body"
+              fontSize="$3"
+              color={onDarkSurfaceColors.textMuted}
+            >
+              {subtitle}
+            </Paragraph>
+          </YStack>
+          <XStack gap="$2">
+            <HeroRoundButton
+              icon={calendarActive ? "format-list-bulleted" : "calendar-month-outline"}
+              accessibilityLabel={calendarActive ? "Ver lista" : "Ver calendário"}
+              testID="tx-hero-calendar-toggle"
+              onPress={onToggleCalendar}
+            />
+            <HeroRoundButton
+              icon={isDark ? "white-balance-sunny" : "weather-night"}
+              accessibilityLabel="Alternar tema"
+              testID="tx-hero-theme-toggle"
+              onPress={onToggleTheme}
+            />
+          </XStack>
+        </XStack>
+        <HeroResultRow kpis={kpis} />
+      </YStack>
+    </AppGradient>
+  );
+}

--- a/features/transactions/components/tx-mode-toggle.tsx
+++ b/features/transactions/components/tx-mode-toggle.tsx
@@ -1,0 +1,98 @@
+import type { ReactElement } from "react";
+
+import { MaterialCommunityIcons } from "@expo/vector-icons";
+import { Paragraph, XStack, useTheme } from "tamagui";
+
+import { borderWidths } from "@/config/design-tokens";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
+import { iconSizes } from "@/shared/theme";
+import type { TransactionsFeedViewMode } from "@/features/transactions/hooks/use-transactions-feed-controller";
+
+/** Props do segmented "Fácil | Analítico". */
+export interface TxModeToggleProps {
+  /** Modo de visualização ativo. */
+  readonly value: TransactionsFeedViewMode;
+  /** Troca o modo de visualização ativo. */
+  readonly onChange: (value: TransactionsFeedViewMode) => void;
+  readonly testID?: string;
+}
+
+interface SegmentDef {
+  readonly value: TransactionsFeedViewMode;
+  readonly label: string;
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+}
+
+const SEGMENTS: readonly SegmentDef[] = [
+  { value: "facil", label: "Fácil", icon: "layers-outline" },
+  { value: "analitico", label: "Analítico", icon: "chart-bar" },
+];
+
+/**
+ * Segmented control de duas opções (Fácil / Analítico) num trilho arredondado.
+ * O segmento ativo ganha superfície de card + cor primária; o inativo fica
+ * neutro. Apresentacional — estado e troca vêm via props. Espelha o padrão do
+ * segmented dos Cartões.
+ *
+ * @param props Modo ativo e handler de troca.
+ * @returns Segmented control selecionável.
+ */
+export function TxModeToggle({
+  value,
+  onChange,
+  testID,
+}: TxModeToggleProps): ReactElement {
+  const theme = useTheme();
+  const activeIconColor = theme.primary?.val ?? theme.color?.val ?? "#000000";
+  const inactiveIconColor = theme.muted?.val ?? theme.color?.val ?? "#000000";
+  return (
+    <XStack
+      backgroundColor="$surfaceRaised"
+      borderRadius="$2"
+      borderWidth={borderWidths.hairline}
+      borderColor="$borderColor"
+      padding="$1"
+      gap="$1"
+      testID={testID ?? "tx-mode-toggle"}
+    >
+      {SEGMENTS.map((segment) => {
+        const isActive = segment.value === value;
+        return (
+          <XStack
+            key={segment.value}
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+            gap="$2"
+            paddingVertical="$3"
+            borderRadius="$1"
+            backgroundColor={isActive ? "$surfaceCard" : "transparent"}
+            accessibilityRole="button"
+            accessibilityState={{ selected: isActive }}
+            accessibilityLabel={segment.label}
+            testID={`tx-mode-toggle-${segment.value}`}
+            pressStyle={{ opacity: 0.85 }}
+            onPress={() => {
+              triggerHapticImpact("light");
+              onChange(segment.value);
+            }}
+          >
+            <MaterialCommunityIcons
+              name={segment.icon}
+              size={iconSizes.sm}
+              color={isActive ? activeIconColor : inactiveIconColor}
+            />
+            <Paragraph
+              fontFamily="$body"
+              fontSize="$4"
+              fontWeight={isActive ? "$7" : "$5"}
+              color={isActive ? "$primary" : "$muted"}
+            >
+              {segment.label}
+            </Paragraph>
+          </XStack>
+        );
+      })}
+    </XStack>
+  );
+}

--- a/features/transactions/hooks/use-transaction-feed-actions.test.ts
+++ b/features/transactions/hooks/use-transaction-feed-actions.test.ts
@@ -1,0 +1,92 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import { useTransactionFeedActions } from "@/features/transactions/hooks/use-transaction-feed-actions";
+import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+
+const vm = (overrides: Partial<TransactionViewModel> = {}): TransactionViewModel => ({
+  id: "tx-1",
+  title: "Impostos",
+  amount: "2000.00",
+  type: "expense",
+  dueDate: "2026-06-29",
+  status: "pending",
+  description: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  installmentGroupId: null,
+  installmentNumber: null,
+  ...overrides,
+});
+
+const mockHandleOpenEdit = jest.fn();
+const mockHandleDuplicate = jest.fn();
+const mockHandleShowGroup = jest.fn();
+
+const buildController = (
+  overrides: Partial<TransactionsFeedController> = {},
+): TransactionsFeedController =>
+  ({
+    transactions: [vm()],
+    transactionsQuery: { data: { transactions: [{ ...vm(), tagId: null }] } },
+    payingTransactionId: null,
+    duplicatingTransactionId: null,
+    deletingTransactionId: null,
+    handleOpenEdit: mockHandleOpenEdit,
+    handleDuplicate: mockHandleDuplicate,
+    handleShowInstallmentGroup: mockHandleShowGroup,
+    ...overrides,
+  }) as unknown as TransactionsFeedController;
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("useTransactionFeedActions", () => {
+  it("abre e fecha o action sheet pelo id", () => {
+    const { result } = renderHook(() => useTransactionFeedActions(buildController()));
+    expect(result.current.actionTarget).toBeNull();
+    act(() => result.current.handlers.openActions("tx-1"));
+    expect(result.current.actionTarget?.id).toBe("tx-1");
+    act(() => result.current.closeActions());
+    expect(result.current.actionTarget).toBeNull();
+  });
+
+  it("requestPay define o alvo de pagamento e fecha o sheet", () => {
+    const { result } = renderHook(() => useTransactionFeedActions(buildController()));
+    act(() => result.current.handlers.openActions("tx-1"));
+    act(() => result.current.handlers.requestPay("tx-1"));
+    expect(result.current.actionTarget).toBeNull();
+    expect(result.current.payTarget).toEqual({ id: "tx-1", title: "Impostos" });
+  });
+
+  it("requestDelete marca série quando recorrente/parcelada", () => {
+    const controller = buildController({
+      transactions: [vm({ isInstallment: true })],
+    });
+    const { result } = renderHook(() => useTransactionFeedActions(controller));
+    act(() => result.current.handlers.requestDelete("tx-1"));
+    expect(result.current.deleteTarget?.isSeries).toBe(true);
+  });
+
+  it("handleEdit delega para o controller com o registro cru", () => {
+    const { result } = renderHook(() => useTransactionFeedActions(buildController()));
+    act(() => result.current.handleEdit("tx-1"));
+    expect(mockHandleOpenEdit).toHaveBeenCalled();
+  });
+
+  it("handleDuplicate e handleShowInstallmentGroup delegam ao controller", () => {
+    const { result } = renderHook(() => useTransactionFeedActions(buildController()));
+    act(() => result.current.handleDuplicate("tx-1"));
+    act(() => result.current.handleShowInstallmentGroup("grp-1"));
+    expect(mockHandleDuplicate).toHaveBeenCalledWith("tx-1");
+    expect(mockHandleShowGroup).toHaveBeenCalledWith("grp-1");
+  });
+
+  it("ignora ids inexistentes sem definir alvos", () => {
+    const { result } = renderHook(() => useTransactionFeedActions(buildController()));
+    act(() => result.current.handlers.openActions("nope"));
+    act(() => result.current.handlers.requestPay("nope"));
+    expect(result.current.actionTarget).toBeNull();
+    expect(result.current.payTarget).toBeNull();
+  });
+});

--- a/features/transactions/hooks/use-transaction-feed-actions.ts
+++ b/features/transactions/hooks/use-transaction-feed-actions.ts
@@ -1,0 +1,149 @@
+import { useCallback, useMemo, useState } from "react";
+
+import type {
+  DeleteTarget,
+  MarkPaidTarget,
+} from "@/features/transactions/components/transaction-action-modals";
+import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+
+/** Handlers de ação por id passados aos cards do feed. */
+export interface FeedItemActionHandlers {
+  /** Abre o action sheet do item. */
+  readonly openActions: (id: string) => void;
+  /** Solicita confirmação de pagamento do item. */
+  readonly requestPay: (id: string) => void;
+  /** Solicita confirmação de exclusão do item. */
+  readonly requestDelete: (id: string) => void;
+}
+
+/** Estado + handlers das ações do feed (action sheet e modais). */
+export interface TransactionFeedActions {
+  /** Transação ativa no action sheet (ou null). */
+  readonly actionTarget: TransactionViewModel | null;
+  /** Alvo do modal de "marcar como pago" (ou null). */
+  readonly payTarget: MarkPaidTarget | null;
+  /** Alvo do modal de exclusão (ou null). */
+  readonly deleteTarget: DeleteTarget | null;
+  /** Handlers por id passados aos cards. */
+  readonly handlers: FeedItemActionHandlers;
+  /** Fecha o action sheet. */
+  readonly closeActions: () => void;
+  /** Abre o form de edição do item. */
+  readonly handleEdit: (id: string) => void;
+  /** Duplica o item. */
+  readonly handleDuplicate: (id: string) => void;
+  /** Aplica o filtro de "mesma compra" (grupo de parcelas). */
+  readonly handleShowInstallmentGroup: (installmentGroupId: string) => void;
+  /** Fecha o modal de pagamento. */
+  readonly closePay: () => void;
+  /** Fecha o modal de exclusão. */
+  readonly closeDelete: () => void;
+}
+
+/**
+ * Concentra o estado e os handlers das ações do feed de transações (abrir o
+ * action sheet, pagar, editar, duplicar, excluir e ver parcelas), delegando as
+ * mutações para o controller. Mantém o componente do feed enxuto e a lógica
+ * testável fora da árvore de UI.
+ *
+ * @param controller Controller do feed.
+ * @returns Estado dos alvos + handlers das ações.
+ */
+// eslint-disable-next-line max-lines-per-function -- agregador de ~10 handlers/estados de ação
+export function useTransactionFeedActions(
+  controller: TransactionsFeedController,
+): TransactionFeedActions {
+  const [actionTarget, setActionTarget] = useState<TransactionViewModel | null>(null);
+  const [payTarget, setPayTarget] = useState<MarkPaidTarget | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+
+  const findViewModel = useCallback(
+    (id: string): TransactionViewModel | null =>
+      controller.transactions.find((tx) => tx.id === id) ?? null,
+    [controller.transactions],
+  );
+
+  const openActions = useCallback(
+    (id: string): void => {
+      const vm = findViewModel(id);
+      if (vm) {
+        setActionTarget(vm);
+      }
+    },
+    [findViewModel],
+  );
+
+  const requestPay = useCallback(
+    (id: string): void => {
+      const vm = findViewModel(id);
+      if (vm) {
+        setActionTarget(null);
+        setPayTarget({ id: vm.id, title: vm.title });
+      }
+    },
+    [findViewModel],
+  );
+
+  const requestDelete = useCallback(
+    (id: string): void => {
+      const vm = findViewModel(id);
+      if (vm) {
+        setActionTarget(null);
+        setDeleteTarget({
+          id: vm.id,
+          title: vm.title,
+          isSeries: vm.isRecurring || vm.isInstallment,
+        });
+      }
+    },
+    [findViewModel],
+  );
+
+  const handleEdit = useCallback(
+    (id: string): void => {
+      const record = controller.transactionsQuery.data?.transactions.find(
+        (tx) => tx.id === id,
+      );
+      if (record) {
+        setActionTarget(null);
+        controller.handleOpenEdit(record);
+      }
+    },
+    [controller],
+  );
+
+  const handleDuplicate = useCallback(
+    (id: string): void => {
+      setActionTarget(null);
+      void controller.handleDuplicate(id);
+    },
+    [controller],
+  );
+
+  const handleShowInstallmentGroup = useCallback(
+    (installmentGroupId: string): void => {
+      setActionTarget(null);
+      controller.handleShowInstallmentGroup(installmentGroupId);
+    },
+    [controller],
+  );
+
+  const handlers = useMemo<FeedItemActionHandlers>(
+    () => ({ openActions, requestPay, requestDelete }),
+    [openActions, requestPay, requestDelete],
+  );
+
+  return {
+    actionTarget,
+    payTarget,
+    deleteTarget,
+    handlers,
+    closeActions: () => setActionTarget(null),
+    handleEdit,
+    handleDuplicate,
+    handleShowInstallmentGroup,
+    closePay: () => setPayTarget(null),
+    closeDelete: () => setDeleteTarget(null),
+  };
+}

--- a/features/transactions/hooks/use-transactions-feed-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-feed-controller.test.ts
@@ -1,0 +1,176 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import { useTransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import {
+  useCreateTransactionMutation,
+  useDeleteTransactionMutation,
+  useMarkTransactionPaidMutation,
+  useUpdateTransactionMutation,
+} from "@/features/transactions/hooks/use-transaction-mutations";
+import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
+import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
+
+jest.mock("@/features/transactions/hooks/use-transactions-query", () => ({
+  useTransactionsQuery: jest.fn(),
+}));
+jest.mock("@/features/transactions/hooks/use-transaction-mutations", () => ({
+  useCreateTransactionMutation: jest.fn(),
+  useUpdateTransactionMutation: jest.fn(),
+  useDeleteTransactionMutation: jest.fn(),
+  useMarkTransactionPaidMutation: jest.fn(),
+}));
+jest.mock("@/features/tags/hooks/use-tags-query", () => ({
+  useTagsQuery: jest.fn(),
+}));
+
+const mockedUseQuery = jest.mocked(useTransactionsQuery);
+const mockedUseTagsQuery = jest.mocked(useTagsQuery);
+const mockedUseCreate = jest.mocked(useCreateTransactionMutation);
+const mockedUseUpdate = jest.mocked(useUpdateTransactionMutation);
+const mockedUseDelete = jest.mocked(useDeleteTransactionMutation);
+const mockedUseMarkPaid = jest.mocked(useMarkTransactionPaidMutation);
+
+const buildMutationStub = () => ({
+  mutateAsync: jest.fn().mockResolvedValue(undefined),
+  reset: jest.fn(),
+  isPending: false,
+  error: null,
+});
+
+const buildRecord = (
+  override: Partial<TransactionRecord> = {},
+): TransactionRecord => ({
+  id: "tx-1",
+  title: "Salário",
+  amount: "8200.00",
+  type: "income",
+  dueDate: "2026-06-20",
+  startDate: null,
+  endDate: null,
+  description: null,
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: null,
+  accountId: null,
+  creditCardId: null,
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: null,
+  updatedAt: null,
+  ...override,
+});
+
+const setQuery = (transactions: readonly TransactionRecord[]): void => {
+  mockedUseQuery.mockReturnValue({
+    data: {
+      transactions,
+      pagination: { total: transactions.length, page: 1, perPage: 50 },
+    },
+  } as never);
+};
+
+beforeAll(() => {
+  jest.useFakeTimers({ doNotFake: ["queueMicrotask"] });
+  jest.setSystemTime(new Date("2026-06-20T12:00:00"));
+});
+afterAll(() => jest.useRealTimers());
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedUseCreate.mockReturnValue(buildMutationStub() as never);
+  mockedUseUpdate.mockReturnValue(buildMutationStub() as never);
+  mockedUseDelete.mockReturnValue(buildMutationStub() as never);
+  mockedUseMarkPaid.mockReturnValue(buildMutationStub() as never);
+  mockedUseTagsQuery.mockReturnValue({
+    data: {
+      tags: [{ id: "tag-1", name: "Alimentação", color: "#11A36B", icon: "cart" }],
+    },
+  } as never);
+  setQuery([
+    buildRecord(),
+    buildRecord({
+      id: "tx-2",
+      title: "Mercado",
+      type: "expense",
+      amount: "300.00",
+      tagId: "tag-1",
+      dueDate: "2026-06-19",
+    }),
+  ]);
+});
+
+describe("useTransactionsFeedController — modo de visualização", () => {
+  it("inicia no modo 'facil'", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    expect(result.current.viewMode).toBe("facil");
+  });
+
+  it("alterna para 'analitico' via setViewMode", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    act(() => result.current.setViewMode("analitico"));
+    expect(result.current.viewMode).toBe("analitico");
+  });
+});
+
+describe("useTransactionsFeedController — view-models derivados", () => {
+  it("expõe heroKpis calculados a partir dos registros crus", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    expect(result.current.heroKpis.income).toBeCloseTo(8200);
+    expect(result.current.heroKpis.expense).toBeCloseTo(300);
+    expect(result.current.heroKpis.result).toBeCloseTo(7900);
+    expect(result.current.heroKpis.count).toBe(2);
+  });
+
+  it("expõe categoryBars apenas com despesas", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    expect(result.current.categoryBars).toHaveLength(1);
+    expect(result.current.categoryBars[0]?.name).toBe("Alimentação");
+    expect(result.current.categoryBars[0]?.total).toBeCloseTo(300);
+  });
+
+  it("expõe feedItems com rótulo relativo e sinal", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    const items = result.current.feedItems;
+    expect(items).toHaveLength(2);
+    const income = items.find((item) => item.id === "tx-1");
+    const expense = items.find((item) => item.id === "tx-2");
+    expect(income?.relativeDate).toBe("Hoje");
+    expect(income?.signedDisplay.startsWith("+")).toBe(true);
+    expect(expense?.relativeDate).toBe("Ontem");
+    expect(expense?.signedDisplay.startsWith("−")).toBe(true);
+    expect(expense?.categoryName).toBe("Alimentação");
+  });
+
+  it("preserva a interface do controller existente (passthrough)", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    expect(typeof result.current.goToPreviousMonth).toBe("function");
+    expect(typeof result.current.setTypeFilter).toBe("function");
+    expect(result.current.total).toBe(2);
+    // monthBalance vem do controller base e bate com o resultado dos KPIs.
+    expect(result.current.monthBalance).toBeCloseTo(result.current.heroKpis.result);
+  });
+
+  it("lida com ausência de dados retornando coleções vazias e KPIs zerados", () => {
+    mockedUseQuery.mockReturnValue({ data: undefined } as never);
+    mockedUseTagsQuery.mockReturnValue({ data: undefined } as never);
+    const { result } = renderHook(() => useTransactionsFeedController());
+    expect(result.current.feedItems).toEqual([]);
+    expect(result.current.categoryBars).toEqual([]);
+    expect(result.current.heroKpis).toEqual({
+      income: 0,
+      expense: 0,
+      result: 0,
+      count: 0,
+    });
+  });
+});

--- a/features/transactions/hooks/use-transactions-feed-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-feed-controller.test.ts
@@ -120,6 +120,15 @@ describe("useTransactionsFeedController — modo de visualização", () => {
     act(() => result.current.setViewMode("analitico"));
     expect(result.current.viewMode).toBe("analitico");
   });
+
+  it("inicia com o calendário inativo e alterna via toggleCalendar", () => {
+    const { result } = renderHook(() => useTransactionsFeedController());
+    expect(result.current.calendarActive).toBe(false);
+    act(() => result.current.toggleCalendar());
+    expect(result.current.calendarActive).toBe(true);
+    act(() => result.current.toggleCalendar());
+    expect(result.current.calendarActive).toBe(false);
+  });
 });
 
 describe("useTransactionsFeedController — view-models derivados", () => {

--- a/features/transactions/hooks/use-transactions-feed-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-feed-controller.test.ts
@@ -96,15 +96,24 @@ beforeEach(() => {
       tags: [{ id: "tag-1", name: "Alimentação", color: "#11A36B", icon: "cart" }],
     },
   } as never);
+  // Datas derivadas do MESMO relógio fake via getters locais (igual ao
+  // todayIso do controller), para o rótulo relativo ser estável em qualquer
+  // timezone (o CI roda em UTC, o dev pode estar em UTC-3).
+  const now = new Date();
+  const pad = (value: number): string => `${value}`.padStart(2, "0");
+  const localDate = (date: Date): string =>
+    `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`;
   setQuery([
-    buildRecord(),
+    buildRecord({ dueDate: localDate(now) }),
     buildRecord({
       id: "tx-2",
       title: "Mercado",
       type: "expense",
       amount: "300.00",
       tagId: "tag-1",
-      dueDate: "2026-06-19",
+      dueDate: localDate(
+        new Date(now.getFullYear(), now.getMonth(), now.getDate() - 1),
+      ),
     }),
   ]);
 });

--- a/features/transactions/hooks/use-transactions-feed-controller.ts
+++ b/features/transactions/hooks/use-transactions-feed-controller.ts
@@ -12,7 +12,7 @@
  * (espelha o controller da home de Cartões).
  */
 
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 import {
   type TransactionsScreenController,
@@ -45,9 +45,10 @@ const todayIso = (): string => {
 /**
  * Contrato do controller do feed: o controller base + os extras do feed.
  *
- * `viewMode`/`setViewMode` do controller base (list | calendar — conceito
- * legado) são substituídos pelo modo do redesign (Fácil | Analítico); por isso
- * são omitidos da base e redeclarados aqui.
+ * `viewMode`/`setViewMode` do controller base (list | calendar) são o eixo do
+ * redesign (Fácil | Analítico); por isso são omitidos da base e redeclarados
+ * aqui. O toggle de calendário (que reusa a flag list/calendar do controller
+ * base) é exposto separadamente via `calendarActive`/`toggleCalendar`.
  */
 export interface TransactionsFeedController
   extends Omit<TransactionsScreenController, "viewMode" | "setViewMode"> {
@@ -55,6 +56,10 @@ export interface TransactionsFeedController
   readonly viewMode: TransactionsFeedViewMode;
   /** Alterna o modo de visualização. */
   readonly setViewMode: (mode: TransactionsFeedViewMode) => void;
+  /** True quando a visão de calendário está ativa (reusa o estado base). */
+  readonly calendarActive: boolean;
+  /** Alterna entre a lista (feed) e o calendário. */
+  readonly toggleCalendar: () => void;
   /** KPIs agregados do período para o herói. */
   readonly heroKpis: FeedKpis;
   /** Barras de "Gastos por categoria" (modo Analítico). */
@@ -70,9 +75,18 @@ export interface TransactionsFeedController
  * @returns Controller do feed (base + extras).
  */
 export function useTransactionsFeedController(): TransactionsFeedController {
-  const base = useTransactionsScreenController();
+  const {
+    viewMode: baseViewMode,
+    setViewMode: setBaseViewMode,
+    ...base
+  } = useTransactionsScreenController();
   const tagsQuery = useTagsQuery();
   const [viewMode, setViewMode] = useState<TransactionsFeedViewMode>("facil");
+
+  const calendarActive = baseViewMode === "calendar";
+  const toggleCalendar = useCallback((): void => {
+    setBaseViewMode(baseViewMode === "calendar" ? "list" : "calendar");
+  }, [baseViewMode, setBaseViewMode]);
 
   const records = useMemo(
     () => base.transactionsQuery.data?.transactions ?? [],
@@ -88,10 +102,27 @@ export function useTransactionsFeedController(): TransactionsFeedController {
     () => groupExpensesByCategory(records, tags),
     [records, tags],
   );
+  // O feed visível respeita o filtro client-side de grupo de parcelas
+  // ("mostrar a mesma compra"); os KPIs/barras seguem o conjunto do período
+  // (paridade com o `monthBalance` do controller base, que usa tudo).
   const feedItems = useMemo<readonly TransactionFeedItem[]>(() => {
     const today = todayIso();
-    return records.map((tx) => toFeedItem({ tx, tags, kpis: heroKpis, today }));
-  }, [records, tags, heroKpis]);
+    const visible = base.installmentGroupFilter
+      ? records.filter(
+          (tx) => tx.installmentGroupId === base.installmentGroupFilter,
+        )
+      : records;
+    return visible.map((tx) => toFeedItem({ tx, tags, kpis: heroKpis, today }));
+  }, [records, tags, heroKpis, base.installmentGroupFilter]);
 
-  return { ...base, viewMode, setViewMode, heroKpis, categoryBars, feedItems };
+  return {
+    ...base,
+    viewMode,
+    setViewMode,
+    calendarActive,
+    toggleCalendar,
+    heroKpis,
+    categoryBars,
+    feedItems,
+  };
 }

--- a/features/transactions/hooks/use-transactions-feed-controller.ts
+++ b/features/transactions/hooks/use-transactions-feed-controller.ts
@@ -1,0 +1,97 @@
+/**
+ * Controller (somente lógica, sem UI) do FEED redesenhado de "Transações".
+ *
+ * É uma camada fina sobre `useTransactionsScreenController` (filtros, navegação
+ * de período, mutações, form) que adiciona o modo de visualização
+ * (Fácil | Analítico) e deriva os view-models do feed — KPIs do herói, barras
+ * de "Gastos por categoria" e itens do feed — a partir das funções puras de
+ * `model/transactions-feed` e das tags públicas (`useTagsQuery`).
+ *
+ * O controller base permanece intocado: este hook apenas o consome e enriquece.
+ * Consumir hooks públicos de outras features (`useTagsQuery`) é o padrão aceito
+ * (espelha o controller da home de Cartões).
+ */
+
+import { useMemo, useState } from "react";
+
+import {
+  type TransactionsScreenController,
+  useTransactionsScreenController,
+} from "@/features/transactions/hooks/use-transactions-screen-controller";
+import {
+  type CategoryBar,
+  type FeedKpis,
+  type TransactionFeedItem,
+  computeFeedKpis,
+  groupExpensesByCategory,
+  toFeedItem,
+} from "@/features/transactions/model/transactions-feed";
+import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
+
+/** Modo de visualização do feed redesenhado. */
+export type TransactionsFeedViewMode = "facil" | "analitico";
+
+/** KPIs zerados, usados quando ainda não há dados carregados. */
+const EMPTY_KPIS: FeedKpis = { income: 0, expense: 0, result: 0, count: 0 };
+
+/** Data de hoje (`YYYY-MM-DD`) em horário local, para rótulos relativos. */
+const todayIso = (): string => {
+  const now = new Date();
+  const month = `${now.getMonth() + 1}`.padStart(2, "0");
+  const day = `${now.getDate()}`.padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
+};
+
+/**
+ * Contrato do controller do feed: o controller base + os extras do feed.
+ *
+ * `viewMode`/`setViewMode` do controller base (list | calendar — conceito
+ * legado) são substituídos pelo modo do redesign (Fácil | Analítico); por isso
+ * são omitidos da base e redeclarados aqui.
+ */
+export interface TransactionsFeedController
+  extends Omit<TransactionsScreenController, "viewMode" | "setViewMode"> {
+  /** Modo de visualização atual (Fácil | Analítico). */
+  readonly viewMode: TransactionsFeedViewMode;
+  /** Alterna o modo de visualização. */
+  readonly setViewMode: (mode: TransactionsFeedViewMode) => void;
+  /** KPIs agregados do período para o herói. */
+  readonly heroKpis: FeedKpis;
+  /** Barras de "Gastos por categoria" (modo Analítico). */
+  readonly categoryBars: readonly CategoryBar[];
+  /** Itens do feed prontos para render (view-models). */
+  readonly feedItems: readonly TransactionFeedItem[];
+}
+
+/**
+ * Orquestra o feed de transações: estende o controller base com o modo de
+ * visualização e os view-models derivados (KPIs, barras por categoria e itens).
+ *
+ * @returns Controller do feed (base + extras).
+ */
+export function useTransactionsFeedController(): TransactionsFeedController {
+  const base = useTransactionsScreenController();
+  const tagsQuery = useTagsQuery();
+  const [viewMode, setViewMode] = useState<TransactionsFeedViewMode>("facil");
+
+  const records = useMemo(
+    () => base.transactionsQuery.data?.transactions ?? [],
+    [base.transactionsQuery.data],
+  );
+  const tags = useMemo(() => tagsQuery.data?.tags ?? [], [tagsQuery.data]);
+
+  const heroKpis = useMemo<FeedKpis>(
+    () => (records.length > 0 ? computeFeedKpis(records) : EMPTY_KPIS),
+    [records],
+  );
+  const categoryBars = useMemo<readonly CategoryBar[]>(
+    () => groupExpensesByCategory(records, tags),
+    [records, tags],
+  );
+  const feedItems = useMemo<readonly TransactionFeedItem[]>(() => {
+    const today = todayIso();
+    return records.map((tx) => toFeedItem({ tx, tags, kpis: heroKpis, today }));
+  }, [records, tags, heroKpis]);
+
+  return { ...base, viewMode, setViewMode, heroKpis, categoryBars, feedItems };
+}

--- a/features/transactions/model/transactions-feed.test.ts
+++ b/features/transactions/model/transactions-feed.test.ts
@@ -1,0 +1,298 @@
+import type {
+  TransactionRecord,
+  TransactionStatus,
+} from "@/features/transactions/contracts";
+import {
+  computeFeedKpis,
+  groupExpensesByCategory,
+  percentOfTotal,
+  relativeDateLabel,
+  toFeedItem,
+  type FeedKpis,
+} from "@/features/transactions/model/transactions-feed";
+import type { Tag } from "@/features/tags/contracts";
+import { NO_CATEGORY_COLOR, resolveCategoryColor } from "@/shared/theme";
+
+/**
+ * Monta um TransactionRecord completo com defaults para os testes.
+ *
+ * @param partial Campos a sobrescrever.
+ * @returns TransactionRecord completo.
+ */
+const tx = (partial: Partial<TransactionRecord> = {}): TransactionRecord => ({
+  id: "tx-1",
+  title: "Mercado",
+  amount: "100.00",
+  type: "expense",
+  dueDate: "2026-06-20",
+  startDate: null,
+  endDate: null,
+  description: null,
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: null,
+  accountId: null,
+  creditCardId: null,
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: null,
+  updatedAt: null,
+  ...partial,
+});
+
+const tag = (partial: Partial<Tag> = {}): Tag => ({
+  id: "tag-1",
+  name: "Alimentação",
+  color: "#11A36B",
+  icon: "cart",
+  ...partial,
+});
+
+describe("relativeDateLabel", () => {
+  const today = "2026-06-20";
+
+  it("retorna 'Hoje' quando é o mesmo dia", () => {
+    expect(relativeDateLabel("2026-06-20", today)).toBe("Hoje");
+  });
+
+  it("retorna 'Ontem' para -1 dia", () => {
+    expect(relativeDateLabel("2026-06-19", today)).toBe("Ontem");
+  });
+
+  it("retorna 'Amanhã' para +1 dia", () => {
+    expect(relativeDateLabel("2026-06-21", today)).toBe("Amanhã");
+  });
+
+  it("retorna 'em N dias' para futuro próximo (2..14)", () => {
+    expect(relativeDateLabel("2026-06-22", today)).toBe("em 2 dias");
+    expect(relativeDateLabel("2026-07-04", today)).toBe("em 14 dias");
+  });
+
+  it("retorna 'há N dias' para passado recente (2..14)", () => {
+    expect(relativeDateLabel("2026-06-18", today)).toBe("há 2 dias");
+    expect(relativeDateLabel("2026-06-06", today)).toBe("há 14 dias");
+  });
+
+  it("retorna null fora da janela de ±14 dias", () => {
+    expect(relativeDateLabel("2026-07-05", today)).toBeNull();
+    expect(relativeDateLabel("2026-06-05", today)).toBeNull();
+  });
+
+  it("faz parsing date-only timezone-safe (sem componente de horário)", () => {
+    // Mesmo com horários diferentes embutidos, a comparação é só por data.
+    expect(relativeDateLabel("2026-06-20T23:59:59Z", "2026-06-20T00:00:00Z")).toBe(
+      "Hoje",
+    );
+  });
+
+  it("atravessa virada de mês corretamente", () => {
+    expect(relativeDateLabel("2026-07-01", "2026-06-30")).toBe("Amanhã");
+    expect(relativeDateLabel("2026-05-31", "2026-06-01")).toBe("Ontem");
+  });
+
+  it("não quebra com strings de data vazias/malformadas (fallback defensivo)", () => {
+    // Ambas caem no epoch local 1970-01-01 → mesmo dia → "Hoje".
+    expect(relativeDateLabel("", "")).toBe("Hoje");
+  });
+});
+
+describe("computeFeedKpis", () => {
+  it("soma receitas e despesas a partir do amount string", () => {
+    const kpis = computeFeedKpis([
+      tx({ type: "income", amount: "8200.00" }),
+      tx({ type: "expense", amount: "2300.00" }),
+      tx({ type: "expense", amount: "200.50" }),
+    ]);
+    expect(kpis.income).toBeCloseTo(8200);
+    expect(kpis.expense).toBeCloseTo(2500.5);
+    expect(kpis.result).toBeCloseTo(5699.5);
+    expect(kpis.count).toBe(3);
+  });
+
+  it("exclui transações canceladas", () => {
+    const kpis = computeFeedKpis([
+      tx({ type: "income", amount: "100.00" }),
+      tx({ type: "expense", amount: "50.00", status: "cancelled" }),
+    ]);
+    expect(kpis.income).toBeCloseTo(100);
+    expect(kpis.expense).toBe(0);
+    expect(kpis.count).toBe(1);
+  });
+
+  it("ignora amounts não numéricos", () => {
+    const kpis = computeFeedKpis([
+      tx({ type: "income", amount: "abc" }),
+      tx({ type: "income", amount: "10.00" }),
+    ]);
+    expect(kpis.income).toBeCloseTo(10);
+    expect(kpis.count).toBe(2);
+  });
+
+  it("filtra por whitelist de status quando informada", () => {
+    const statuses: readonly TransactionStatus[] = ["paid"];
+    const kpis = computeFeedKpis(
+      [
+        tx({ type: "expense", amount: "30.00", status: "paid" }),
+        tx({ type: "expense", amount: "70.00", status: "pending" }),
+      ],
+      statuses,
+    );
+    expect(kpis.expense).toBeCloseTo(30);
+    expect(kpis.count).toBe(1);
+  });
+
+  it("retorna zeros para lista vazia", () => {
+    const kpis = computeFeedKpis([]);
+    expect(kpis).toEqual({ income: 0, expense: 0, result: 0, count: 0 });
+  });
+});
+
+describe("groupExpensesByCategory", () => {
+  it("agrupa apenas despesas por categoria, ordenado por total desc", () => {
+    const tags = [tag(), tag({ id: "tag-2", name: "Transporte", color: "#2E7CF6" })];
+    const bars = groupExpensesByCategory(
+      [
+        tx({ type: "expense", amount: "100.00", tagId: "tag-1" }),
+        tx({ type: "expense", amount: "300.00", tagId: "tag-2" }),
+        tx({ type: "income", amount: "999.00", tagId: "tag-1" }),
+      ],
+      tags,
+    );
+    expect(bars).toHaveLength(2);
+    expect(bars[0]).toEqual({
+      tagId: "tag-2",
+      name: "Transporte",
+      color: resolveCategoryColor({ id: "tag-2", color: "#2E7CF6" }),
+      total: 300,
+    });
+    expect(bars[1]?.tagId).toBe("tag-1");
+  });
+
+  it("usa 'Sem categoria' e cor neutra quando não há tag", () => {
+    const bars = groupExpensesByCategory(
+      [tx({ type: "expense", amount: "40.00", tagId: null })],
+      [],
+    );
+    expect(bars[0]).toEqual({
+      tagId: null,
+      name: "Sem categoria",
+      color: NO_CATEGORY_COLOR,
+      total: 40,
+    });
+  });
+
+  it("ignora transações canceladas", () => {
+    const bars = groupExpensesByCategory(
+      [tx({ type: "expense", amount: "40.00", status: "cancelled", tagId: "tag-1" })],
+      [tag()],
+    );
+    expect(bars).toEqual([]);
+  });
+
+  it("cai para 'Sem categoria' quando o tagId não está na lista de tags", () => {
+    const bars = groupExpensesByCategory(
+      [tx({ type: "expense", amount: "15.00", tagId: "ghost" })],
+      [],
+    );
+    expect(bars[0]?.name).toBe("Sem categoria");
+    expect(bars[0]?.tagId).toBe("ghost");
+  });
+});
+
+describe("percentOfTotal", () => {
+  it("retorna percentual inteiro", () => {
+    expect(percentOfTotal(25, 100)).toBe(25);
+    expect(percentOfTotal(1, 3)).toBe(33);
+  });
+
+  it("retorna 0 quando o total é zero", () => {
+    expect(percentOfTotal(50, 0)).toBe(0);
+  });
+});
+
+describe("toFeedItem", () => {
+  const today = "2026-06-20";
+  const kpis: FeedKpis = { income: 1000, expense: 400, result: 600, count: 5 };
+
+  it("constrói o view-model com categoria, sinal e percentuais", () => {
+    const item = toFeedItem({
+      tx: tx({
+        id: "tx-9",
+        title: "Uber",
+        description: "corrida",
+        amount: "200.00",
+        type: "expense",
+        tagId: "tag-1",
+        dueDate: "2026-06-20",
+        status: "pending",
+      }),
+      tags: [tag()],
+      kpis,
+      today,
+    });
+    expect(item.id).toBe("tx-9");
+    expect(item.title).toBe("Uber");
+    expect(item.description).toBe("corrida");
+    expect(item.amount).toBeCloseTo(200);
+    expect(item.type).toBe("expense");
+    expect(item.status).toBe("pending");
+    expect(item.categoryName).toBe("Alimentação");
+    expect(item.categoryColor).toBe(resolveCategoryColor({ id: "tag-1", color: "#11A36B" }));
+    expect(item.categoryIcon).toBe("cart");
+    expect(item.relativeDate).toBe("Hoje");
+    expect(item.signedDisplay.startsWith("−")).toBe(true);
+    // 200 / 400 (despesa) = 50%
+    expect(item.percentOfFlow).toBe(50);
+  });
+
+  it("usa o fluxo de receita para transações de entrada e sinal positivo", () => {
+    const item = toFeedItem({
+      tx: tx({ type: "income", amount: "250.00", tagId: null }),
+      tags: [],
+      kpis,
+      today,
+    });
+    expect(item.signedDisplay.startsWith("+")).toBe(true);
+    expect(item.categoryName).toBe("Sem categoria");
+    expect(item.categoryColor).toBe(NO_CATEGORY_COLOR);
+    expect(item.categoryIcon).toBeNull();
+    // 250 / 1000 (receita) = 25%
+    expect(item.percentOfFlow).toBe(25);
+  });
+
+  it("retorna 0% de fluxo quando o denominador é zero", () => {
+    const item = toFeedItem({
+      tx: tx({ type: "expense", amount: "10.00" }),
+      tags: [],
+      kpis: { income: 0, expense: 0, result: 0, count: 0 },
+      today,
+    });
+    expect(item.percentOfFlow).toBe(0);
+  });
+
+  it("expõe flags de recorrência e parcelamento e relativeDate null fora da janela", () => {
+    const item = toFeedItem({
+      tx: tx({
+        isRecurring: true,
+        isInstallment: true,
+        installmentCount: 12,
+        dueDate: "2026-12-25",
+      }),
+      tags: [],
+      kpis,
+      today,
+    });
+    expect(item.isRecurring).toBe(true);
+    expect(item.isInstallment).toBe(true);
+    expect(item.relativeDate).toBeNull();
+  });
+});

--- a/features/transactions/model/transactions-feed.test.ts
+++ b/features/transactions/model/transactions-feed.test.ts
@@ -7,6 +7,7 @@ import {
   groupExpensesByCategory,
   percentOfTotal,
   relativeDateLabel,
+  shortDateLabel,
   toFeedItem,
   type FeedKpis,
 } from "@/features/transactions/model/transactions-feed";
@@ -294,5 +295,25 @@ describe("toFeedItem", () => {
     expect(item.isRecurring).toBe(true);
     expect(item.isInstallment).toBe(true);
     expect(item.relativeDate).toBeNull();
+    // Fora da janela relativa, o display cai para "DD mmm".
+    expect(item.dateDisplay).toBe("25 dez");
+  });
+
+  it("usa o rótulo relativo no dateDisplay quando está na janela", () => {
+    const item = toFeedItem({
+      tx: tx({ dueDate: "2026-06-20" }),
+      tags: [],
+      kpis,
+      today,
+    });
+    expect(item.dateDisplay).toBe("Hoje");
+  });
+});
+
+describe("shortDateLabel", () => {
+  it("formata 'DD mmm' em pt-BR (date-only)", () => {
+    expect(shortDateLabel("2026-06-20")).toBe("20 jun");
+    expect(shortDateLabel("2026-01-05")).toBe("5 jan");
+    expect(shortDateLabel("2026-12-31")).toBe("31 dez");
   });
 });

--- a/features/transactions/model/transactions-feed.ts
+++ b/features/transactions/model/transactions-feed.ts
@@ -69,6 +69,8 @@ export interface TransactionFeedItem {
   readonly categoryIcon: string | null;
   /** Rótulo relativo ("Hoje", "em 3 dias") ou null para fallback "DD mmm". */
   readonly relativeDate: string | null;
+  /** Rótulo de data pronto: o relativo quando há, senão o fallback "DD mmm". */
+  readonly dateDisplay: string;
   /** Valor monetário formatado com sinal (ex.: "+ R$ 250,00"). */
   readonly signedDisplay: string;
   /** Participação do lançamento no fluxo do seu tipo (0..100, inteiro). */
@@ -130,6 +132,24 @@ export const relativeDateLabel = (
     return `há ${Math.abs(delta)} dias`;
   }
   return null;
+};
+
+/** Abreviações de mês em pt-BR (índice 0 = janeiro), para o fallback "DD mmm". */
+const MONTH_ABBR_PT = [
+  "jan", "fev", "mar", "abr", "mai", "jun",
+  "jul", "ago", "set", "out", "nov", "dez",
+];
+
+/**
+ * Rótulo curto "DD mmm" (ex.: "20 jun") a partir de uma data `YYYY-MM-DD`,
+ * com parsing date-only/timezone-safe.
+ *
+ * @param dueDate Data de vencimento (`YYYY-MM-DD`).
+ * @returns Rótulo curto pt-BR.
+ */
+export const shortDateLabel = (dueDate: string): string => {
+  const date = toDateOnly(dueDate);
+  return `${date.getDate()} ${MONTH_ABBR_PT[date.getMonth()] ?? ""}`.trim();
 };
 
 /** Converte o amount string da API em número, tratando valores inválidos. */
@@ -276,6 +296,7 @@ export const toFeedItem = ({
   const amount = parseAmount(tx.amount);
   const signed = tx.type === "income" ? amount : -amount;
   const flow = tx.type === "income" ? kpis.income : kpis.expense;
+  const relativeDate = relativeDateLabel(tx.dueDate, today);
   return {
     id: tx.id,
     title: tx.title,
@@ -288,7 +309,8 @@ export const toFeedItem = ({
     categoryName: category.name,
     categoryColor: category.color,
     categoryIcon: tag?.icon ?? null,
-    relativeDate: relativeDateLabel(tx.dueDate, today),
+    relativeDate,
+    dateDisplay: relativeDate ?? shortDateLabel(tx.dueDate),
     signedDisplay: formatCurrencySigned(signed),
     percentOfFlow: percentOfTotal(amount, flow),
   };

--- a/features/transactions/model/transactions-feed.ts
+++ b/features/transactions/model/transactions-feed.ts
@@ -1,0 +1,295 @@
+/**
+ * Funções puras que alimentam o FEED redesenhado de "Transações" (modos Fácil
+ * e Analítico). Sem dependência de UI ou framework: recebem registros crus +
+ * tags e devolvem KPIs, barras por categoria e view-models tipados.
+ *
+ * O cálculo de cor/nome de categoria espelha o padrão dos Cartões
+ * (`credit-card-aggregation`), reusando `resolveCategoryColor` /
+ * `NO_CATEGORY_COLOR`. Formatação monetária delega para `formatCurrencySigned`.
+ */
+
+import type {
+  TransactionRecord,
+  TransactionStatus,
+  TransactionType,
+} from "@/features/transactions/contracts";
+import type { Tag } from "@/features/tags/contracts";
+import { NO_CATEGORY_COLOR, resolveCategoryColor } from "@/shared/theme";
+import { formatCurrencySigned } from "@/shared/utils/formatters";
+
+/** Rótulo usado para lançamentos sem categoria. */
+export const NO_CATEGORY_LABEL = "Sem categoria";
+
+/** Janela máxima (em dias) coberta por rótulos relativos "em/há N dias". */
+export const RELATIVE_DATE_WINDOW_DAYS = 14;
+
+/** Milissegundos em um dia, usado no cálculo de diferença de datas. */
+const MS_PER_DAY = 86_400_000;
+
+/** KPIs agregados do feed (herói). */
+export interface FeedKpis {
+  /** Soma das receitas (entradas) não canceladas. */
+  readonly income: number;
+  /** Soma das despesas (saídas) não canceladas. */
+  readonly expense: number;
+  /** Resultado líquido do período (income − expense). */
+  readonly result: number;
+  /** Quantidade de lançamentos considerados. */
+  readonly count: number;
+}
+
+/** Barra de "Gastos por categoria" (modo Analítico). */
+export interface CategoryBar {
+  /** Id da tag, ou null para "Sem categoria". */
+  readonly tagId: string | null;
+  /** Nome da categoria (tag) ou "Sem categoria". */
+  readonly name: string;
+  /** Cor hexadecimal resolvida para a categoria. */
+  readonly color: string;
+  /** Total gasto na categoria. */
+  readonly total: number;
+}
+
+/** View-model de um item do feed de transações. */
+export interface TransactionFeedItem {
+  readonly id: string;
+  readonly title: string;
+  readonly description: string | null;
+  /** Valor numérico do lançamento (sempre positivo). */
+  readonly amount: number;
+  readonly type: TransactionType;
+  readonly status: TransactionStatus;
+  readonly isRecurring: boolean;
+  readonly isInstallment: boolean;
+  /** Nome da categoria (tag) ou "Sem categoria". */
+  readonly categoryName: string;
+  /** Cor hexadecimal da categoria. */
+  readonly categoryColor: string;
+  /** Ícone da categoria (tag) ou null. */
+  readonly categoryIcon: string | null;
+  /** Rótulo relativo ("Hoje", "em 3 dias") ou null para fallback "DD mmm". */
+  readonly relativeDate: string | null;
+  /** Valor monetário formatado com sinal (ex.: "+ R$ 250,00"). */
+  readonly signedDisplay: string;
+  /** Participação do lançamento no fluxo do seu tipo (0..100, inteiro). */
+  readonly percentOfFlow: number;
+}
+
+/**
+ * Converte uma string de data (`YYYY-MM-DD` ou ISO com horário) em uma data
+ * local somente-data (sem componente de horário), evitando bugs de fuso.
+ *
+ * @param value String de data da API.
+ * @returns Data local normalizada (00:00 local).
+ */
+const toDateOnly = (value: string): Date => {
+  const [datePart] = value.split("T");
+  const [year, month, day] = (datePart ?? "").split("-").map(Number);
+  return new Date(year ?? 1970, (month ?? 1) - 1, day ?? 1);
+};
+
+/**
+ * Diferença em dias (inteiro) entre `dueDate` e `today`, somente por data.
+ *
+ * @param dueDate Data alvo (`YYYY-MM-DD`).
+ * @param today Data de referência (`YYYY-MM-DD`).
+ * @returns Dias relativos (positivo = futuro, negativo = passado).
+ */
+const dayDelta = (dueDate: string, today: string): number => {
+  const diff = toDateOnly(dueDate).getTime() - toDateOnly(today).getTime();
+  return Math.round(diff / MS_PER_DAY);
+};
+
+/**
+ * Rótulo relativo de uma data de vencimento ("Hoje", "Ontem", "Amanhã",
+ * "em N dias", "há N dias") ou null quando está fora da janela de ±14 dias —
+ * nesse caso a UI usa o fallback "DD mmm". Parsing é date-only/timezone-safe.
+ *
+ * @param dueDate Data de vencimento (`YYYY-MM-DD`).
+ * @param today Data de referência (`YYYY-MM-DD`).
+ * @returns Rótulo relativo em pt-BR ou null.
+ */
+export const relativeDateLabel = (
+  dueDate: string,
+  today: string,
+): string | null => {
+  const delta = dayDelta(dueDate, today);
+  if (delta === 0) {
+    return "Hoje";
+  }
+  if (delta === -1) {
+    return "Ontem";
+  }
+  if (delta === 1) {
+    return "Amanhã";
+  }
+  if (delta > 1 && delta <= RELATIVE_DATE_WINDOW_DAYS) {
+    return `em ${delta} dias`;
+  }
+  if (delta < -1 && delta >= -RELATIVE_DATE_WINDOW_DAYS) {
+    return `há ${Math.abs(delta)} dias`;
+  }
+  return null;
+};
+
+/** Converte o amount string da API em número, tratando valores inválidos. */
+const parseAmount = (amount: string): number => {
+  const value = Number.parseFloat(amount);
+  return Number.isNaN(value) ? 0 : value;
+};
+
+/**
+ * Indica se um registro deve entrar nos agregados: nunca canceladas e, quando
+ * uma whitelist de status é informada, somente os status listados.
+ *
+ * @param record Registro de transação.
+ * @param statuses Whitelist opcional de status.
+ * @returns True quando o registro deve ser contado.
+ */
+const isCountable = (
+  record: TransactionRecord,
+  statuses: readonly TransactionStatus[] | undefined,
+): boolean => {
+  if (record.status === "cancelled") {
+    return false;
+  }
+  return statuses ? statuses.includes(record.status) : true;
+};
+
+/**
+ * Calcula os KPIs do herói (receitas, despesas, resultado e contagem) a partir
+ * dos registros, somando pelo `amount` string. Canceladas são sempre excluídas;
+ * uma whitelist opcional de status restringe ainda mais o conjunto.
+ *
+ * @param transactions Registros de transação.
+ * @param statuses Whitelist opcional de status a considerar.
+ * @returns KPIs agregados do período.
+ */
+export const computeFeedKpis = (
+  transactions: readonly TransactionRecord[],
+  statuses?: readonly TransactionStatus[],
+): FeedKpis => {
+  let income = 0;
+  let expense = 0;
+  let count = 0;
+  for (const record of transactions) {
+    if (!isCountable(record, statuses)) {
+      continue;
+    }
+    count += 1;
+    const value = parseAmount(record.amount);
+    if (record.type === "income") {
+      income += value;
+    } else {
+      expense += value;
+    }
+  }
+  return { income, expense, result: income - expense, count };
+};
+
+/** Resolve nome/cor de categoria a partir de um id de tag (ou null). */
+const resolveCategory = (
+  tagId: string | null,
+  tagById: ReadonlyMap<string, Tag>,
+): { readonly name: string; readonly color: string } => {
+  const tag = tagId ? tagById.get(tagId) ?? null : null;
+  if (!tagId) {
+    return { name: NO_CATEGORY_LABEL, color: NO_CATEGORY_COLOR };
+  }
+  return {
+    name: tag?.name ?? NO_CATEGORY_LABEL,
+    color: resolveCategoryColor({ id: tagId, color: tag?.color }),
+  };
+};
+
+/**
+ * Agrupa apenas as despesas (não canceladas) por categoria, somando o total e
+ * resolvendo nome/cor da tag, ordenado por total decrescente. Espelha o padrão
+ * dos Cartões.
+ *
+ * @param transactions Registros de transação.
+ * @param tags Categorias do usuário.
+ * @returns Barras por categoria, do maior para o menor total.
+ */
+export const groupExpensesByCategory = (
+  transactions: readonly TransactionRecord[],
+  tags: readonly Tag[],
+): CategoryBar[] => {
+  const tagById = new Map(tags.map((tag) => [tag.id, tag]));
+  const totals = new Map<string | null, number>();
+  for (const record of transactions) {
+    if (record.type !== "expense" || record.status === "cancelled") {
+      continue;
+    }
+    const current = totals.get(record.tagId) ?? 0;
+    totals.set(record.tagId, current + parseAmount(record.amount));
+  }
+  return [...totals.entries()]
+    .map(([tagId, total]) => ({ ...resolveCategory(tagId, tagById), tagId, total }))
+    .sort((a, b) => b.total - a.total);
+};
+
+/**
+ * Percentual inteiro de um valor sobre um total. Retorna 0 quando o total é 0.
+ *
+ * @param amount Valor parcial.
+ * @param total Total de referência.
+ * @returns Percentual inteiro (0..100+).
+ */
+export const percentOfTotal = (amount: number, total: number): number => {
+  if (total === 0) {
+    return 0;
+  }
+  return Math.round((amount / total) * 100);
+};
+
+/** Argumentos para construir um item do feed. */
+export interface ToFeedItemArgs {
+  /** Registro cru da transação. */
+  readonly tx: TransactionRecord;
+  /** Categorias do usuário. */
+  readonly tags: readonly Tag[];
+  /** KPIs do período (para o denominador de `percentOfFlow`). */
+  readonly kpis: FeedKpis;
+  /** Data de referência (`YYYY-MM-DD`) para o rótulo relativo. */
+  readonly today: string;
+}
+
+/**
+ * Constrói o view-model de um item do feed: categoria (nome/cor/ícone), rótulo
+ * relativo de data, valor com sinal e participação no fluxo do seu tipo
+ * (receita vs despesa). Recebe um objeto único para respeitar o limite de
+ * parâmetros do lint.
+ *
+ * @param args Registro, tags, KPIs e data de referência.
+ * @returns View-model pronto para a UI.
+ */
+export const toFeedItem = ({
+  tx,
+  tags,
+  kpis,
+  today,
+}: ToFeedItemArgs): TransactionFeedItem => {
+  const tagById = new Map(tags.map((tag) => [tag.id, tag]));
+  const category = resolveCategory(tx.tagId, tagById);
+  const tag = tx.tagId ? tagById.get(tx.tagId) ?? null : null;
+  const amount = parseAmount(tx.amount);
+  const signed = tx.type === "income" ? amount : -amount;
+  const flow = tx.type === "income" ? kpis.income : kpis.expense;
+  return {
+    id: tx.id,
+    title: tx.title,
+    description: tx.description,
+    amount,
+    type: tx.type,
+    status: tx.status,
+    isRecurring: tx.isRecurring,
+    isInstallment: tx.isInstallment,
+    categoryName: category.name,
+    categoryColor: category.color,
+    categoryIcon: tag?.icon ?? null,
+    relativeDate: relativeDateLabel(tx.dueDate, today),
+    signedDisplay: formatCurrencySigned(signed),
+    percentOfFlow: percentOfTotal(amount, flow),
+  };
+};

--- a/features/transactions/screens/transactions-screen.test.tsx
+++ b/features/transactions/screens/transactions-screen.test.tsx
@@ -1,0 +1,198 @@
+/* eslint-disable @typescript-eslint/no-require-imports */
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { TestProviders } from "@/shared/testing/test-providers";
+
+import { TransactionsScreen } from "@/features/transactions/screens/transactions-screen";
+import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import type { TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+import type { TransactionViewModel } from "@/features/transactions/hooks/use-transactions-screen-controller";
+
+const mockSetViewMode = jest.fn();
+const mockToggleCalendar = jest.fn();
+const mockHandleOpenEdit = jest.fn();
+const mockPush = jest.fn();
+
+let mockOverrides: Partial<TransactionsFeedController> = {};
+
+const feedItem: TransactionFeedItem = {
+  id: "tx-1",
+  title: "Impostos",
+  description: "Impostos do salário gringo",
+  amount: 2000,
+  type: "expense",
+  status: "pending",
+  isRecurring: false,
+  isInstallment: false,
+  categoryName: "Impostos",
+  categoryColor: "#E5484D",
+  categoryIcon: "tax",
+  relativeDate: "em 9 dias",
+  dateDisplay: "em 9 dias",
+  signedDisplay: "− R$ 2.000,00",
+  percentOfFlow: 10,
+};
+
+const viewModel: TransactionViewModel = {
+  id: "tx-1",
+  title: "Impostos",
+  amount: "2000.00",
+  type: "expense",
+  dueDate: "2026-06-29",
+  status: "pending",
+  description: "Impostos do salário gringo",
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  installmentGroupId: null,
+  installmentNumber: null,
+};
+
+const mockBaseController: TransactionsFeedController = {
+  transactionsQuery: {
+    data: { transactions: [{ ...viewModel, tagId: null }], pagination: { total: 1 } },
+    isPending: false,
+    isError: false,
+    isSuccess: true,
+  } as never,
+  transactions: [viewModel],
+  total: 1,
+  monthBalance: 7769.07,
+  hasActiveFilters: false,
+  typeFilter: "all",
+  setTypeFilter: jest.fn(),
+  statusFilter: "all",
+  setStatusFilter: jest.fn(),
+  tagFilter: "all",
+  setTagFilter: jest.fn(),
+  periodLabel: "Junho de 2026",
+  goToPreviousMonth: jest.fn(),
+  goToNextMonth: jest.fn(),
+  resetToCurrentMonth: jest.fn(),
+  clearFilters: jest.fn(),
+  installmentGroupFilter: null,
+  formMode: { kind: "closed" },
+  isSubmitting: false,
+  submitError: null,
+  deletingTransactionId: null,
+  duplicatingTransactionId: null,
+  payingTransactionId: null,
+  handleOpenCreate: jest.fn(),
+  handleOpenEdit: mockHandleOpenEdit,
+  handleCloseForm: jest.fn(),
+  handleSubmit: jest.fn(),
+  handleDelete: jest.fn(),
+  handleMarkPaid: jest.fn(),
+  handleDuplicate: jest.fn(),
+  handleShowInstallmentGroup: jest.fn(),
+  handleClearInstallmentGroupFilter: jest.fn(),
+  dismissSubmitError: jest.fn(),
+  viewMode: "facil",
+  setViewMode: mockSetViewMode,
+  calendarActive: false,
+  toggleCalendar: mockToggleCalendar,
+  heroKpis: { income: 27675.37, expense: 19906.3, result: 7769.07, count: 10 },
+  categoryBars: [{ tagId: "t1", name: "Cartão", color: "#FF8A3D", total: 11000 }],
+  feedItems: [feedItem],
+};
+
+jest.mock("@/features/transactions/hooks/use-transactions-feed-controller", () => ({
+  useTransactionsFeedController: (): TransactionsFeedController => ({
+    ...mockBaseController,
+    ...mockOverrides,
+  }),
+}));
+
+jest.mock("@/features/insights/components/ai-insight-surface", () => ({
+  AiInsightSurface: (): null => null,
+}));
+
+jest.mock("@/features/transactions/hooks/use-transactions-export", () => ({
+  useTransactionsExport: () => ({
+    exportNow: jest.fn(),
+    isExporting: false,
+    error: null,
+    dismissError: jest.fn(),
+  }),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock("react-native-gesture-handler/ReanimatedSwipeable", () => {
+  const ReactInner = require("react");
+  const { View } = require("react-native");
+  const Swipeable = ({ children }: { readonly children: React.ReactNode }): React.ReactNode =>
+    ReactInner.createElement(View, null, children);
+  return { __esModule: true, default: Swipeable };
+});
+
+const renderScreen = () =>
+  render(
+    <TestProviders>
+      <TransactionsScreen />
+    </TestProviders>,
+  );
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockOverrides = {};
+});
+
+describe("TransactionsScreen", () => {
+  it("renderiza o herói com título, período e resultado", () => {
+    const { getByText, getByTestId } = renderScreen();
+    expect(getByText("Transações")).toBeTruthy();
+    expect(getByText("Junho de 2026 · 10 lançamentos")).toBeTruthy();
+    expect(getByTestId("tx-hero-result")).toBeTruthy();
+  });
+
+  it("mostra o segmented Fácil/Analítico e troca de modo", () => {
+    const { getByTestId } = renderScreen();
+    fireEvent.press(getByTestId("tx-mode-toggle-analitico"));
+    expect(mockSetViewMode).toHaveBeenCalledWith("analitico");
+  });
+
+  it("no modo Analítico mostra o painel de categorias acima do feed", () => {
+    mockOverrides = { viewMode: "analitico" };
+    const { getByTestId, getByText } = renderScreen();
+    expect(getByTestId("tx-category-breakdown")).toBeTruthy();
+    expect(getByText("Gastos por categoria")).toBeTruthy();
+  });
+
+  it("renderiza os cards do feed e abre as ações ao tocar", () => {
+    const { getByTestId, queryByTestId } = renderScreen();
+    expect(getByTestId("tx-card-tx-1")).toBeTruthy();
+    // O action sheet só existe após o toque no card.
+    expect(queryByTestId("transaction-action-sheet")).toBeNull();
+    fireEvent.press(getByTestId("tx-card-tx-1"));
+    expect(getByTestId("transaction-action-sheet")).toBeTruthy();
+    expect(getByTestId("action-delete")).toBeTruthy();
+  });
+
+  it("alterna o calendário pelo botão do herói", () => {
+    const { getByTestId } = renderScreen();
+    fireEvent.press(getByTestId("tx-hero-calendar-toggle"));
+    expect(mockToggleCalendar).toHaveBeenCalled();
+  });
+
+  it("renderiza o calendário quando a visão de calendário está ativa", () => {
+    mockOverrides = { calendarActive: true };
+    const { queryByTestId } = renderScreen();
+    // O feed não é renderizado na visão de calendário.
+    expect(queryByTestId("transactions-flashlist")).toBeNull();
+  });
+
+  it("navega para a lixeira pelo botão de ações", () => {
+    const { getByTestId } = renderScreen();
+    fireEvent.press(getByTestId("transactions-trash-button"));
+    expect(mockPush).toHaveBeenCalledWith("/lixeira-transacoes");
+  });
+
+  it("renderiza o formulário existente quando o modo não está fechado", () => {
+    mockOverrides = { formMode: { kind: "create" } };
+    const { queryByTestId } = renderScreen();
+    expect(queryByTestId("transactions-screen")).toBeNull();
+  });
+});

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -1,61 +1,30 @@
-import { useCallback, useMemo, useState, type ReactElement } from "react";
+import type { ReactElement } from "react";
 
-import { MaterialCommunityIcons } from "@expo/vector-icons";
-import { FlashList } from "@shopify/flash-list";
-import { useRouter } from "expo-router";
-import { Modal, Pressable, RefreshControl } from "react-native";
-import { Paragraph, XStack, YStack } from "tamagui";
-
-import { appRoutes } from "@/core/navigation/routes";
-import { queryKeys } from "@/core/query/query-keys";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
-import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
-import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { FinancialCalendar } from "@/features/transactions/components/financial-calendar";
-import {
-  DeleteConfirmModal,
-  MarkPaidConfirmModal,
-  type DeleteTarget,
-  type MarkPaidTarget,
-} from "@/features/transactions/components/transaction-action-modals";
-import { TransactionActionSheet } from "@/features/transactions/components/transaction-action-sheet";
-import { TransactionBottomSheet } from "@/features/transactions/components/transaction-bottom-sheet";
-import {
-  PeriodNavigator,
-  TransactionFilterControls,
-} from "@/features/transactions/components/transaction-filters";
+import { PeriodNavigator } from "@/features/transactions/components/transaction-filters";
+import { TransactionFeed } from "@/features/transactions/components/transaction-feed-list";
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
-import { TransactionRow } from "@/features/transactions/components/transaction-row";
-import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
-import {
-  useTransactionsScreenController,
-  type TransactionsScreenController,
-  type TransactionViewModel,
-} from "@/features/transactions/hooks/use-transactions-screen-controller";
-import { AppButton } from "@/shared/components/app-button";
-import { AppEmptyState } from "@/shared/components/app-empty-state";
-import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { TxHero } from "@/features/transactions/components/tx-hero";
+import { useTransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
 import { AppScreen } from "@/shared/components/app-screen";
-import { AppSurfaceCard } from "@/shared/components/app-surface-card";
-import { isFeatureEnabled } from "@/shared/feature-flags";
-import { useListRefresh } from "@/shared/hooks/use-list-refresh";
-import { useT } from "@/shared/i18n";
-import { TransactionListSkeleton } from "@/shared/skeletons";
-import { darkSemanticColors, lightSemanticColors } from "@/shared/theme";
-import { formatCurrency } from "@/shared/utils/formatters";
-
-const TRANSACTIONS_REFRESH_KEYS = [
-  queryKeys.transactions.list(),
-  queryKeys.transactions.summary(),
-] as const;
 
 /**
- * Canonical transactions screen composition for the mobile app.
+ * Tela canônica de "Transações" (feed redesenhado): herói teal, segmented
+ * Fácil/Analítico, filtros e o feed em cards (ou o calendário existente).
+ * Mantém intactos o formulário de criar/editar, os filtros, a exportação, a
+ * navegação para importação/lixeira, o calendário e as ações de swipe — toda
+ * a lógica vive no controller e nos componentes do feed; a tela só compõe.
  *
- * @returns List with collapsed header and swipe/tap actions, or active form.
+ * @returns Tela de transações, ou o formulário ativo.
  */
 export function TransactionsScreen(): ReactElement {
-  const controller = useTransactionsScreenController();
+  const controller = useTransactionsFeedController();
+  const isDark = useResolvedTheme() === "auraxis_dark";
+  const setThemePreference = useAppShellStore(
+    (state) => state.setThemePreference,
+  );
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -76,517 +45,35 @@ export function TransactionsScreen(): ReactElement {
     );
   }
 
-  const listHeader = (
-    <YStack gap="$4" paddingBottom="$2">
-      <FilterHeader controller={controller} />
-      <AiInsightSurface dimension="transactions" />
-    </YStack>
+  const hero = (
+    <TxHero
+      periodLabel={controller.periodLabel}
+      kpis={controller.heroKpis}
+      isDark={isDark}
+      onToggleTheme={() => setThemePreference(isDark ? "light" : "dark")}
+      onToggleCalendar={controller.toggleCalendar}
+      calendarActive={controller.calendarActive}
+    />
   );
 
-  if (controller.viewMode === "calendar") {
+  if (controller.calendarActive) {
     return (
-      <AppScreen>
-        {listHeader}
+      <AppScreen scrollable testID="transactions-screen">
+        {hero}
+        <PeriodNavigator
+          periodLabel={controller.periodLabel}
+          onPreviousMonth={controller.goToPreviousMonth}
+          onNextMonth={controller.goToNextMonth}
+        />
         <FinancialCalendar transactions={controller.transactions} />
       </AppScreen>
     );
   }
 
-  // Lista: filtros colapsados + insight rolam JUNTO com os itens
-  // (ListHeaderComponent), deixando as transações visíveis na dobra.
   return (
-    <AppScreen scrollable={false}>
-      <TransactionsListCard controller={controller} listHeader={listHeader} />
+    <AppScreen scrollable={false} testID="transactions-screen">
+      {hero}
+      <TransactionFeed controller={controller} />
     </AppScreen>
   );
-}
-
-interface ControllerProps {
-  readonly controller: TransactionsScreenController;
-}
-
-interface HeaderIconButtonProps {
-  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
-  readonly accessibilityLabel: string;
-  readonly color: string;
-  readonly onPress: () => void;
-  readonly badgeColor?: string;
-}
-
-/** Botão só-ícone do cabeçalho (44×44), com dot opcional de filtro ativo. */
-function HeaderIconButton({
-  icon,
-  accessibilityLabel,
-  color,
-  onPress,
-  badgeColor,
-}: HeaderIconButtonProps): ReactElement {
-  return (
-    <Pressable
-      accessibilityRole="button"
-      accessibilityLabel={accessibilityLabel}
-      onPress={onPress}
-      style={{ width: 44, height: 44, alignItems: "center", justifyContent: "center" }}
-    >
-      <MaterialCommunityIcons name={icon} size={24} color={color} />
-      {badgeColor ? (
-        <YStack
-          position="absolute"
-          top={9}
-          right={9}
-          width={9}
-          height={9}
-          borderRadius={9}
-          backgroundColor={badgeColor}
-        />
-      ) : null}
-    </Pressable>
-  );
-}
-
-interface HeaderActionsRowProps extends ControllerProps {
-  readonly iconColor: string;
-  readonly badgeColor: string;
-  readonly onOpenFilters: () => void;
-  readonly onOpenExport: () => void;
-}
-
-/** Saldo do período (esquerda) + ações em ícones (direita). */
-function HeaderActionsRow({
-  controller,
-  iconColor,
-  badgeColor,
-  onOpenFilters,
-  onOpenExport,
-}: HeaderActionsRowProps): ReactElement {
-  const positive = controller.monthBalance >= 0;
-  return (
-    <XStack alignItems="center" justifyContent="space-between">
-      <YStack>
-        <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
-          Saldo do período
-        </Paragraph>
-        <Paragraph
-          color={positive ? "$success" : "$danger"}
-          fontFamily="$body"
-          fontSize="$6"
-          fontWeight="$7"
-        >
-          {formatCurrency(controller.monthBalance)}
-        </Paragraph>
-      </YStack>
-      <XStack alignItems="center">
-        <HeaderIconButton
-          icon={
-            controller.viewMode === "list"
-              ? "calendar-month-outline"
-              : "format-list-bulleted"
-          }
-          accessibilityLabel={
-            controller.viewMode === "list" ? "Ver calendário" : "Ver lista"
-          }
-          color={iconColor}
-          onPress={() =>
-            controller.setViewMode(
-              controller.viewMode === "list" ? "calendar" : "list",
-            )
-          }
-        />
-        <HeaderIconButton
-          icon="filter-variant"
-          accessibilityLabel="Filtros"
-          color={iconColor}
-          onPress={onOpenFilters}
-          badgeColor={controller.hasActiveFilters ? badgeColor : undefined}
-        />
-        <HeaderIconButton
-          icon="tray-arrow-up"
-          accessibilityLabel="Exportar"
-          color={iconColor}
-          onPress={onOpenExport}
-        />
-      </XStack>
-    </XStack>
-  );
-}
-
-function FilterHeader({ controller }: ControllerProps): ReactElement {
-  const { t } = useT();
-  const router = useRouter();
-  const isDark = useResolvedTheme() === "auraxis_dark";
-  const palette = isDark ? darkSemanticColors : lightSemanticColors;
-  const [exportSheetOpen, setExportSheetOpen] = useState<boolean>(false);
-  const [filterSheetOpen, setFilterSheetOpen] = useState<boolean>(false);
-  const exportRunner = useTransactionsExport();
-  const importEnabled = isFeatureEnabled(IMPORT_FEATURE_FLAG_KEY);
-
-  const handleExportFormat = useCallback(
-    async (format: "csv" | "pdf"): Promise<void> => {
-      await exportRunner.exportNow({ format });
-      setExportSheetOpen(false);
-    },
-    [exportRunner],
-  );
-
-  return (
-    <YStack gap="$3">
-      <PeriodNavigator
-        periodLabel={controller.periodLabel}
-        onPreviousMonth={controller.goToPreviousMonth}
-        onNextMonth={controller.goToNextMonth}
-      />
-      <HeaderActionsRow
-        controller={controller}
-        iconColor={palette.mutedForeground}
-        badgeColor={palette.primary}
-        onOpenFilters={() => setFilterSheetOpen(true)}
-        onOpenExport={() => setExportSheetOpen(true)}
-      />
-      {importEnabled ? (
-        <AppButton
-          tone="secondary"
-          size="sm"
-          onPress={() => router.push(appRoutes.private.importTransactions)}
-        >
-          Importar planilha
-        </AppButton>
-      ) : null}
-      <InstallmentGroupFilterNotice controller={controller} />
-      <FilterSheet
-        visible={filterSheetOpen}
-        controller={controller}
-        onClose={() => setFilterSheetOpen(false)}
-      />
-      <Modal
-        visible={exportSheetOpen}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setExportSheetOpen(false)}
-      >
-        <ExportSheet
-          onClose={() => setExportSheetOpen(false)}
-          onExport={handleExportFormat}
-          isExporting={exportRunner.isExporting}
-          error={exportRunner.error}
-          dismissError={exportRunner.dismissError}
-          translate={t}
-        />
-      </Modal>
-    </YStack>
-  );
-}
-
-interface FilterSheetProps extends ControllerProps {
-  readonly visible: boolean;
-  readonly onClose: () => void;
-}
-
-function FilterSheet({ visible, controller, onClose }: FilterSheetProps): ReactElement {
-  return (
-    <TransactionBottomSheet
-      visible={visible}
-      onClose={onClose}
-      testID="transaction-filter-sheet"
-    >
-      <Paragraph fontFamily="$body" fontWeight="$7" fontSize="$5" color="$color">
-        Filtros
-      </Paragraph>
-      <TransactionFilterControls
-        typeFilter={controller.typeFilter}
-        onTypeFilterChange={controller.setTypeFilter}
-        statusFilter={controller.statusFilter}
-        onStatusFilterChange={controller.setStatusFilter}
-        tagFilter={controller.tagFilter}
-        onTagFilterChange={controller.setTagFilter}
-        onClearFilters={controller.clearFilters}
-      />
-      <AppButton onPress={onClose}>Aplicar</AppButton>
-    </TransactionBottomSheet>
-  );
-}
-
-function InstallmentGroupFilterNotice({
-  controller,
-}: ControllerProps): ReactElement | null {
-  if (!controller.installmentGroupFilter) {
-    return null;
-  }
-
-  return (
-    <XStack alignItems="center" gap="$2">
-      <Paragraph color="$muted" flex={1} fontFamily="$body" fontSize="$2">
-        Mostrando parcelas da mesma compra.
-      </Paragraph>
-      <AppButton
-        tone="secondary"
-        size="sm"
-        onPress={controller.handleClearInstallmentGroupFilter}
-      >
-        Mostrar todas
-      </AppButton>
-    </XStack>
-  );
-}
-
-interface ExportSheetProps {
-  readonly onClose: () => void;
-  readonly onExport: (format: "csv" | "pdf") => Promise<void>;
-  readonly isExporting: boolean;
-  readonly error: unknown | null;
-  readonly dismissError: () => void;
-  readonly translate: (key: string) => string;
-}
-
-function ExportSheet({
-  onClose,
-  onExport,
-  isExporting,
-  error,
-  dismissError,
-  translate,
-}: ExportSheetProps): ReactElement {
-  return (
-    <YStack flex={1} backgroundColor="rgba(0,0,0,0.45)" justifyContent="flex-end">
-      <YStack
-        backgroundColor="$background"
-        padding="$4"
-        gap="$3"
-        borderTopLeftRadius="$3"
-        borderTopRightRadius="$3"
-      >
-        <AppSurfaceCard
-          title={translate("transactions.export.title")}
-          description={translate("transactions.export.description")}
-        >
-          <YStack gap="$3">
-            <XStack gap="$2">
-              <AppButton
-                flex={1}
-                onPress={() => {
-                  void onExport("csv");
-                }}
-                disabled={isExporting}
-              >
-                {translate("transactions.export.csv")}
-              </AppButton>
-              <AppButton
-                flex={1}
-                onPress={() => {
-                  void onExport("pdf");
-                }}
-                disabled={isExporting}
-              >
-                {translate("transactions.export.pdf")}
-              </AppButton>
-            </XStack>
-            {isExporting ? (
-              <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
-                {translate("transactions.export.submitting")}
-              </Paragraph>
-            ) : null}
-            {error ? (
-              <AppErrorNotice
-                error={error}
-                fallbackTitle={translate("transactions.export.errorTitle")}
-                fallbackDescription={translate(
-                  "transactions.export.errorDescription",
-                )}
-                secondaryActionLabel="Fechar"
-                onSecondaryAction={dismissError}
-              />
-            ) : null}
-            <AppButton tone="secondary" onPress={onClose}>
-              Fechar
-            </AppButton>
-          </YStack>
-        </AppSurfaceCard>
-      </YStack>
-    </YStack>
-  );
-}
-
-interface TransactionsListCardProps extends ControllerProps {
-  readonly listHeader: ReactElement;
-}
-
-function TransactionsListCard({
-  controller,
-  listHeader,
-}: TransactionsListCardProps): ReactElement {
-  const query = controller.transactionsQuery;
-
-  const listEmptyComponent = useMemo((): ReactElement => {
-    if (query.isPending) {
-      return <TransactionListSkeleton rows={5} />;
-    }
-    if (query.isError) {
-      return (
-        <AppErrorNotice
-          error={query.error}
-          fallbackTitle="Nao foi possivel carregar as transacoes"
-          fallbackDescription="Tente novamente em instantes."
-        />
-      );
-    }
-    return (
-      <AppEmptyState
-        illustration="transactions"
-        title="Nenhuma transacao no filtro atual"
-        description="Crie uma nova transacao no botao central ou troque o filtro para visualizar movimentos."
-      />
-    );
-  }, [query.isPending, query.isError, query.error]);
-
-  return (
-    <TransactionsList
-      controller={controller}
-      listHeader={listHeader}
-      listEmptyComponent={listEmptyComponent}
-    />
-  );
-}
-
-interface TransactionsListProps extends ControllerProps {
-  readonly listHeader: ReactElement;
-  readonly listEmptyComponent: ReactElement;
-}
-
-// eslint-disable-next-line max-lines-per-function
-function TransactionsList({
-  controller,
-  listHeader,
-  listEmptyComponent,
-}: TransactionsListProps): ReactElement {
-  const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
-  const [actionTarget, setActionTarget] = useState<TransactionViewModel | null>(null);
-  const [payTarget, setPayTarget] = useState<MarkPaidTarget | null>(null);
-  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
-
-  const openActions = useCallback((tx: TransactionViewModel): void => {
-    setActionTarget(tx);
-  }, []);
-
-  const requestPay = useCallback(
-    (txId: string): void => {
-      const tx = controller.transactions.find((item) => item.id === txId);
-      if (tx) {
-        setActionTarget(null);
-        setPayTarget({ id: tx.id, title: tx.title });
-      }
-    },
-    [controller.transactions],
-  );
-
-  const requestDelete = useCallback(
-    (txId: string): void => {
-      const tx = controller.transactions.find((item) => item.id === txId);
-      if (tx) {
-        setActionTarget(null);
-        setDeleteTarget({
-          id: tx.id,
-          title: tx.title,
-          isSeries: tx.isRecurring || tx.isInstallment,
-        });
-      }
-    },
-    [controller.transactions],
-  );
-
-  const handleEdit = useCallback(
-    (txId: string): void => {
-      const record = controller.transactionsQuery.data?.transactions.find(
-        (item) => item.id === txId,
-      );
-      if (record) {
-        setActionTarget(null);
-        controller.handleOpenEdit(record);
-      }
-    },
-    [controller],
-  );
-
-  const handleDuplicate = useCallback(
-    (txId: string): void => {
-      setActionTarget(null);
-      void controller.handleDuplicate(txId);
-    },
-    [controller],
-  );
-
-  const handleShowInstallmentGroup = useCallback(
-    (installmentGroupId: string): void => {
-      setActionTarget(null);
-      controller.handleShowInstallmentGroup(installmentGroupId);
-    },
-    [controller],
-  );
-
-  const renderItem = useCallback(
-    ({ item }: { readonly item: TransactionViewModel }) => (
-      <TransactionRow
-        tx={item}
-        onOpenActions={openActions}
-        onMarkPaid={requestPay}
-        onDelete={requestDelete}
-      />
-    ),
-    [openActions, requestPay, requestDelete],
-  );
-
-  return (
-    <>
-      <FlashList
-        data={controller.transactions}
-        keyExtractor={extractTransactionKey}
-        renderItem={renderItem}
-        ListHeaderComponent={listHeader}
-        ListEmptyComponent={listEmptyComponent}
-        contentContainerStyle={listContainerStyle}
-        ItemSeparatorComponent={RowSeparator}
-        refreshControl={
-          <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
-        }
-        showsVerticalScrollIndicator={false}
-        testID="transactions-flashlist"
-      />
-      <TransactionActionSheet
-        transaction={actionTarget}
-        isPaying={controller.payingTransactionId !== null}
-        isDuplicating={controller.duplicatingTransactionId !== null}
-        isDeleting={controller.deletingTransactionId !== null}
-        onClose={() => setActionTarget(null)}
-        onMarkPaid={requestPay}
-        onEdit={handleEdit}
-        onDuplicate={handleDuplicate}
-        onDelete={requestDelete}
-        onShowInstallmentGroup={handleShowInstallmentGroup}
-      />
-      <MarkPaidConfirmModal
-        target={payTarget}
-        isSubmitting={controller.payingTransactionId !== null}
-        onConfirm={(txId, paidAt) => {
-          void controller.handleMarkPaid(txId, paidAt);
-          setPayTarget(null);
-        }}
-        onClose={() => setPayTarget(null)}
-      />
-      <DeleteConfirmModal
-        target={deleteTarget}
-        isDeleting={controller.deletingTransactionId !== null}
-        onConfirm={(txId, scope) => {
-          void controller.handleDelete(txId, scope);
-          setDeleteTarget(null);
-        }}
-        onClose={() => setDeleteTarget(null)}
-      />
-    </>
-  );
-}
-
-const extractTransactionKey = (item: TransactionViewModel): string => item.id;
-
-const listContainerStyle = { paddingBottom: 24 } as const;
-
-function RowSeparator(): ReactElement {
-  return <YStack height={1} backgroundColor="$borderColor" />;
 }

--- a/features/transactions/utils/category-icon.test.ts
+++ b/features/transactions/utils/category-icon.test.ts
@@ -1,0 +1,35 @@
+import {
+  DEFAULT_CATEGORY_ICON,
+  resolveCategoryIcon,
+} from "@/features/transactions/utils/category-icon";
+
+describe("resolveCategoryIcon", () => {
+  it("mapeia apelidos de ícone conhecidos (case-insensitive)", () => {
+    expect(resolveCategoryIcon("cash", "Qualquer")).toBe("cash");
+    expect(resolveCategoryIcon("WALLET", "Qualquer")).toBe("wallet-outline");
+    expect(resolveCategoryIcon("credit-card", "Qualquer")).toBe("credit-card-outline");
+  });
+
+  it("infere pelo nome da categoria quando o ícone não é reconhecido", () => {
+    expect(resolveCategoryIcon(null, "Impostos")).toBe("file-document-outline");
+    expect(resolveCategoryIcon("desconhecido", "Salário")).toBe("briefcase-outline");
+    expect(resolveCategoryIcon(null, "Moradia")).toBe("home-outline");
+  });
+
+  it("ignora acentos e caixa ao inferir pelo nome", () => {
+    expect(resolveCategoryIcon(null, "ALIMENTAÇÃO")).toBe("silverware-fork-knife");
+    expect(resolveCategoryIcon(null, "Saúde")).toBe("heart-pulse");
+  });
+
+  it("usa o fallback quando não há pista de ícone nem nome", () => {
+    expect(resolveCategoryIcon(null, "Categoria Estranha")).toBe(
+      DEFAULT_CATEGORY_ICON,
+    );
+    expect(resolveCategoryIcon("", "")).toBe(DEFAULT_CATEGORY_ICON);
+  });
+
+  it("prioriza o apelido do ícone sobre a inferência por nome", () => {
+    // ícone "gift" tem prioridade mesmo com nome que casaria com outra regra.
+    expect(resolveCategoryIcon("gift", "Impostos")).toBe("gift-outline");
+  });
+});

--- a/features/transactions/utils/category-icon.ts
+++ b/features/transactions/utils/category-icon.ts
@@ -1,0 +1,136 @@
+/**
+ * Resolve o glifo de ícone (`MaterialCommunityIcons`) de uma categoria a partir
+ * do nome de ícone cru da Tag (API) e/ou do nome da categoria. O backend pode
+ * mandar nomes de bibliotecas diferentes (ou nenhum), então mapeamos apelidos
+ * conhecidos e, em último caso, inferimos pelo nome da categoria — sempre com
+ * um fallback estável. Função pura (sem React), unit-testável.
+ */
+
+/** Glifo padrão para categorias sem ícone reconhecível. */
+export const DEFAULT_CATEGORY_ICON = "tag-outline";
+
+/**
+ * Apelidos de ícone (em minúsculas) → glifo `MaterialCommunityIcons`. Cobre os
+ * nomes mais comuns que a API/seed pode enviar (lucide/feather/MCI), além das
+ * categorias do handoff de design (Impostos, Salário, Eletrônicos, etc.).
+ */
+const ICON_ALIASES: Readonly<Record<string, string>> = {
+  // Genéricos / dinheiro
+  cash: "cash",
+  money: "cash",
+  wallet: "wallet-outline",
+  bank: "bank-outline",
+  salary: "briefcase-outline",
+  briefcase: "briefcase-outline",
+  income: "cash-plus",
+  receipt: "receipt-text-outline",
+  tax: "file-document-outline",
+  taxes: "file-document-outline",
+  // Casa / contas
+  home: "home-outline",
+  house: "home-outline",
+  rent: "home-city-outline",
+  bolt: "lightning-bolt-outline",
+  zap: "lightning-bolt-outline",
+  energy: "lightning-bolt-outline",
+  water: "water-outline",
+  wifi: "wifi",
+  internet: "wifi",
+  phone: "cellphone",
+  // Compras / lazer
+  cart: "cart-outline",
+  "shopping-cart": "cart-outline",
+  shopping: "shopping-outline",
+  bag: "shopping-outline",
+  gift: "gift-outline",
+  electronics: "monitor",
+  monitor: "monitor",
+  laptop: "laptop",
+  gamepad: "gamepad-variant-outline",
+  game: "gamepad-variant-outline",
+  leisure: "party-popper",
+  movie: "movie-outline",
+  music: "music",
+  // Transporte
+  car: "car-outline",
+  bus: "bus",
+  fuel: "gas-station-outline",
+  plane: "airplane",
+  travel: "airplane",
+  // Comida / saúde
+  food: "silverware-fork-knife",
+  restaurant: "silverware-fork-knife",
+  coffee: "coffee-outline",
+  health: "heart-pulse",
+  medical: "medical-bag",
+  pet: "paw-outline",
+  // Serviços / assinaturas / cartão
+  service: "wrench-outline",
+  services: "wrench-outline",
+  subscription: "autorenew",
+  repeat: "autorenew",
+  card: "credit-card-outline",
+  "credit-card": "credit-card-outline",
+  financing: "chart-line",
+  education: "school-outline",
+};
+
+/**
+ * Palavras-chave do NOME da categoria (em minúsculas, sem acento) → glifo, para
+ * inferir o ícone quando a Tag não traz um nome de ícone reconhecível.
+ */
+const NAME_KEYWORDS: readonly (readonly [string, string])[] = [
+  ["imposto", "file-document-outline"],
+  ["salario", "briefcase-outline"],
+  ["eletronic", "monitor"],
+  ["servico", "wrench-outline"],
+  ["cartao", "credit-card-outline"],
+  ["financ", "chart-line"],
+  ["lazer", "party-popper"],
+  ["moradia", "home-outline"],
+  ["aluguel", "home-city-outline"],
+  ["internet", "wifi"],
+  ["pet", "paw-outline"],
+  ["mercado", "cart-outline"],
+  ["compra", "shopping-outline"],
+  ["transporte", "car-outline"],
+  ["viagem", "airplane"],
+  ["saude", "heart-pulse"],
+  ["aliment", "silverware-fork-knife"],
+  ["educa", "school-outline"],
+  ["assinatura", "autorenew"],
+];
+
+/** Normaliza para minúsculas sem acentos (para casar palavras-chave do nome). */
+const normalize = (value: string): string =>
+  value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[̀-ͯ]/g, "");
+
+/**
+ * Resolve o glifo `MaterialCommunityIcons` de uma categoria: tenta o apelido do
+ * ícone cru, depois infere por palavra-chave do nome e, por fim, usa o fallback.
+ *
+ * @param icon Nome de ícone cru da Tag (ou null).
+ * @param name Nome da categoria (usado para inferência).
+ * @returns Nome do glifo MCI a renderizar.
+ */
+export const resolveCategoryIcon = (
+  icon: string | null,
+  name: string,
+): string => {
+  if (icon) {
+    const alias = ICON_ALIASES[icon.trim().toLowerCase()];
+    if (alias) {
+      return alias;
+    }
+  }
+  const normalizedName = normalize(name);
+  for (const [keyword, glyph] of NAME_KEYWORDS) {
+    if (normalizedName.includes(keyword)) {
+      return glyph;
+    }
+  }
+  return DEFAULT_CATEGORY_ICON;
+};

--- a/features/transactions/utils/transaction-presentation.test.ts
+++ b/features/transactions/utils/transaction-presentation.test.ts
@@ -1,7 +1,9 @@
 import {
   formatStatusLabel,
+  formatStatusLabelForType,
   getInstallmentLabel,
   statusTone,
+  statusVisual,
 } from "@/features/transactions/utils/transaction-presentation";
 
 describe("transaction-presentation", () => {
@@ -25,6 +27,35 @@ describe("transaction-presentation", () => {
 
     it("faz fallback para o valor cru quando desconhecido", () => {
       expect(formatStatusLabel("weird")).toBe("weird");
+    });
+  });
+
+  describe("statusVisual", () => {
+    it("mapeia tom semântico + ícone dos estados conhecidos", () => {
+      expect(statusVisual("paid").tone).toBe("success");
+      expect(statusVisual("pending").tone).toBe("warning");
+      expect(statusVisual("overdue").tone).toBe("danger");
+      expect(statusVisual("paid").icon).toBe("check-circle-outline");
+    });
+
+    it("usa fallback neutro para estado desconhecido", () => {
+      expect(statusVisual("weird").tone).toBe("neutral");
+      expect(statusVisual("weird").icon).toBe("circle-outline");
+    });
+  });
+
+  describe("formatStatusLabelForType", () => {
+    it("mostra 'Recebido' para receita paga", () => {
+      expect(formatStatusLabelForType("paid", "income")).toBe("Recebido");
+    });
+
+    it("mostra 'Pago' para despesa paga", () => {
+      expect(formatStatusLabelForType("paid", "expense")).toBe("Pago");
+    });
+
+    it("delega para o rótulo padrão nos demais estados", () => {
+      expect(formatStatusLabelForType("overdue", "expense")).toBe("Vencido");
+      expect(formatStatusLabelForType("pending", "income")).toBe("Pendente");
     });
   });
 

--- a/features/transactions/utils/transaction-presentation.ts
+++ b/features/transactions/utils/transaction-presentation.ts
@@ -1,3 +1,5 @@
+import type { TransactionType } from "@/features/transactions/contracts";
+
 /** Tom do badge de status por estado da transação. */
 export const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
   paid: "primary",
@@ -5,6 +7,64 @@ export const STATUS_TONE: Record<string, "default" | "primary" | "danger"> = {
   overdue: "danger",
   cancelled: "default",
   postponed: "default",
+};
+
+/**
+ * Tom semântico do chip de status no FEED redesenhado. Mapeia para os tokens
+ * de cor do tema (`$success`/`$warning`/`$danger`/`$muted`) — a resolução em
+ * cor concreta fica no componente, mantendo o `.tsx` livre de hex.
+ */
+export type StatusVisualTone = "success" | "warning" | "danger" | "neutral";
+
+interface StatusVisual {
+  /** Tom semântico (token de cor do tema). */
+  readonly tone: StatusVisualTone;
+  /** Glifo do `MaterialCommunityIcons` que ilustra o status. */
+  readonly icon: string;
+}
+
+/** Descritor visual (tom + ícone) por estado da transação. */
+const STATUS_VISUAL: Record<string, StatusVisual> = {
+  paid: { tone: "success", icon: "check-circle-outline" },
+  pending: { tone: "warning", icon: "clock-outline" },
+  overdue: { tone: "danger", icon: "alert-circle-outline" },
+  cancelled: { tone: "neutral", icon: "close-circle-outline" },
+  postponed: { tone: "neutral", icon: "calendar-clock-outline" },
+};
+
+/** Descritor visual padrão para estados desconhecidos. */
+const FALLBACK_STATUS_VISUAL: StatusVisual = {
+  tone: "neutral",
+  icon: "circle-outline",
+};
+
+/**
+ * Resolve o tom semântico + ícone do chip de status (feed redesenhado), com
+ * fallback neutro seguro para estados não mapeados.
+ *
+ * @param status Estado cru da transação (inglês, vindo da API).
+ * @returns Descritor visual (tom de tema + glifo MCI).
+ */
+export const statusVisual = (status: string): StatusVisual =>
+  STATUS_VISUAL[status] ?? FALLBACK_STATUS_VISUAL;
+
+/**
+ * Rótulo do status sensível ao tipo: uma receita paga é exibida como
+ * "Recebido" (em vez de "Pago"), espelhando o design. Demais casos delegam
+ * para `formatStatusLabel`.
+ *
+ * @param status Estado cru da transação.
+ * @param type Tipo da transação (receita/despesa).
+ * @returns Rótulo pt-BR do status.
+ */
+export const formatStatusLabelForType = (
+  status: string,
+  type: TransactionType,
+): string => {
+  if (status === "paid" && type === "income") {
+    return "Recebido";
+  }
+  return formatStatusLabel(status);
 };
 
 /** Rótulo pt-BR do status (o backend devolve em inglês). */

--- a/shared/theme/on-dark-surface.ts
+++ b/shared/theme/on-dark-surface.ts
@@ -27,6 +27,10 @@ export const onDarkSurfaceColors = {
   gloss: "rgba(255,255,255,0.12)",
   /** Glifo do chip dourado da face do cartão. */
   chip: "#E9C877",
+  /** Verde de receita/positivo legível sobre o hero teal escuro. */
+  positive: "#7FE3B8",
+  /** Vermelho de despesa/negativo legível sobre o hero teal escuro. */
+  negative: "#FF9EA1",
 } as const;
 
 export type OnDarkSurfaceColorKey = keyof typeof onDarkSurfaceColors;

--- a/shared/utils/formatters.test.ts
+++ b/shared/utils/formatters.test.ts
@@ -1,6 +1,7 @@
 import {
   formatCurrency,
   formatCurrencyShort,
+  formatCurrencySigned,
   formatPercent,
   formatShortDate,
 } from "@/shared/utils/formatters";
@@ -46,5 +47,40 @@ describe("formatCurrencyShort", () => {
   it("trata negativos preservando o sinal", () => {
     expect(formatCurrencyShort(-2500)).toContain("-");
     expect(formatCurrencyShort(-2500)).toContain("2,5");
+  });
+});
+
+describe("formatCurrencySigned", () => {
+  // Intl.NumberFormat (pt-BR/BRL) usa espaço não separável (U+00A0) entre
+  // "R$" e o número; normalizamos para espaço comum nas comparações exatas.
+  const normalizeSpaces = (value: string): string => value.replace(/ /g, " ");
+
+  it("prefixa valores positivos com sinal de mais e o valor absoluto", () => {
+    const result = formatCurrencySigned(27675.37);
+    expect(result.startsWith("+ ")).toBe(true);
+    expect(result).toContain("R$");
+    expect(result).toContain("27.675,37");
+    expect(result).not.toContain("-");
+    expect(result).not.toContain("−");
+  });
+
+  it("prefixa valores negativos com sinal de menos tipográfico (U+2212)", () => {
+    const result = formatCurrencySigned(-2000);
+    expect(result.startsWith("− ")).toBe(true);
+    expect(result).toContain("R$");
+    expect(result).toContain("2.000,00");
+    // Usa o valor absoluto: o "-" do Intl não vaza para dentro da string.
+    expect(result).not.toContain("-");
+  });
+
+  it("formata zero sem sinal", () => {
+    const result = formatCurrencySigned(0);
+    expect(normalizeSpaces(result)).toBe("R$ 0,00");
+    expect(result).not.toContain("+");
+    expect(result).not.toContain("−");
+  });
+
+  it("trata -0 como zero (sem sinal)", () => {
+    expect(normalizeSpaces(formatCurrencySigned(-0))).toBe("R$ 0,00");
   });
 });

--- a/shared/utils/formatters.ts
+++ b/shared/utils/formatters.ts
@@ -43,6 +43,26 @@ export const formatCurrencyShort = (value: number): string => {
   return `R$ ${wholeFormatter.format(value)}`;
 };
 
+/** Sinal de menos tipográfico (U+2212), usado no design do feed. */
+const MINUS_SIGN = "−";
+
+/**
+ * Formata um valor monetário com sinal explícito para o feed de transações.
+ * Positivos recebem "+ ", negativos o sinal de menos tipográfico (U+2212) "− "
+ * e o módulo formatado; zero é exibido como "R$ 0,00" sem sinal.
+ *
+ * @param value Valor numérico em reais (positivo = entrada, negativo = saída).
+ * @returns String monetária com sinal em pt-BR (ex.: "+ R$ 27.675,37").
+ */
+export const formatCurrencySigned = (value: number): string => {
+  if (value === 0) {
+    return currencyFormatter.format(0);
+  }
+  const amount = currencyFormatter.format(Math.abs(value));
+  const sign = value > 0 ? "+" : MINUS_SIGN;
+  return `${sign} ${amount}`;
+};
+
 export const formatPercent = (value: number): string => {
   return `${percentFormatter.format(value)}%`;
 };


### PR DESCRIPTION
## Resumo
Redesign da tela de **Transações** (feed) com base no handoff `design-handoff-transacoes-mobile/`. Dois modos **Fácil | Analítico**, hero teal com KPIs (Resultado/receitas/despesas), cards com categoria/status/data relativa, e breakdown por categoria (HBars) no Analítico. Reaproveita a linguagem visual + primitivos do redesign de Cartões. **OTA-safe** (sem dependências nativas novas).

### O que entrou
- **Lógica (T0):** `formatCurrencySigned`; model do feed (KPIs, agregação por categoria, data relativa, % do total); controller "wrap" (Fácil/Analítico) sem tocar no controller existente.
- **UI (T1):** `TxHero`, mode toggle, `TxCard` (borda de categoria + chip de ícone + status + data relativa + footer analítico), `CategoryBreakdown` (HBars), tela recomposta (592→79 linhas).
- **Funcionalidade preservada:** filtros (tipo/status/tag), calendário (toggle no header), swipe (pagar/excluir), form criar/editar, export, lixeira, importação, action sheet/modais.

### Verificação
- `npm run quality-check` ✅ (lint + typecheck + policy + contracts + codegen + test:coverage) — **2471 testes**, cobertura ≥ 85%.

### Pendências (validação em device — OTA, sem novo build)
- [ ] Validar visualmente no **mesmo dev build Android** (só reload do Metro — sem `eas build`).
- [ ] Pixel-polish: tamanho da fonte do "Resultado", glifos de ícone por categoria, alpha do chip.

## Refs
Closes #590

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx