### PR TITLE
feat(transactions): selo "fatura {mês}" em lançamentos de cartão no feed

### DIFF
--- a/features/transactions/components/tx-card-body.tsx
+++ b/features/transactions/components/tx-card-body.tsx
@@ -5,7 +5,11 @@ import { Pressable } from "react-native";
 import { Paragraph, XStack, YStack, useTheme } from "tamagui";
 
 import type { TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
-import { TxCategoryChip, TxStatusChip } from "@/features/transactions/components/tx-chips";
+import {
+  TxCategoryChip,
+  TxInvoiceChip,
+  TxStatusChip,
+} from "@/features/transactions/components/tx-chips";
 import { AppMoneyText } from "@/shared/components/app-money-text";
 import { AppText } from "@/shared/components/app-text";
 import { colorPalette, iconSizes } from "@/shared/theme";
@@ -164,6 +168,9 @@ export function TxCardBody({ item, analytic }: TxCardBodyProps): ReactElement {
         ) : null}
         <XStack alignItems="center" gap="$2" flexWrap="wrap">
           <TxStatusChip status={item.status} type={item.type} />
+          {item.invoiceBadgeMonth ? (
+            <TxInvoiceChip month={item.invoiceBadgeMonth} />
+          ) : null}
           <XStack alignItems="center" gap="$1">
             <MaterialCommunityIcons
               name="calendar-blank-outline"

--- a/features/transactions/components/tx-chips.tsx
+++ b/features/transactions/components/tx-chips.tsx
@@ -10,6 +10,7 @@ import {
   statusVisual,
   type StatusVisualTone,
 } from "@/features/transactions/utils/transaction-presentation";
+import { useT } from "@/shared/i18n";
 import { iconSizes } from "@/shared/theme";
 
 /** Fundo do chip de categoria como fração de opacidade da cor da categoria. */
@@ -75,6 +76,60 @@ export function TxStatusChip({ status, type }: TxStatusChipProps): ReactElement 
       />
       <Paragraph fontFamily="$body" fontWeight="$7" fontSize="$1" color={toneColor}>
         {label}
+      </Paragraph>
+    </XStack>
+  );
+}
+
+/** Opacidade do fundo do selo de fatura (sutil, sobre a cor neutra). */
+const INVOICE_CHIP_BG_OPACITY = 0.1;
+
+/** Props do selo discreto de fatura. */
+export interface TxInvoiceChipProps {
+  /** Rótulo curto do mês da fatura (ex.: "jul/26"). */
+  readonly month: string;
+}
+
+/**
+ * Selo discreto "fatura {mmm/aa}" para lançamentos de cartão cuja compra caiu
+ * na fatura de outro mês (agrupados pelo ciclo de fechamento). Usa tom neutro
+ * (`$muted`) com fundo de baixa opacidade — mesmo idioma visual dos chips do
+ * feed, porém mais quieto, por ser apenas informativo. O texto vem do i18n.
+ *
+ * @param props Mês curto da fatura.
+ * @returns Selo informativo de fatura.
+ */
+export function TxInvoiceChip({ month }: TxInvoiceChipProps): ReactElement {
+  const { t } = useT();
+  const theme = useTheme();
+  const toneColor = theme.muted?.val ?? theme.color?.val ?? "#000000";
+
+  return (
+    <XStack
+      alignItems="center"
+      gap="$1"
+      paddingHorizontal="$2"
+      paddingVertical="$1"
+      borderRadius="$5"
+      overflow="hidden"
+      testID="tx-invoice-chip"
+    >
+      <YStack
+        position="absolute"
+        top={0}
+        left={0}
+        right={0}
+        bottom={0}
+        backgroundColor={toneColor}
+        opacity={INVOICE_CHIP_BG_OPACITY}
+      />
+      <MaterialCommunityIcons
+        name="credit-card-outline"
+        size={iconSizes.xs}
+        color={toneColor}
+      />
+      <Paragraph fontFamily="$body" fontWeight="$6" fontSize="$1" color={toneColor}>
+        {t("transactions.feed.invoiceBadge", { month })}
       </Paragraph>
     </XStack>
   );

--- a/features/transactions/components/tx-components.test.tsx
+++ b/features/transactions/components/tx-components.test.tsx
@@ -7,8 +7,13 @@ import { TxCard } from "@/features/transactions/components/tx-card";
 import { TxCategoryBreakdown } from "@/features/transactions/components/tx-category-breakdown";
 import { TxHero } from "@/features/transactions/components/tx-hero";
 import { TxModeToggle } from "@/features/transactions/components/tx-mode-toggle";
-import { TxCategoryChip, TxStatusChip } from "@/features/transactions/components/tx-chips";
+import {
+  TxCategoryChip,
+  TxInvoiceChip,
+  TxStatusChip,
+} from "@/features/transactions/components/tx-chips";
 import type { CategoryBar, TransactionFeedItem } from "@/features/transactions/model/transactions-feed";
+import { initI18n } from "@/shared/i18n";
 
 // Mocka o ReanimatedSwipeable: renderiza as right actions + os children, para
 // exercitar tap/Pagar/Excluir sem o wrapper nativo (mesmo padrão do row).
@@ -58,6 +63,7 @@ const item: TransactionFeedItem = {
   dateDisplay: "em 9 dias",
   signedDisplay: "− R$ 2.000,00",
   percentOfFlow: 10,
+  invoiceBadgeMonth: "jul/26",
 };
 
 const incomeItem: TransactionFeedItem = {
@@ -69,12 +75,17 @@ const incomeItem: TransactionFeedItem = {
   signedDisplay: "+ R$ 27.675,37",
   categoryColor: "#11A36B",
   percentOfFlow: 100,
+  invoiceBadgeMonth: null,
 };
 
 const bars: readonly CategoryBar[] = [
   { tagId: "t1", name: "Cartão", color: "#FF8A3D", total: 11000 },
   { tagId: "t2", name: "Financiamento", color: "#0E6376", total: 2650 },
 ];
+
+beforeAll(async () => {
+  await initI18n("pt");
+});
 
 describe("TxHero", () => {
   it("mostra título, período + contagem e o resultado", () => {
@@ -169,6 +180,32 @@ describe("TxCard", () => {
     expect(getByText("Recebido")).toBeTruthy();
     expect(getByText("100% do total")).toBeTruthy();
   });
+
+  it("mostra o selo de fatura quando o lançamento de cartão veio de outro mês", () => {
+    const { getByText } = wrap(
+      <TxCard
+        item={item}
+        analytic={false}
+        onPress={jest.fn()}
+        onMarkPaid={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(getByText("fatura jul/26")).toBeTruthy();
+  });
+
+  it("não mostra o selo de fatura quando invoiceBadgeMonth é null", () => {
+    const { queryByTestId } = wrap(
+      <TxCard
+        item={incomeItem}
+        analytic={false}
+        onPress={jest.fn()}
+        onMarkPaid={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    );
+    expect(queryByTestId("tx-invoice-chip")).toBeNull();
+  });
 });
 
 describe("TxCategoryBreakdown", () => {
@@ -195,5 +232,11 @@ describe("tx-chips", () => {
       <TxCategoryChip color="#E5484D" icon="tax" name="Impostos" />,
     );
     expect(toJSON()).toBeTruthy();
+  });
+
+  it("TxInvoiceChip compõe o rótulo 'fatura {mmm/aa}' via i18n", () => {
+    const { getByText, getByTestId } = wrap(<TxInvoiceChip month="jul/26" />);
+    expect(getByTestId("tx-invoice-chip")).toBeTruthy();
+    expect(getByText("fatura jul/26")).toBeTruthy();
   });
 });

--- a/features/transactions/hooks/use-transactions-feed-controller.ts
+++ b/features/transactions/hooks/use-transactions-feed-controller.ts
@@ -112,8 +112,10 @@ export function useTransactionsFeedController(): TransactionsFeedController {
           (tx) => tx.installmentGroupId === base.installmentGroupFilter,
         )
       : records;
-    return visible.map((tx) => toFeedItem({ tx, tags, kpis: heroKpis, today }));
-  }, [records, tags, heroKpis, base.installmentGroupFilter]);
+    return visible.map((tx) =>
+      toFeedItem({ tx, tags, kpis: heroKpis, today, selectedMonth: base.selectedMonth }),
+    );
+  }, [records, tags, heroKpis, base.installmentGroupFilter, base.selectedMonth]);
 
   return {
     ...base,

--- a/features/transactions/hooks/use-transactions-screen-controller.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.ts
@@ -45,7 +45,7 @@ export interface TransactionViewModel {
   readonly installmentNumber: number | null;
 }
 
-interface SelectedMonth {
+export interface SelectedMonth {
   readonly year: number;
   readonly month: number;
 }
@@ -65,6 +65,8 @@ export interface TransactionsScreenController {
   readonly tagFilter: TransactionsTagFilter;
   readonly setTagFilter: (filter: TransactionsTagFilter) => void;
   readonly periodLabel: string;
+  /** Mês selecionado no feed (year + month 0-indexado), para o selo de fatura. */
+  readonly selectedMonth: SelectedMonth;
   readonly goToPreviousMonth: () => void;
   readonly goToNextMonth: () => void;
   readonly resetToCurrentMonth: () => void;
@@ -229,6 +231,7 @@ interface TransactionsFiltersState {
   readonly tagFilter: TransactionsTagFilter;
   readonly setTagFilter: (filter: TransactionsTagFilter) => void;
   readonly periodLabel: string;
+  readonly selectedMonth: SelectedMonth;
   readonly goToPreviousMonth: () => void;
   readonly goToNextMonth: () => void;
   readonly resetToCurrentMonth: () => void;
@@ -258,6 +261,7 @@ function useTransactionsFilters(): TransactionsFiltersState {
     tagFilter,
     setTagFilter,
     periodLabel: formatMonthLabel(selectedMonth),
+    selectedMonth,
     goToPreviousMonth: () => setSelectedMonth((current) => shiftMonth(current, -1)),
     goToNextMonth: () => setSelectedMonth((current) => shiftMonth(current, 1)),
     resetToCurrentMonth: () => setSelectedMonth(currentMonth()),
@@ -502,6 +506,7 @@ export function useTransactionsScreenController(): TransactionsScreenController 
     tagFilter: filters.tagFilter,
     setTagFilter: filters.setTagFilter,
     periodLabel: filters.periodLabel,
+    selectedMonth: filters.selectedMonth,
     goToPreviousMonth: filters.goToPreviousMonth,
     goToNextMonth: filters.goToNextMonth,
     resetToCurrentMonth: filters.resetToCurrentMonth,

--- a/features/transactions/model/invoice-badge.test.ts
+++ b/features/transactions/model/invoice-badge.test.ts
@@ -1,0 +1,89 @@
+import {
+  invoiceBadgeMonthLabel,
+  resolveInvoiceBadgeMonth,
+  type SelectedMonthRef,
+} from "@/features/transactions/model/invoice-badge";
+
+/** Julho/2026 — mês 0-indexado (6 = julho), espelha o `SelectedMonth` do controller. */
+const JULY_2026: SelectedMonthRef = { year: 2026, month: 6 };
+
+describe("invoiceBadgeMonthLabel", () => {
+  it("formata o mês curto pt-BR como 'mmm/aa' (sem ponto)", () => {
+    expect(invoiceBadgeMonthLabel(JULY_2026)).toBe("jul/26");
+  });
+
+  it("formata janeiro e dezembro corretamente", () => {
+    expect(invoiceBadgeMonthLabel({ year: 2026, month: 0 })).toBe("jan/26");
+    expect(invoiceBadgeMonthLabel({ year: 2025, month: 11 })).toBe("dez/25");
+  });
+
+  it("usa os dois últimos dígitos do ano (vira de década/século)", () => {
+    expect(invoiceBadgeMonthLabel({ year: 2030, month: 6 })).toBe("jul/30");
+    expect(invoiceBadgeMonthLabel({ year: 2009, month: 6 })).toBe("jul/09");
+  });
+});
+
+describe("resolveInvoiceBadgeMonth", () => {
+  it("retorna o rótulo quando é lançamento de cartão e a compra veio de outro mês", () => {
+    // Compra em 19/06 que caiu na fatura de julho (mês selecionado).
+    expect(
+      resolveInvoiceBadgeMonth({
+        creditCardId: "cc-1",
+        dueDate: "2026-06-19",
+        selectedMonth: JULY_2026,
+      }),
+    ).toBe("jul/26");
+  });
+
+  it("retorna null quando o mês do dueDate coincide com o mês selecionado", () => {
+    expect(
+      resolveInvoiceBadgeMonth({
+        creditCardId: "cc-1",
+        dueDate: "2026-07-10",
+        selectedMonth: JULY_2026,
+      }),
+    ).toBeNull();
+  });
+
+  it("retorna null quando não é lançamento de cartão (sem creditCardId)", () => {
+    expect(
+      resolveInvoiceBadgeMonth({
+        creditCardId: null,
+        dueDate: "2026-06-19",
+        selectedMonth: JULY_2026,
+      }),
+    ).toBeNull();
+  });
+
+  it("retorna null quando não há mês selecionado (ex.: modo de range custom)", () => {
+    expect(
+      resolveInvoiceBadgeMonth({
+        creditCardId: "cc-1",
+        dueDate: "2026-06-19",
+        selectedMonth: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("diferencia por mês E ano (mesmo número de mês em anos distintos é 'outro mês')", () => {
+    // dueDate em julho/2025, mês selecionado julho/2026 → veio de outro mês.
+    expect(
+      resolveInvoiceBadgeMonth({
+        creditCardId: "cc-1",
+        dueDate: "2025-07-19",
+        selectedMonth: JULY_2026,
+      }),
+    ).toBe("jul/26");
+  });
+
+  it("faz parsing date-only/timezone-safe do dueDate (ignora componente de horário)", () => {
+    // dueDate com horário em 30/06 não deve ser empurrado para julho por fuso.
+    expect(
+      resolveInvoiceBadgeMonth({
+        creditCardId: "cc-1",
+        dueDate: "2026-06-30T23:59:59Z",
+        selectedMonth: JULY_2026,
+      }),
+    ).toBe("jul/26");
+  });
+});

--- a/features/transactions/model/invoice-badge.ts
+++ b/features/transactions/model/invoice-badge.ts
@@ -1,0 +1,94 @@
+/**
+ * Lógica derivada (pura) do selo "fatura {mmm/aa}" exibido em lançamentos de
+ * cartão no FEED de "Transações".
+ *
+ * Contexto: quando a lista é navegada por MÊS, o backend agrupa lançamentos de
+ * cartão pelo mês da FATURA (ciclo de fechamento), não pela data da compra. Uma
+ * compra de 19/06 que cai na fatura de julho aparece na lista de "julho"
+ * exibindo a data real 19/06. Para não confundir, marcamos essas linhas com um
+ * selo discreto com o mês da fatura (= mês selecionado no feed).
+ *
+ * Sem dependência de UI: recebe dados crus e devolve o rótulo curto do mês ou
+ * null quando o selo não se aplica. A composição i18n ("fatura {{month}}") fica
+ * na camada de componente.
+ */
+
+/** Referência de mês selecionado no feed (`month` 0-indexado, como `Date`). */
+export interface SelectedMonthRef {
+  readonly year: number;
+  /** Mês 0-indexado (0 = janeiro, 11 = dezembro). */
+  readonly month: number;
+}
+
+/** Argumentos para resolver o selo de fatura de um lançamento. */
+export interface InvoiceBadgeArgs {
+  /** Id do cartão de crédito do lançamento (null quando não é de cartão). */
+  readonly creditCardId: string | null;
+  /** Data de vencimento do lançamento (`YYYY-MM-DD` ou ISO com horário). */
+  readonly dueDate: string;
+  /**
+   * Mês selecionado no feed, ou null quando não há um mês único de referência
+   * (ex.: um eventual modo de range custom) — nesse caso o selo não aparece.
+   */
+  readonly selectedMonth: SelectedMonthRef | null;
+}
+
+/**
+ * Extrai o par ano/mês (0-indexado) de uma string de data, somente por data
+ * (sem componente de horário), evitando bugs de fuso.
+ *
+ * @param value String de data (`YYYY-MM-DD` ou ISO).
+ * @returns Ano e mês 0-indexado.
+ */
+const toYearMonth = (value: string): { year: number; month: number } => {
+  const [datePart] = value.split("T");
+  const [year, month] = (datePart ?? "").split("-").map(Number);
+  return { year: year ?? 1970, month: (month ?? 1) - 1 };
+};
+
+/**
+ * Rótulo curto "mmm/aa" (ex.: "jul/26") do mês selecionado, em pt-BR via Intl.
+ * O `Intl` devolve "jul. de 26"; reduzimos para a forma compacta removendo o
+ * ponto da abreviação do mês e juntando mês e ano de 2 dígitos com "/".
+ *
+ * @param selectedMonth Mês selecionado no feed.
+ * @returns Rótulo curto pt-BR no formato "mmm/aa".
+ */
+export const invoiceBadgeMonthLabel = (selectedMonth: SelectedMonthRef): string => {
+  const reference = new Date(selectedMonth.year, selectedMonth.month, 1);
+  const parts = new Intl.DateTimeFormat("pt-BR", {
+    month: "short",
+    year: "2-digit",
+  }).formatToParts(reference);
+  const monthPart = parts.find((part) => part.type === "month")?.value ?? "";
+  const yearPart = parts.find((part) => part.type === "year")?.value ?? "";
+  const month = monthPart.replace(/\.$/, "");
+  return `${month}/${yearPart}`;
+};
+
+/**
+ * Resolve o rótulo do selo de fatura ("mmm/aa") para um lançamento, ou null
+ * quando o selo não se aplica. O selo só aparece quando:
+ *   1. o lançamento é de cartão (`creditCardId` presente);
+ *   2. há um mês selecionado de referência (não em modo range custom); e
+ *   3. o mês/ano do `dueDate` (data da compra) difere do mês selecionado — ou
+ *      seja, a compra "veio de outro mês" pela fatura.
+ *
+ * @param args Id do cartão, data de vencimento e mês selecionado.
+ * @returns Rótulo "mmm/aa" do mês da fatura, ou null.
+ */
+export const resolveInvoiceBadgeMonth = ({
+  creditCardId,
+  dueDate,
+  selectedMonth,
+}: InvoiceBadgeArgs): string | null => {
+  if (!creditCardId || !selectedMonth) {
+    return null;
+  }
+  const due = toYearMonth(dueDate);
+  const sameMonth = due.year === selectedMonth.year && due.month === selectedMonth.month;
+  if (sameMonth) {
+    return null;
+  }
+  return invoiceBadgeMonthLabel(selectedMonth);
+};

--- a/features/transactions/model/transactions-feed.test.ts
+++ b/features/transactions/model/transactions-feed.test.ts
@@ -308,6 +308,49 @@ describe("toFeedItem", () => {
     });
     expect(item.dateDisplay).toBe("Hoje");
   });
+
+  it("marca o selo de fatura quando o lançamento de cartão veio de outro mês", () => {
+    const item = toFeedItem({
+      tx: tx({ creditCardId: "cc-1", dueDate: "2026-06-19" }),
+      tags: [],
+      kpis,
+      today,
+      selectedMonth: { year: 2026, month: 6 },
+    });
+    expect(item.invoiceBadgeMonth).toBe("jul/26");
+  });
+
+  it("não marca o selo quando o mês do dueDate coincide com o selecionado", () => {
+    const item = toFeedItem({
+      tx: tx({ creditCardId: "cc-1", dueDate: "2026-07-10" }),
+      tags: [],
+      kpis,
+      today,
+      selectedMonth: { year: 2026, month: 6 },
+    });
+    expect(item.invoiceBadgeMonth).toBeNull();
+  });
+
+  it("não marca o selo para lançamento sem cartão", () => {
+    const item = toFeedItem({
+      tx: tx({ creditCardId: null, dueDate: "2026-06-19" }),
+      tags: [],
+      kpis,
+      today,
+      selectedMonth: { year: 2026, month: 6 },
+    });
+    expect(item.invoiceBadgeMonth).toBeNull();
+  });
+
+  it("não marca o selo quando não há mês selecionado (sem range/mês de referência)", () => {
+    const item = toFeedItem({
+      tx: tx({ creditCardId: "cc-1", dueDate: "2026-06-19" }),
+      tags: [],
+      kpis,
+      today,
+    });
+    expect(item.invoiceBadgeMonth).toBeNull();
+  });
 });
 
 describe("shortDateLabel", () => {

--- a/features/transactions/model/transactions-feed.ts
+++ b/features/transactions/model/transactions-feed.ts
@@ -13,6 +13,10 @@ import type {
   TransactionStatus,
   TransactionType,
 } from "@/features/transactions/contracts";
+import {
+  resolveInvoiceBadgeMonth,
+  type SelectedMonthRef,
+} from "@/features/transactions/model/invoice-badge";
 import type { Tag } from "@/features/tags/contracts";
 import { NO_CATEGORY_COLOR, resolveCategoryColor } from "@/shared/theme";
 import { formatCurrencySigned } from "@/shared/utils/formatters";
@@ -75,6 +79,11 @@ export interface TransactionFeedItem {
   readonly signedDisplay: string;
   /** Participação do lançamento no fluxo do seu tipo (0..100, inteiro). */
   readonly percentOfFlow: number;
+  /**
+   * Rótulo "mmm/aa" do mês da fatura (= mês selecionado) quando o lançamento é
+   * de cartão e a compra veio de outro mês; null quando o selo não se aplica.
+   */
+  readonly invoiceBadgeMonth: string | null;
 }
 
 /**
@@ -273,6 +282,11 @@ export interface ToFeedItemArgs {
   readonly kpis: FeedKpis;
   /** Data de referência (`YYYY-MM-DD`) para o rótulo relativo. */
   readonly today: string;
+  /**
+   * Mês selecionado no feed (para o selo de fatura). Ausente/null quando não há
+   * um mês único de referência — nesse caso o selo nunca aparece.
+   */
+  readonly selectedMonth?: SelectedMonthRef | null;
 }
 
 /**
@@ -289,6 +303,7 @@ export const toFeedItem = ({
   tags,
   kpis,
   today,
+  selectedMonth = null,
 }: ToFeedItemArgs): TransactionFeedItem => {
   const tagById = new Map(tags.map((tag) => [tag.id, tag]));
   const category = resolveCategory(tx.tagId, tagById);
@@ -313,5 +328,10 @@ export const toFeedItem = ({
     dateDisplay: relativeDate ?? shortDateLabel(tx.dueDate),
     signedDisplay: formatCurrencySigned(signed),
     percentOfFlow: percentOfTotal(amount, flow),
+    invoiceBadgeMonth: resolveInvoiceBadgeMonth({
+      creditCardId: tx.creditCardId,
+      dueDate: tx.dueDate,
+      selectedMonth,
+    }),
   };
 };

--- a/features/transactions/screens/transactions-screen.test.tsx
+++ b/features/transactions/screens/transactions-screen.test.tsx
@@ -31,6 +31,7 @@ const feedItem: TransactionFeedItem = {
   dateDisplay: "em 9 dias",
   signedDisplay: "− R$ 2.000,00",
   percentOfFlow: 10,
+  invoiceBadgeMonth: null,
 };
 
 const viewModel: TransactionViewModel = {
@@ -66,6 +67,7 @@ const mockBaseController: TransactionsFeedController = {
   tagFilter: "all",
   setTagFilter: jest.fn(),
   periodLabel: "Junho de 2026",
+  selectedMonth: { year: 2026, month: 5 },
   goToPreviousMonth: jest.fn(),
   goToNextMonth: jest.fn(),
   resetToCurrentMonth: jest.fn(),

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -111,6 +111,9 @@
       "duplicateDescription": "Creates a copy dated today.",
       "title": "Actions"
     },
+    "feed": {
+      "invoiceBadge": "invoice {{month}}"
+    },
     "export": {
       "title": "Export transactions",
       "description": "Pick a format; we generate the file and open share.",

--- a/shared/i18n/locales/pt.json
+++ b/shared/i18n/locales/pt.json
@@ -111,6 +111,9 @@
       "duplicateDescription": "Cria uma copia com a data de hoje.",
       "title": "Acoes"
     },
+    "feed": {
+      "invoiceBadge": "fatura {{month}}"
+    },
     "export": {
       "title": "Exportar transacoes",
       "description": "Escolha o formato; geramos o arquivo e abrimos o compartilhamento.",


### PR DESCRIPTION
Closes #597

## O que muda

No feed de Transações (modo MÊS), lançamentos de cartão de crédito agora podem aparecer na lista de um mês diferente do mês da compra, porque o backend os agrupa pelo mês da FATURA (ciclo de fechamento). Para deixar isso claro, cada linha de cartão cuja compra "veio de outro mês" ganha um selo discreto **"fatura {mmm/aa}"** (ex.: `fatura jul/26`), onde `{mmm/aa}` é o mês selecionado no feed.

### Regras do selo
- Só aparece para transações com `creditCardId` (lançamento de cartão).
- Só aparece quando o mês do `dueDate` (data da compra) difere do mês selecionado. Coincidindo, não mostra.
- Nunca aparece sem um mês único de referência (um eventual modo de range custom é no-op por construção).
- Mês formatado curto em pt-BR via `Intl` (`mmm/aa`).

## Como foi feito (TDD)

A lógica derivada vive num helper puro `features/transactions/model/invoice-badge.ts`:
- `invoiceBadgeMonthLabel(selectedMonth)` → `"jul/26"` (Intl `short`/`2-digit`, sem ponto, separador `/`).
- `resolveInvoiceBadgeMonth({ creditCardId, dueDate, selectedMonth })` → rótulo ou `null`.

Teste Jest escrito primeiro (red → green). O view-model do feed (`toFeedItem`) passou a expor `invoiceBadgeMonth`, e o `selectedMonth` é threaded do controller base até o feed. A UI é um chip discreto `TxInvoiceChip` (tom `$muted`, tokens de tema, sem estilos literais), com texto via `shared/i18n` (`transactions.feed.invoiceBadge`, pt + en).

## Decisão de design

Selo informativo, não de status: tom neutro (`$muted`) com fundo de baixa opacidade e ícone `credit-card-outline`, seguindo o idioma visual de `TxStatusChip` porém mais quieto. Posicionado na linha de status/data do card.

## Quality gate

`npm run quality-check` verde: lint, typecheck, policy:check, contracts:check, codegen:check e test:coverage (385 suites / 2498 testes; cobertura agregada 94.58% stmts / 85.15% branch, acima do limite de 85%).

## Arquivos

- `features/transactions/model/invoice-badge.ts` (+ teste) — helper puro
- `features/transactions/model/transactions-feed.ts` (+ teste) — campo `invoiceBadgeMonth` no view-model
- `features/transactions/hooks/use-transactions-screen-controller.ts` — expõe `selectedMonth`
- `features/transactions/hooks/use-transactions-feed-controller.ts` — passa `selectedMonth` ao `toFeedItem`
- `features/transactions/components/tx-chips.tsx` — `TxInvoiceChip`
- `features/transactions/components/tx-card-body.tsx` — renderiza o chip
- `features/transactions/components/tx-components.test.tsx`, `screens/transactions-screen.test.tsx` — testes/fixtures
- `shared/i18n/locales/pt.json`, `en.json` — string i18n

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx