### PR TITLE
feat(transactions): animações de entrada transform-only no feed

### DIFF
--- a/features/transactions/components/transaction-feed-list.tsx
+++ b/features/transactions/components/transaction-feed-list.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/features/transactions/hooks/use-transaction-feed-actions";
 import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
 import type { TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+import { RevealInView } from "@/shared/animations/reveal-in-view";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { useListRefresh } from "@/shared/hooks/use-list-refresh";
@@ -49,14 +50,22 @@ function FeedList({
   const { refreshing, onRefresh } = useListRefresh(TRANSACTIONS_REFRESH_KEYS);
 
   const renderItem = useCallback(
-    ({ item }: { readonly item: TransactionFeedItem }) => (
-      <TxCard
-        item={item}
-        analytic={controller.viewMode === "analitico"}
-        onPress={handlers.openActions}
-        onMarkPaid={handlers.requestPay}
-        onDelete={handlers.requestDelete}
-      />
+    ({
+      item,
+      index,
+    }: {
+      readonly item: TransactionFeedItem;
+      readonly index: number;
+    }) => (
+      <RevealInView index={index}>
+        <TxCard
+          item={item}
+          analytic={controller.viewMode === "analitico"}
+          onPress={handlers.openActions}
+          onMarkPaid={handlers.requestPay}
+          onDelete={handlers.requestDelete}
+        />
+      </RevealInView>
     ),
     [controller.viewMode, handlers],
   );

--- a/features/transactions/components/transaction-feed-toolbar.tsx
+++ b/features/transactions/components/transaction-feed-toolbar.tsx
@@ -18,6 +18,7 @@ import { TxCategoryBreakdown } from "@/features/transactions/components/tx-categ
 import { TxModeToggle } from "@/features/transactions/components/tx-mode-toggle";
 import type { TransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
 import { useTransactionsExport } from "@/features/transactions/hooks/use-transactions-export";
+import { RevealInView } from "@/shared/animations/reveal-in-view";
 import { AppButton } from "@/shared/components/app-button";
 import { isFeatureEnabled } from "@/shared/feature-flags";
 import { useT } from "@/shared/i18n";
@@ -133,7 +134,9 @@ function FeedToolbar({
       ) : null}
       <InstallmentGroupFilterNotice controller={controller} />
       {controller.viewMode === "analitico" ? (
-        <TxCategoryBreakdown categories={controller.categoryBars} />
+        <RevealInView index={1}>
+          <TxCategoryBreakdown categories={controller.categoryBars} />
+        </RevealInView>
       ) : null}
       <AiInsightSurface dimension="transactions" />
     </YStack>

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -8,6 +8,7 @@ import { TransactionFeed } from "@/features/transactions/components/transaction-
 import { TransactionForm } from "@/features/transactions/components/transaction-form";
 import { TxHero } from "@/features/transactions/components/tx-hero";
 import { useTransactionsFeedController } from "@/features/transactions/hooks/use-transactions-feed-controller";
+import { RevealInView } from "@/shared/animations/reveal-in-view";
 import { AppScreen } from "@/shared/components/app-screen";
 
 /**
@@ -46,14 +47,16 @@ export function TransactionsScreen(): ReactElement {
   }
 
   const hero = (
-    <TxHero
-      periodLabel={controller.periodLabel}
-      kpis={controller.heroKpis}
-      isDark={isDark}
-      onToggleTheme={() => setThemePreference(isDark ? "light" : "dark")}
-      onToggleCalendar={controller.toggleCalendar}
-      calendarActive={controller.calendarActive}
-    />
+    <RevealInView index={0}>
+      <TxHero
+        periodLabel={controller.periodLabel}
+        kpis={controller.heroKpis}
+        isDark={isDark}
+        onToggleTheme={() => setThemePreference(isDark ? "light" : "dark")}
+        onToggleCalendar={controller.toggleCalendar}
+        calendarActive={controller.calendarActive}
+      />
+    </RevealInView>
   );
 
   if (controller.calendarActive) {

--- a/shared/animations/reveal-in-view.test.tsx
+++ b/shared/animations/reveal-in-view.test.tsx
@@ -1,0 +1,32 @@
+import { render } from "@testing-library/react-native";
+import { Text } from "react-native";
+
+import { resetAppShellStore } from "@/core/shell/app-shell-store";
+
+import { RevealInView } from "./reveal-in-view";
+
+describe("RevealInView", () => {
+  beforeEach(() => {
+    resetAppShellStore();
+  });
+
+  it("renderiza o conteúdo filho", () => {
+    const { getByText } = render(
+      <RevealInView index={0}>
+        <Text>conteúdo do reveal</Text>
+      </RevealInView>,
+    );
+
+    expect(getByText("conteúdo do reveal")).toBeTruthy();
+  });
+
+  it("expõe o testID para asserção nas telas hospedeiras", () => {
+    const { getByTestId } = render(
+      <RevealInView index={3} testID="reveal-secao">
+        <Text>x</Text>
+      </RevealInView>,
+    );
+
+    expect(getByTestId("reveal-secao")).toBeTruthy();
+  });
+});

--- a/shared/animations/reveal-in-view.tsx
+++ b/shared/animations/reveal-in-view.tsx
@@ -1,0 +1,34 @@
+import type { ReactElement, ReactNode } from "react";
+
+import Animated from "react-native-reanimated";
+
+import { useRevealAnimation } from "@/shared/animations/use-reveal-animation";
+
+export interface RevealInViewProps {
+  readonly children: ReactNode;
+  /** Posição na lista/composição — escalona o atraso (stagger) da entrada. */
+  readonly index?: number;
+  readonly testID?: string;
+}
+
+/**
+ * Revela o conteúdo com um deslize curto + leve escala (**transform-only**, sem
+ * fade por opacidade), em cascata por `index`, respeitando "Reduzir movimento".
+ * Análogo ao `AppReveal`, porém sem animar opacidade.
+ *
+ * @param props Conteúdo, índice opcional para o stagger e estilo/testID.
+ * @returns Wrapper animado de entrada (transform-only).
+ */
+export function RevealInView({
+  children,
+  index = 0,
+  testID,
+}: RevealInViewProps): ReactElement {
+  const animatedStyle = useRevealAnimation(index);
+
+  return (
+    <Animated.View testID={testID} style={animatedStyle}>
+      {children}
+    </Animated.View>
+  );
+}

--- a/shared/animations/use-reveal-animation.test.ts
+++ b/shared/animations/use-reveal-animation.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { resetAppShellStore, useAppShellStore } from "@/core/shell/app-shell-store";
+import { motionStagger, motionTranslate } from "@/shared/theme";
+
+import {
+  REVEAL_FROM_SCALE,
+  REVEAL_STAGGER_CAP,
+  revealDelay,
+  revealFromOffset,
+  useRevealAnimation,
+} from "./use-reveal-animation";
+
+describe("revealDelay", () => {
+  it("não atrasa o primeiro item (índice 0)", () => {
+    expect(revealDelay(0)).toBe(0);
+  });
+
+  it("escalona o atraso por índice usando o token de stagger", () => {
+    expect(revealDelay(1)).toBe(motionStagger);
+    expect(revealDelay(3)).toBe(3 * motionStagger);
+  });
+
+  it("limita o atraso no cap para não acumular em listas longas", () => {
+    expect(revealDelay(REVEAL_STAGGER_CAP + 7)).toBe(
+      REVEAL_STAGGER_CAP * motionStagger,
+    );
+  });
+
+  it("trata índice negativo como zero (sem atraso negativo)", () => {
+    expect(revealDelay(-3)).toBe(0);
+  });
+});
+
+describe("revealFromOffset", () => {
+  it("parte deslocado em Y e levemente reduzido quando há movimento", () => {
+    expect(revealFromOffset(false)).toEqual({
+      translateY: motionTranslate.revealY,
+      scale: REVEAL_FROM_SCALE,
+    });
+  });
+
+  it("parte do repouso (sem deslocamento) quando 'reduzir movimento' está ativo", () => {
+    expect(revealFromOffset(true)).toEqual({ translateY: 0, scale: 1 });
+  });
+});
+
+describe("useRevealAnimation", () => {
+  beforeEach(() => {
+    resetAppShellStore();
+  });
+
+  it("anima apenas transform — nunca opacidade (sem fade)", () => {
+    const { result } = renderHook(() => useRevealAnimation(0));
+
+    expect(result.current).toHaveProperty("transform");
+    expect(result.current).not.toHaveProperty("opacity");
+  });
+
+  it("compõe translateY e scale no transform de entrada", () => {
+    const { result } = renderHook(() => useRevealAnimation(0));
+
+    const keys = result.current.transform.flatMap((entry) =>
+      Object.keys(entry),
+    );
+
+    expect(keys).toContain("translateY");
+    expect(keys).toContain("scale");
+  });
+
+  it("permanece em repouso quando 'reduzir movimento' está ativo", () => {
+    useAppShellStore.getState().setReducedMotionEnabled(true);
+
+    const { result } = renderHook(() => useRevealAnimation(5));
+
+    expect(result.current.transform).toContainEqual({ translateY: 0 });
+    expect(result.current.transform).toContainEqual({ scale: 1 });
+  });
+});

--- a/shared/animations/use-reveal-animation.ts
+++ b/shared/animations/use-reveal-animation.ts
@@ -1,0 +1,88 @@
+import { useEffect } from "react";
+
+import {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from "react-native-reanimated";
+
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import {
+  motionDurations,
+  motionEasings,
+  motionStagger,
+  motionTranslate,
+} from "@/shared/theme";
+
+/**
+ * Máximo de posições que ainda recebem atraso em cascata. Acima disso o item
+ * entra sem stagger — evita atraso acumulado (e re-animação na reciclagem da
+ * FlashList) em listas longas.
+ */
+export const REVEAL_STAGGER_CAP = 8;
+
+/** Escala inicial do reveal (transform-only): leve encolhimento antes do repouso. */
+export const REVEAL_FROM_SCALE = 0.985;
+
+/** Atraso de entrada (ms) da posição `index`, limitado ao cap e nunca negativo. */
+export function revealDelay(index: number): number {
+  const clamped = Math.min(Math.max(index, 0), REVEAL_STAGGER_CAP);
+  return clamped * motionStagger;
+}
+
+export interface RevealOffset {
+  readonly translateY: number;
+  readonly scale: number;
+}
+
+/**
+ * Posição inicial do reveal. Com "Reduzir movimento" ativo, parte já do repouso
+ * (sem deslocamento), de modo que a entrada seja instantânea.
+ */
+export function revealFromOffset(reducedMotion: boolean): RevealOffset {
+  if (reducedMotion) {
+    return { translateY: 0, scale: 1 };
+  }
+  return { translateY: motionTranslate.revealY, scale: REVEAL_FROM_SCALE };
+}
+
+/**
+ * Anima a entrada de um item/seção com um deslize curto (`translateY`) e uma
+ * leve escala, em cascata por `index`. É **transform-only**: nunca anima
+ * opacidade (sem fade). Respeita a preferência "Reduzir movimento".
+ *
+ * O tipo de retorno é inferido de `useAnimatedStyle` (de propósito — anotá-lo
+ * como `ReturnType<typeof useAnimatedStyle>` colapsa para `DefaultStyle` e
+ * deixa de casar com o `style` do `Animated.View`).
+ *
+ * @param index Posição na lista/composição — escalona o atraso da entrada.
+ * @returns Estilo animado (transform-only) para aplicar num `Animated.View`.
+ */
+export function useRevealAnimation(index: number) {
+  const reducedMotion = useAppShellStore((state) => state.reducedMotionEnabled);
+  const from = revealFromOffset(reducedMotion);
+  const translateY = useSharedValue(from.translateY);
+  const scale = useSharedValue(from.scale);
+
+  useEffect(() => {
+    if (reducedMotion) {
+      translateY.value = 0;
+      scale.value = 1;
+      return;
+    }
+
+    const delay = revealDelay(index);
+    const timing = {
+      duration: motionDurations.normal,
+      easing: Easing.bezier(...motionEasings.emphasized),
+    };
+    translateY.value = withDelay(delay, withTiming(0, timing));
+    scale.value = withDelay(delay, withTiming(1, timing));
+  }, [index, reducedMotion, scale, translateY]);
+
+  return useAnimatedStyle(() => ({
+    transform: [{ translateY: translateY.value }, { scale: scale.value }],
+  }));
+}


### PR DESCRIPTION
## Resumo

Adiciona o **reveal de entrada transform-only** (sem fade por opacidade) ao feed de Transações: o hero, o painel "Gastos por categoria" e os cards entram deslizando (`translateY`) com leve `scale`, em cascata, respeitando "Reduzir movimento".

Fecha o gap do redesign #591, que entregou os modos Fácil/Analítico mas não trouxe as animações de entrada do design handoff.

## Mudanças

- 🆕 `shared/animations/use-reveal-animation.ts` — hook transform-only + lógica pura (`revealDelay`, `revealFromOffset`)
- 🆕 `shared/animations/reveal-in-view.tsx` — wrapper `<RevealInView index={i}>`
- ✏️ hero (`transactions-screen`), painel de categorias (`transaction-feed-toolbar`) e cards (`transaction-feed-list`) envolvidos com o reveal; os controles (period nav, toggle, ações) ficam estáticos.

Reutiliza os tokens de motion já existentes no DS (`motionTranslate.revealY`, `motionStagger`, `motionEasings`) — sem hardcode. Análogo ao `AppReveal`, porém transform-only (o `AppReveal` usa `FadeIn`/opacidade).

## Como testar

- `npm run quality-check` — verde (384 suítes, 2482 testes, cobertura ≥85%).
- Visual: abrir **Transações** → hero, painel e cards entram em cascata deslizando de baixo, **sem fade**; alternar Fácil/Analítico; ativar "Reduzir movimento" no SO → entrada instantânea.

## Notas

- Cobertura do requisito "transform-only" garantida por teste: o hook prova que o estilo anima `transform` e **nunca** `opacity`.
- Trade-off conhecido: por usar o índice do item no `FlashList` (que recicla views), cada card re-anima sutilmente ao entrar na viewport durante o scroll (8px/180ms). Intencional e sutil; hero e painel montam uma vez.

Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx
