### PR TITLE
feat(insights): fluida etapa 3 — refino de cadência e temas

### DIFF
--- a/config/design-tokens.ts
+++ b/config/design-tokens.ts
@@ -94,6 +94,9 @@ export const motionDurations = {
   normal: 180,
   slow: 260,
   deliberate: 320,
+  // ~0.5s growth for data viz (bars/meters animating their fill). Slower than
+  // UI feedback on purpose, so the magnitude of a value reads as it fills.
+  expressive: 500,
 } as const;
 
 export const motionScales = {

--- a/features/insights/fluida/components/chart-beat.test.tsx
+++ b/features/insights/fluida/components/chart-beat.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react-native";
 
+import { resetAppShellStore, useAppShellStore } from "@/core/shell/app-shell-store";
 import type { InsightSeries } from "@/features/insights/fluida/contracts";
 import { ChartBeat } from "@/features/insights/fluida/components/chart-beat";
 import { SERIES_LABELS } from "@/features/insights/fluida/series";
@@ -10,6 +11,10 @@ const series: InsightSeries = {
   daily: [1200, 0, 250, 0, 2650, 0, 11950],
   weekly: [4200, 980, 3100, 1400, 9800, 13650],
 };
+
+beforeEach(() => {
+  resetAppShellStore();
+});
 
 describe("ChartBeat", () => {
   it("renders the daily title and all 7 day labels for the daily cadence", () => {
@@ -58,5 +63,25 @@ describe("ChartBeat", () => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { Rect } = require("react-native-svg");
     expect(UNSAFE_getAllByType(Rect)).toHaveLength(series.weekly.length);
+  });
+
+  it("rests the peak bar at full chart height when motion is reduced (base state visible)", () => {
+    useAppShellStore.getState().setReducedMotionEnabled(true);
+
+    const { UNSAFE_getAllByType } = render(
+      <TestProviders>
+        <ChartBeat series={series} cadence="daily" />
+      </TestProviders>,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { Rect } = require("react-native-svg");
+    const rects = UNSAFE_getAllByType(Rect);
+    // The 7th (last) daily value is the peak; with reduce-motion the bar is at
+    // rest — full height, top pinned to the baseline (height + y === chart H).
+    const peakProps = rects[series.daily.length - 1].props
+      .animatedProps as { height: number; y: number };
+    expect(Number(peakProps.height) + Number(peakProps.y)).toBe(90);
+    expect(Number(peakProps.height)).toBeGreaterThan(0);
   });
 });

--- a/features/insights/fluida/components/chart-beat.tsx
+++ b/features/insights/fluida/components/chart-beat.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 
+import Animated from "react-native-reanimated";
 import { Paragraph, XStack, YStack, useTheme } from "tamagui";
 import Svg, { Rect } from "react-native-svg";
 
@@ -9,6 +10,7 @@ import type {
   InsightSeries,
 } from "@/features/insights/fluida/contracts";
 import { buildChartBars, selectSeriesValues } from "@/features/insights/fluida/series";
+import { useBarGrowAnimation } from "@/shared/animations/use-bar-grow-animation";
 import { maxValue } from "@/shared/utils/chart-geometry";
 import { formatCurrency } from "@/shared/utils/formatters";
 
@@ -24,6 +26,49 @@ const CHART_HEIGHT = 90;
 const MIN_BAR_HEIGHT = 4;
 const BAR_GAP = 6;
 const BAR_CORNER = 4;
+
+const AnimatedRect = Animated.createAnimatedComponent(Rect);
+
+interface ChartBarRectProps {
+  readonly x: number;
+  readonly width: number;
+  readonly height: number;
+  readonly fill: string;
+  readonly index: number;
+}
+
+/**
+ * A single rhythm-chart bar that grows up from the baseline to its final
+ * `height` over ~0.5s, staggered by `index`. The grow animation lives in
+ * {@link useBarGrowAnimation}; the rest state is the fully-drawn bar, so the
+ * bar is never left stuck invisible (and honours "reduce motion").
+ *
+ * @param props The bar's x/width, final height, fill colour and row index.
+ * @returns An animated `<Rect>` driven by the grow animation.
+ */
+function ChartBarRect({
+  x,
+  width,
+  height,
+  fill,
+  index,
+}: ChartBarRectProps): ReactElement {
+  const { animatedProps } = useBarGrowAnimation({
+    height,
+    chartHeight: CHART_HEIGHT,
+    index,
+  });
+
+  return (
+    <AnimatedRect
+      x={x}
+      width={width}
+      rx={BAR_CORNER}
+      fill={fill}
+      animatedProps={animatedProps}
+    />
+  );
+}
 
 const TITLE_BY_CADENCE: Record<InsightCadence, string> = {
   daily: "Saídas · últimos 7 dias",
@@ -80,16 +125,14 @@ export function ChartBeat({ series, cadence, testID }: ChartBeatProps): ReactEle
         {bars.map((bar, index) => {
           const barHeight = Math.max(MIN_BAR_HEIGHT, bar.ratio * CHART_HEIGHT);
           const x = slot * index + BAR_GAP / 2;
-          const y = CHART_HEIGHT - barHeight;
           return (
-            <Rect
+            <ChartBarRect
               key={bar.label}
               x={x}
-              y={y}
               width={barWidth}
               height={barHeight}
-              rx={BAR_CORNER}
               fill={bar.isPeak ? peakColor : trackColor}
+              index={index}
             />
           );
         })}

--- a/features/insights/hooks/use-insights-fluida-screen-controller.test.tsx
+++ b/features/insights/hooks/use-insights-fluida-screen-controller.test.tsx
@@ -75,6 +75,49 @@ describe("useInsightsFluidaScreenController", () => {
     expect(result.current.showCompare).toBe(false);
   });
 
+  it("keeps every beat coherent when cadence changes after a dimension change", () => {
+    const { result } = renderHook(() => useInsightsFluidaScreenController());
+
+    act(() => {
+      result.current.selectDimension("transactions");
+    });
+    act(() => {
+      result.current.selectCadence("weekly");
+    });
+
+    // No stale state: dimension + cadence both reflected, VM fully re-derived.
+    expect(result.current.dimension).toBe("transactions");
+    expect(result.current.cadence).toBe("weekly");
+    expect(result.current.showCompare).toBe(false);
+    expect(result.current.vm).toEqual(
+      selectFluidaVM({ dimension: "transactions", cadence: "weekly" }),
+    );
+    expect(result.current.vm.retro).toHaveLength(0);
+  });
+
+  it("re-derives the chart series and compare flag together when switching back to general", () => {
+    const { result } = renderHook(() => useInsightsFluidaScreenController());
+
+    act(() => {
+      result.current.selectCadence("weekly");
+    });
+    act(() => {
+      result.current.selectDimension("budgets");
+    });
+    act(() => {
+      result.current.selectDimension("general");
+    });
+
+    // Back on general at the weekly cadence: compare returns AND the weekly
+    // series is the one exposed — nothing pinned from the daily/budgets path.
+    expect(result.current.cadence).toBe("weekly");
+    expect(result.current.showCompare).toBe(true);
+    expect(result.current.vm.retro.length).toBeGreaterThan(0);
+    expect(result.current.vm.series).toEqual(
+      selectFluidaVM({ dimension: "general", cadence: "weekly" }).series,
+    );
+  });
+
   it("exposes the resolved colour scheme as a boolean isDark flag", () => {
     mockedUseResolvedTheme.mockReturnValue("auraxis_dark");
 

--- a/features/insights/mocks/fluida-lead.test.ts
+++ b/features/insights/mocks/fluida-lead.test.ts
@@ -1,3 +1,4 @@
+import type { InsightDimension } from "@/features/insights/contracts";
 import { INSIGHT_DIMENSION_ORDER } from "@/features/insights/hooks/use-insights-by-dimension";
 import { INSIGHT_CADENCE_ORDER } from "@/features/insights/fluida/contracts";
 import {
@@ -33,5 +34,20 @@ describe("fluida lead mock fixture", () => {
     const weekly = selectFluidaLead({ dimension: "general", cadence: "weekly" });
 
     expect(weekly.readMinutes).toBeGreaterThan(daily.readMinutes);
+  });
+
+  it("anchors the reading time per dimension × cadence to the handoff (3/5 themes, 15/30 geral)", () => {
+    // Handoff: daily = ~3 min per theme + ~15 min on Geral;
+    //          weekly = ~5 min per theme + ~30 min on Geral.
+    const perThemeDimensions: readonly InsightDimension[] =
+      INSIGHT_DIMENSION_ORDER.filter((dimension) => dimension !== "general");
+
+    expect(selectFluidaLead({ dimension: "general", cadence: "daily" }).readMinutes).toBe(15);
+    expect(selectFluidaLead({ dimension: "general", cadence: "weekly" }).readMinutes).toBe(30);
+
+    perThemeDimensions.forEach((dimension) => {
+      expect(selectFluidaLead({ dimension, cadence: "daily" }).readMinutes).toBe(3);
+      expect(selectFluidaLead({ dimension, cadence: "weekly" }).readMinutes).toBe(5);
+    });
   });
 });

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -47,16 +47,20 @@ jest.mock("react-native-reanimated", () => {
       return React.createElement(View, { style, ref, ...rest }, children);
     },
   );
+  const createAnimatedComponent = (component: unknown) => component;
   return {
     __esModule: true,
-    default: { View: ForwardedView },
+    default: { View: ForwardedView, createAnimatedComponent },
     View: ForwardedView,
+    createAnimatedComponent,
     FadeIn: fadeStub,
     FadeOut: fadeStub,
     SlideInRight: fadeStub,
     SlideOutLeft: fadeStub,
     useSharedValue: (initial: unknown) => ({ value: initial }),
     useAnimatedStyle: (factory: () => unknown) =>
+      typeof factory === "function" ? factory() : {},
+    useAnimatedProps: (factory: () => unknown) =>
       typeof factory === "function" ? factory() : {},
     withTiming: (value: unknown) => value,
     withSpring: (value: unknown) => value,

--- a/shared/animations/use-bar-grow-animation.test.ts
+++ b/shared/animations/use-bar-grow-animation.test.ts
@@ -1,0 +1,72 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { resetAppShellStore, useAppShellStore } from "@/core/shell/app-shell-store";
+
+import {
+  barGrowGeometry,
+  barGrowInitialProgress,
+  useBarGrowAnimation,
+} from "./use-bar-grow-animation";
+
+describe("barGrowInitialProgress", () => {
+  it("starts collapsed (0) so the bar grows in when motion is allowed", () => {
+    expect(barGrowInitialProgress(false)).toBe(0);
+  });
+
+  it("starts at rest (1) when 'reduce motion' is on — no animation, base state", () => {
+    expect(barGrowInitialProgress(true)).toBe(1);
+  });
+});
+
+describe("barGrowGeometry", () => {
+  it("maps progress 0 to a zero-height bar pinned at the baseline", () => {
+    expect(barGrowGeometry({ progress: 0, height: 60, chartHeight: 90 })).toEqual({
+      height: 0,
+      y: 90,
+    });
+  });
+
+  it("maps progress 1 to the full bar resting at its final position (base state)", () => {
+    expect(barGrowGeometry({ progress: 1, height: 60, chartHeight: 90 })).toEqual({
+      height: 60,
+      y: 30,
+    });
+  });
+
+  it("grows the bar upward from the baseline at the midpoint", () => {
+    expect(barGrowGeometry({ progress: 0.5, height: 60, chartHeight: 90 })).toEqual({
+      height: 30,
+      y: 60,
+    });
+  });
+});
+
+describe("useBarGrowAnimation", () => {
+  beforeEach(() => {
+    resetAppShellStore();
+  });
+
+  it("drives an animated rect via numeric height/y props bound to the baseline", () => {
+    const { result } = renderHook(() =>
+      useBarGrowAnimation({ height: 60, chartHeight: 90 }),
+    );
+
+    // The hook always yields the rect geometry (height + baseline-anchored y);
+    // the resting target is locked by `barGrowGeometry(progress: 1)` above and
+    // by the reduce-motion path below, so a bar is never left stuck invisible.
+    const { height, y } = result.current.animatedProps;
+    expect(typeof height).toBe("number");
+    expect(typeof y).toBe("number");
+    expect(Number(height) + Number(y)).toBe(90);
+  });
+
+  it("renders the final geometry immediately when 'reduce motion' is on", () => {
+    useAppShellStore.getState().setReducedMotionEnabled(true);
+
+    const { result } = renderHook(() =>
+      useBarGrowAnimation({ height: 42, chartHeight: 90 }),
+    );
+
+    expect(result.current.animatedProps).toEqual({ height: 42, y: 48 });
+  });
+});

--- a/shared/animations/use-bar-grow-animation.ts
+++ b/shared/animations/use-bar-grow-animation.ts
@@ -1,0 +1,113 @@
+import { useEffect } from "react";
+
+import {
+  Easing,
+  useAnimatedProps,
+  useSharedValue,
+  withDelay,
+  withTiming,
+} from "react-native-reanimated";
+
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { motionDurations, motionEasings, motionStagger } from "@/shared/theme";
+
+/** Geometry of a single bar at a given growth progress. */
+export interface BarGeometry {
+  /** Drawn height of the bar (px). */
+  readonly height: number;
+  /** Top edge (SVG y), pinned to the baseline as the bar grows upward. */
+  readonly y: number;
+}
+
+/** Inputs describing a bar's final (rest) size within the chart viewBox. */
+export interface BarGrowInput {
+  /** Final bar height at rest (px). */
+  readonly height: number;
+  /** Chart viewBox height — the baseline bars grow up from (px). */
+  readonly chartHeight: number;
+  /** Position in the row; scales the entrance delay (left-to-right). */
+  readonly index?: number;
+}
+
+/**
+ * Initial growth progress for a bar entrance. With motion allowed the bar
+ * starts collapsed (`0`) and grows to full; with "reduce motion" on it starts
+ * already at rest (`1`) so there is no animation and the base state shows
+ * immediately.
+ *
+ * @param reducedMotion Whether the user asked to reduce motion.
+ * @returns `0` (animate in) or `1` (rest immediately).
+ */
+export const barGrowInitialProgress = (reducedMotion: boolean): number => {
+  return reducedMotion ? 1 : 0;
+};
+
+/**
+ * Resolves the drawn geometry of a bar for a growth `progress` in `[0, 1]`.
+ * At `0` the bar is zero-height sitting on the baseline; at `1` it reaches its
+ * full `height` with the top at `chartHeight - height`. The bar always grows
+ * upward from the baseline, so the final (rest) state is the fully-drawn bar.
+ *
+ * @param input Growth progress plus the bar's final height and the baseline.
+ * @returns The `height`/`y` to feed the rect at this progress.
+ */
+export const barGrowGeometry = ({
+  progress,
+  height,
+  chartHeight,
+}: {
+  readonly progress: number;
+  readonly height: number;
+  readonly chartHeight: number;
+}): BarGeometry => {
+  const drawn = height * progress;
+  return {
+    height: drawn,
+    y: chartHeight - drawn,
+  };
+};
+
+/**
+ * Animates a chart bar growing up from the baseline to its final height over
+ * ~0.5s (`motionDurations.expressive`), staggered by `index`. It animates only
+ * the bar's `height`/`y` — the rest state is the fully-drawn bar, so a bar is
+ * never left stuck invisible. Honours the "reduce motion" preference by
+ * settling at the final geometry immediately.
+ *
+ * The return type is intentionally inferred from `useAnimatedProps` (Reanimated
+ * widens the animated prop shape to a `Partial`); annotating it collapses the
+ * shape and stops matching the `animatedProps` of the animated `<Rect>`.
+ *
+ * @param input The bar's final height, the chart baseline and its row index.
+ * @returns `{ animatedProps }` to feed an `Animated.createAnimatedComponent(Rect)`.
+ */
+export function useBarGrowAnimation({
+  height,
+  chartHeight,
+  index = 0,
+}: BarGrowInput) {
+  const reducedMotion = useAppShellStore((state) => state.reducedMotionEnabled);
+  const progress = useSharedValue(barGrowInitialProgress(reducedMotion));
+
+  useEffect(() => {
+    if (reducedMotion) {
+      progress.value = 1;
+      return;
+    }
+
+    const delay = index * motionStagger;
+    progress.value = withDelay(
+      delay,
+      withTiming(1, {
+        duration: motionDurations.expressive,
+        easing: Easing.bezier(...motionEasings.emphasized),
+      }),
+    );
+  }, [chartHeight, height, index, progress, reducedMotion]);
+
+  const animatedProps = useAnimatedProps(() =>
+    barGrowGeometry({ progress: progress.value, height, chartHeight }),
+  );
+
+  return { animatedProps };
+}

--- a/shared/types/generated/graphql.ts
+++ b/shared/types/generated/graphql.ts
@@ -60,6 +60,14 @@ export type AiInsightFeedbackPayload = {
   usefulness?: Maybe<Scalars['Int']['output']>;
 };
 
+/** One calculated per-theme highlight for the Fluida screen (#1501). */
+export type AiInsightHighlightType = {
+  __typename?: 'AIInsightHighlightType';
+  label: Scalars['String']['output'];
+  sub: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
 export type AiInsightHistoryResultType = {
   __typename?: 'AIInsightHistoryResultType';
   items: Array<AiInsightType>;
@@ -76,6 +84,23 @@ export type AiInsightItemType = {
   message: Scalars['String']['output'];
   title: Scalars['String']['output'];
   type: Scalars['String']['output'];
+};
+
+/** One calculated retrospective metric for the Fluida screen (#1501). */
+export type AiInsightRetroEntryType = {
+  __typename?: 'AIInsightRetroEntryType';
+  caption: Scalars['String']['output'];
+  key: Scalars['String']['output'];
+  label: Scalars['String']['output'];
+  sign: Scalars['String']['output'];
+  value: Scalars['Float']['output'];
+};
+
+/** Calculated outflow series: daily over 7 days, weekly over 6 weeks. */
+export type AiInsightSeriesType = {
+  __typename?: 'AIInsightSeriesType';
+  daily: Array<Maybe<Scalars['Float']['output']>>;
+  weekly: Array<Maybe<Scalars['Float']['output']>>;
 };
 
 export type AiInsightType = {
@@ -513,14 +538,18 @@ export type GenerateAiInsightPayload = {
   contextVersion?: Maybe<Scalars['String']['output']>;
   costUsd?: Maybe<Scalars['Float']['output']>;
   forecast?: Maybe<Scalars['Boolean']['output']>;
+  highlights?: Maybe<Array<Maybe<AiInsightHighlightType>>>;
   id?: Maybe<Scalars['String']['output']>;
   items?: Maybe<Array<Maybe<AiInsightItemType>>>;
   model?: Maybe<Scalars['String']['output']>;
   ok: Scalars['Boolean']['output'];
+  paragraphs?: Maybe<Array<Maybe<Scalars['String']['output']>>>;
   periodEnd?: Maybe<Scalars['String']['output']>;
   periodLabel?: Maybe<Scalars['String']['output']>;
   periodStart?: Maybe<Scalars['String']['output']>;
   periodType?: Maybe<Scalars['String']['output']>;
+  retro?: Maybe<Array<Maybe<AiInsightRetroEntryType>>>;
+  series?: Maybe<AiInsightSeriesType>;
   summary?: Maybe<Scalars['String']['output']>;
   tokensUsed?: Maybe<Scalars['Int']['output']>;
 };


### PR DESCRIPTION
## Resumo

Etapa 3 da tela "Insights de IA — Fluida" (`features/insights/fluida/`): fecha o refino de **cadência e temas**. PR encadeado sobre `feat/insights-fluida-etapa2-beats`.

Closes #603

## O que já existia (etapas 1+2) — auditado, não refeito

- **Tempos de leitura**: os valores de `readMinutes` no mock (`fluida-lead.ts`) já estavam corretos por dimensão×cadência (3/5 por tema, 15/30 no Geral). Faltava apenas travar isso com teste.
- **Gráfico por cadência**: `series.ts` (`selectSeriesValues`, `SERIES_LABELS`, `buildChartBars`) + `ChartBeat` já selecionavam `daily` (7 dias) vs `weekly` (6 semanas), com rótulos certos e pico destacado em ambos. Já testado.
- **Coerência ao alternar**: o controller já derivava o VM inteiro (lead, retro, highlights, série) num único `useMemo([cadence, dimension])`, com `showCompare = dimension === "general"` e `ChartBeat` recebendo a cadência viva. Sem estado preso estruturalmente.

## O que esta etapa completou

1. **Transições (gap real)**: as barras do `ChartBeat` eram `<Rect>` estáticos. Agora cada barra cresce a partir da base até a altura final em ~0.5s (novo token `motionDurations.expressive`), escalonadas por índice, via o novo hook reutilizável `shared/animations/useBarGrowAnimation`. O estado final visível é o estado base (barra cheia) — nada de "conteúdo preso invisível" — e respeita "Reduzir movimento" (assenta instantâneo).
2. **Tempos de leitura**: teste de regressão travando `readMinutes` por dimensão×cadência (3/5 por tema, 15/30 no Geral).
3. **Coerência**: testes explícitos de troca sequencial de dimensão + cadência (ex.: weekly → transactions = VM weekly + `showCompare` false; volta a general no weekly = compare retorna + série weekly), garantindo que todos os beats re-derivam juntos sem estado preso.
4. **Contrato**: regenerado `shared/types/generated/graphql.ts` (o schema do backend já expõe os campos fluida de etapa 3 — highlights/retro/series/paragraphs; drift pré-existente no base, corrigido aqui).

## TDD

Lógica primeiro: helpers puros (`barGrowInitialProgress`, `barGrowGeometry`) e o hook (`useBarGrowAnimation`) testados em isolamento; regressão de `readMinutes`; coerência de estado no controller. Depois render: `ChartBeat` assenta o pico na altura cheia sob reduce-motion.

## Quality gate

`npm run quality-check` **verde** (exit 0): lint, typecheck, policy:check, contracts:check, codegen:check e test:coverage. **404 suites / 2588 testes**, cobertura **94.63% stmts / 85.19% branch** (gate ≥85%).

## Notas

- Sem libs novas (reusa `react-native-reanimated` já presente, via `shared/animations`).
- Não fiz merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx