### PR TITLE
chore(eas): habilita build preview para teste em device (fix Sentry)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -19,6 +19,9 @@
       "distribution": "internal",
       "channel": "preview",
       "autoIncrement": true,
+      "env": {
+        "SENTRY_DISABLE_AUTO_UPLOAD": "true"
+      },
       "android": {
         "buildType": "apk"
       },


### PR DESCRIPTION
Adiciona `SENTRY_DISABLE_AUTO_UPLOAD=true` ao perfil `preview` (igual ao `development`) para que `eas build --profile preview` builde iOS sem falhar no upload de source maps do Sentry ("An organization ID or slug is required"). Necessário para gerar builds standalone de teste nos devices (S26 Ultra + iPhone 16 Pro Max).

Produção: configurar o org do Sentry de verdade depois (não desabilitar source maps em prod).

Closes #593

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx