### PR TITLE
feat(insights): etapa 4 — recorte de insights por página de feature

### DIFF
--- a/app/(private)/insights.tsx
+++ b/app/(private)/insights.tsx
@@ -1,13 +1,24 @@
 import type { ReactElement } from "react";
 
+import { useLocalSearchParams } from "expo-router";
+
 import { AiInsightsScreen } from "@/features/insights/screens/ai-insights-screen";
 import { InsightsFluidaScreen } from "@/features/insights/screens/insights-fluida-screen";
 import { AI_INSIGHTS_FLUIDA_FEATURE_FLAG_KEY } from "@/features/insights/insights-config";
 import { isFeatureEnabled } from "@/shared/feature-flags";
+import {
+  INSIGHT_DIMENSION_PARAM,
+  parseInsightDimensionParam,
+} from "@/shared/insights";
 
 export default function InsightsRoute(): ReactElement {
+  const params = useLocalSearchParams<Record<string, string | string[]>>();
+  const initialDimension = parseInsightDimensionParam(
+    params[INSIGHT_DIMENSION_PARAM],
+  );
+
   if (isFeatureEnabled(AI_INSIGHTS_FLUIDA_FEATURE_FLAG_KEY)) {
-    return <InsightsFluidaScreen />;
+    return <InsightsFluidaScreen initialDimension={initialDimension} />;
   }
 
   return <AiInsightsScreen />;

--- a/features/budgets/screens/budgets-screen.tsx
+++ b/features/budgets/screens/budgets-screen.tsx
@@ -17,11 +17,16 @@ import {
   sortBudgetsByRisk,
 } from "@/features/budgets/services/budget-risk";
 import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import { useInsightSection } from "@/features/insights/hooks/use-insight-section";
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import {
+  InsightSection,
+  buildInsightFluidaParams,
+} from "@/shared/insights";
 import { BudgetsListSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
@@ -29,6 +34,7 @@ import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 export function BudgetsScreen(): ReactElement {
   const controller = useBudgetsScreenController();
   const router = useRouter();
+  const insightSection = useInsightSection("budgets");
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -52,6 +58,10 @@ export function BudgetsScreen(): ReactElement {
   return (
     <AppScreen>
       <SummaryCard controller={controller} />
+      <InsightSection
+        vm={insightSection}
+        onReadFull={() => router.push(buildInsightFluidaParams("budgets"))}
+      />
       <AiInsightSurface
         dimension="budgets"
         onOpenHub={() => router.push(appRoutes.private.insights)}

--- a/features/credit-cards/screens/credit-cards-screen.tsx
+++ b/features/credit-cards/screens/credit-cards-screen.tsx
@@ -27,6 +27,7 @@ import {
   type CardsHomeController,
 } from "@/features/credit-cards/hooks/use-cards-home-controller";
 import { useCreditCardsScreenController } from "@/features/credit-cards/hooks/use-credit-cards-screen-controller";
+import { useInsightSection } from "@/features/insights/hooks/use-insight-section";
 import {
   useTourAnchor,
   useTourAnchorContext,
@@ -38,6 +39,10 @@ import {
   AppScreen,
   type AppScreenScrollHandle,
 } from "@/shared/components/app-screen";
+import {
+  InsightSection,
+  buildInsightFluidaParams,
+} from "@/shared/insights";
 import {
   darkSemanticGradients,
   iconSizes,
@@ -63,6 +68,7 @@ export function CreditCardsScreen(): ReactElement {
   const home = useCardsHomeController();
   const crud = useCreditCardsScreenController();
   const router = useRouter();
+  const insightSection = useInsightSection("credit_cards");
 
   // Ref do ScrollView (rolar até o alvo do tour) e ref imperativa do tour
   // (replay pelo botão "?"). A medição das âncoras vem do contexto montado em
@@ -120,6 +126,10 @@ export function CreditCardsScreen(): ReactElement {
         cards={cards}
         onAddCard={crud.handleOpenCreate}
         onReplayTour={handleReplayTour}
+      />
+      <InsightSection
+        vm={insightSection}
+        onReadFull={() => router.push(buildInsightFluidaParams("credit_cards"))}
       />
       <AppQueryState
         query={home.cardsQuery}

--- a/features/goals/screens/goals-screen.tsx
+++ b/features/goals/screens/goals-screen.tsx
@@ -19,6 +19,7 @@ import {
   type GoalsScreenController,
 } from "@/features/goals/hooks/use-goals-screen-controller";
 import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import { useInsightSection } from "@/features/insights/hooks/use-insight-section";
 import type { GoalProgressView } from "@/features/goals/services/goal-progress-calculator";
 import { AppButton } from "@/shared/components/app-button";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
@@ -26,6 +27,10 @@ import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import {
+  InsightSection,
+  buildInsightFluidaParams,
+} from "@/shared/insights";
 import { useListRefresh } from "@/shared/hooks/use-list-refresh";
 import { GoalListSkeleton } from "@/shared/skeletons";
 import { formatCurrency } from "@/shared/utils/formatters";
@@ -66,6 +71,7 @@ function ListSeparator(): ReactElement {
 export function GoalsScreen(): ReactElement {
   const controller = useGoalsScreenController();
   const router = useRouter();
+  const insightSection = useInsightSection("goals");
 
   if (controller.formMode.kind !== "closed") {
     return (
@@ -87,6 +93,10 @@ export function GoalsScreen(): ReactElement {
   return (
     <AppScreen scrollable={false}>
       <SummaryCard controller={controller} />
+      <InsightSection
+        vm={insightSection}
+        onReadFull={() => router.push(buildInsightFluidaParams("goals"))}
+      />
       <AiInsightSurface
         dimension="goals"
         onOpenHub={() => router.push(appRoutes.private.insights)}

--- a/features/insights/hooks/use-insight-section.test.ts
+++ b/features/insights/hooks/use-insight-section.test.ts
@@ -1,0 +1,68 @@
+import { renderHook } from "@testing-library/react-native";
+
+import { selectFluidaVM } from "@/features/insights/mocks/fluida-vm";
+import { useInsightSection } from "@/features/insights/hooks/use-insight-section";
+import { isFeatureEnabled } from "@/shared/feature-flags";
+
+jest.mock("@/shared/feature-flags", () => ({
+  isFeatureEnabled: jest.fn(),
+}));
+
+const mockedIsFeatureEnabled = jest.mocked(isFeatureEnabled);
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockedIsFeatureEnabled.mockReturnValue(true);
+});
+
+describe("useInsightSection", () => {
+  it("gates on the app.insights.fluida flag", () => {
+    mockedIsFeatureEnabled.mockReturnValue(false);
+
+    const { result } = renderHook(() => useInsightSection("transactions"));
+
+    expect(mockedIsFeatureEnabled).toHaveBeenCalledWith("app.insights.fluida");
+    expect(result.current).toBeNull();
+  });
+
+  it("returns the compact recorte for the requested dimension when enabled", () => {
+    const { result } = renderHook(() => useInsightSection("transactions"));
+    const fullVM = selectFluidaVM({ dimension: "transactions", cadence: "daily" });
+
+    expect(result.current).not.toBeNull();
+    expect(result.current?.dimension).toBe("transactions");
+    expect(result.current?.severity).toBe(fullVM.severity);
+    expect(result.current?.title).toBe(fullVM.title);
+    expect(result.current?.lead).toBe(fullVM.lead);
+  });
+
+  it("condenses the highlights to at most two (compact section)", () => {
+    const { result } = renderHook(() => useInsightSection("transactions"));
+    const fullVM = selectFluidaVM({ dimension: "transactions", cadence: "daily" });
+
+    expect(fullVM.highlights.length).toBeGreaterThan(2);
+    expect(result.current?.highlights).toHaveLength(2);
+    expect(result.current?.highlights[0]).toEqual(fullVM.highlights[0]);
+  });
+
+  it("falls back to the general recorte for an unmapped dimension", () => {
+    const { result } = renderHook(() => useInsightSection("wallet"));
+    const generalVM = selectFluidaVM({ dimension: "general", cadence: "daily" });
+
+    expect(result.current?.dimension).toBe("general");
+    expect(result.current?.title).toBe(generalVM.title);
+  });
+
+  it("re-derives the recorte when the dimension changes", () => {
+    const { result, rerender } = renderHook(
+      ({ dimension }: { dimension: string }) => useInsightSection(dimension),
+      { initialProps: { dimension: "goals" } },
+    );
+
+    expect(result.current?.dimension).toBe("goals");
+
+    rerender({ dimension: "budgets" });
+
+    expect(result.current?.dimension).toBe("budgets");
+  });
+});

--- a/features/insights/hooks/use-insight-section.ts
+++ b/features/insights/hooks/use-insight-section.ts
@@ -1,0 +1,59 @@
+import { useMemo } from "react";
+
+import type { InsightDimension } from "@/features/insights/contracts";
+import { selectFluidaVM } from "@/features/insights/mocks/fluida-vm";
+import { AI_INSIGHTS_FLUIDA_FEATURE_FLAG_KEY } from "@/features/insights/insights-config";
+import { isFeatureEnabled } from "@/shared/feature-flags";
+import {
+  INSIGHT_SECTION_DIMENSIONS,
+  type InsightSectionVM,
+} from "@/shared/insights/insight-section-contracts";
+import { toInsightSectionVM } from "@/shared/insights/insight-section-vm";
+
+/**
+ * Normalises an arbitrary dimension hint coming from a feature page (which may
+ * pass a value with no mobile recorte yet, such as `wallet`) onto a known
+ * {@link InsightDimension}, falling back to `general`.
+ *
+ * @param dimension Raw dimension hint from the feature screen.
+ * @returns A dimension present in the mobile contract.
+ */
+const resolveSectionDimension = (dimension: string): InsightDimension => {
+  return (INSIGHT_SECTION_DIMENSIONS as readonly string[]).includes(dimension)
+    ? (dimension as InsightDimension)
+    : "general";
+};
+
+/**
+ * Reusable insights selector that feeds the per-feature "Insights de IA"
+ * section. Gated by the `app.insights.fluida` flag: returns `null` when the
+ * flag is OFF (the feature page then renders no section). When ON, it selects
+ * the daily Fluida VM for the requested dimension from the mock fixture and
+ * condenses it into the compact {@link InsightSectionVM} (lead + at most two
+ * highlights).
+ *
+ * Lives in `features/insights` (the cross-cutting insights provider) on
+ * purpose: the section UI is the shared, reusable piece — the data seam stays
+ * next to the insights mock so the shared component never depends on a feature.
+ *
+ * INTEGRATION POINT: {@link selectFluidaVM} is the single seam to the
+ * AI-generation backend — swap it for a query hook once the contract ships.
+ *
+ * @param dimension Feature dimension to slice (e.g. `transactions`, `goals`).
+ * @returns The compact section VM, or `null` when the flag is OFF.
+ */
+export const useInsightSection = (
+  dimension: string,
+): InsightSectionVM | null => {
+  const enabled = isFeatureEnabled(AI_INSIGHTS_FLUIDA_FEATURE_FLAG_KEY);
+
+  return useMemo<InsightSectionVM | null>(() => {
+    if (!enabled) {
+      return null;
+    }
+
+    const resolved = resolveSectionDimension(dimension);
+    const fullVM = selectFluidaVM({ dimension: resolved, cadence: "daily" });
+    return toInsightSectionVM(fullVM);
+  }, [dimension, enabled]);
+};

--- a/features/insights/hooks/use-insights-fluida-screen-controller.test.tsx
+++ b/features/insights/hooks/use-insights-fluida-screen-controller.test.tsx
@@ -28,6 +28,40 @@ describe("useInsightsFluidaScreenController", () => {
     expect(result.current.cadence).toBe("daily");
   });
 
+  it("starts on the dimension passed in (deep-link from a feature page)", () => {
+    const { result } = renderHook(() =>
+      useInsightsFluidaScreenController({ initialDimension: "transactions" }),
+    );
+
+    expect(result.current.dimension).toBe("transactions");
+    expect(result.current.cadence).toBe("daily");
+    expect(result.current.vm).toEqual(
+      selectFluidaVM({ dimension: "transactions", cadence: "daily" }),
+    );
+  });
+
+  it("ignores an undefined initial dimension and keeps the general default", () => {
+    const { result } = renderHook(() =>
+      useInsightsFluidaScreenController({ initialDimension: undefined }),
+    );
+
+    expect(result.current.dimension).toBe("general");
+  });
+
+  it("still lets the user switch dimension after a deep-linked start", () => {
+    const { result } = renderHook(() =>
+      useInsightsFluidaScreenController({ initialDimension: "budgets" }),
+    );
+
+    expect(result.current.dimension).toBe("budgets");
+
+    act(() => {
+      result.current.selectDimension("goals");
+    });
+
+    expect(result.current.dimension).toBe("goals");
+  });
+
   it("derives the full VM from the mock for the active dimension × cadence", () => {
     const { result } = renderHook(() => useInsightsFluidaScreenController());
 

--- a/features/insights/hooks/use-insights-fluida-screen-controller.ts
+++ b/features/insights/hooks/use-insights-fluida-screen-controller.ts
@@ -26,6 +26,15 @@ export interface InsightCadenceOption {
   readonly label: string;
 }
 
+export interface UseInsightsFluidaScreenControllerOptions {
+  /**
+   * Dimension to pre-select on mount, e.g. when the screen is opened from a
+   * feature page's "ler na íntegra" CTA (`/insights?dimension=goals`).
+   * Defaults to `general` when omitted.
+   */
+  readonly initialDimension?: InsightDimension;
+}
+
 export interface InsightsFluidaScreenController {
   readonly cadence: InsightCadence;
   readonly dimension: InsightDimension;
@@ -68,12 +77,16 @@ const CADENCE_OPTIONS: readonly InsightCadenceOption[] = [
  * INTEGRATION POINT: {@link selectFluidaVM} is the single seam to the
  * AI-generation backend — swap it for a query hook once the contract ships.
  *
+ * @param options Optional initial dimension (e.g. from a deep link).
  * @returns The derived state and handlers for the Fluida screen.
  */
-export const useInsightsFluidaScreenController =
-  (): InsightsFluidaScreenController => {
+export const useInsightsFluidaScreenController = (
+  options: UseInsightsFluidaScreenControllerOptions = {},
+): InsightsFluidaScreenController => {
     const [cadence, setCadence] = useState<InsightCadence>("daily");
-    const [dimension, setDimension] = useState<InsightDimension>("general");
+    const [dimension, setDimension] = useState<InsightDimension>(
+      options.initialDimension ?? "general",
+    );
     const resolvedTheme = useResolvedTheme();
     const isDark = resolvedTheme === "auraxis_dark";
 

--- a/features/insights/screens/insights-fluida-screen.test.tsx
+++ b/features/insights/screens/insights-fluida-screen.test.tsx
@@ -27,6 +27,18 @@ describe("InsightsFluidaScreen", () => {
     expect(getByText("Ontem em foco: muita saída, nenhuma entrada")).toBeTruthy();
   });
 
+  it("starts focused on the dimension passed in (deep link)", () => {
+    const { getByText } = render(
+      <TestProviders>
+        <InsightsFluidaScreen initialDimension="transactions" />
+      </TestProviders>,
+    );
+
+    expect(
+      getByText("Dia leve, mas dentro de um mês concentrado"),
+    ).toBeTruthy();
+  });
+
   it("swaps the lead when another theme tab is selected", () => {
     const { getByTestId, getByText } = render(
       <TestProviders>

--- a/features/insights/screens/insights-fluida-screen.tsx
+++ b/features/insights/screens/insights-fluida-screen.tsx
@@ -3,6 +3,7 @@ import type { ReactElement } from "react";
 import { YStack } from "tamagui";
 
 import { borderWidths } from "@/config/design-tokens";
+import type { InsightDimension } from "@/features/insights/contracts";
 import { ChartBeat } from "@/features/insights/fluida/components/chart-beat";
 import { CompareBeat } from "@/features/insights/fluida/components/compare-beat";
 import { InsightLead } from "@/features/insights/fluida/components/insight-lead";
@@ -11,6 +12,14 @@ import { PullStat } from "@/features/insights/fluida/components/pull-stat";
 import { TextBeat } from "@/features/insights/fluida/components/text-beat";
 import { useInsightsFluidaScreenController } from "@/features/insights/hooks/use-insights-fluida-screen-controller";
 import { AppScreen } from "@/shared/components/app-screen";
+
+export interface InsightsFluidaScreenProps {
+  /**
+   * Dimension to pre-select when the screen mounts, e.g. opened from a feature
+   * page's "ler na íntegra" CTA. Defaults to `general`.
+   */
+  readonly initialDimension?: InsightDimension;
+}
 
 /** Hairline divider between editorial beats. */
 function BeatDivider(): ReactElement {
@@ -25,10 +34,13 @@ function BeatDivider(): ReactElement {
  * paragraph paired with a pull-stat. The closing beats (attention list,
  * "where to go next", AI provenance) land in etapa 3.
  *
+ * @param props Optional initial dimension (deep link from a feature page).
  * @returns The composed Fluida screen.
  */
-export function InsightsFluidaScreen(): ReactElement {
-  const controller = useInsightsFluidaScreenController();
+export function InsightsFluidaScreen({
+  initialDimension,
+}: InsightsFluidaScreenProps = {}): ReactElement {
+  const controller = useInsightsFluidaScreenController({ initialDimension });
   const { vm } = controller;
   const [firstParagraph, secondParagraph] = vm.paragraphs;
   const pullStat = vm.highlights[0];

--- a/features/transactions/components/transaction-feed-toolbar.tsx
+++ b/features/transactions/components/transaction-feed-toolbar.tsx
@@ -8,6 +8,7 @@ import { YStack, useTheme } from "tamagui";
 import { appRoutes } from "@/core/navigation/routes";
 import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
 import { AiInsightSurface } from "@/features/insights/components/ai-insight-surface";
+import { useInsightSection } from "@/features/insights/hooks/use-insight-section";
 import { PeriodNavigator } from "@/features/transactions/components/transaction-filters";
 import {
   ExportSheet,
@@ -22,6 +23,10 @@ import { RevealInView } from "@/shared/animations/reveal-in-view";
 import { AppButton } from "@/shared/components/app-button";
 import { isFeatureEnabled } from "@/shared/feature-flags";
 import { useT } from "@/shared/i18n";
+import {
+  InsightSection,
+  buildInsightFluidaParams,
+} from "@/shared/insights";
 import { iconSizes } from "@/shared/theme";
 
 interface ToolbarButtonProps {
@@ -86,6 +91,7 @@ function FeedToolbar({
   const router = useRouter();
   const theme = useTheme();
   const importEnabled = isFeatureEnabled(IMPORT_FEATURE_FLAG_KEY);
+  const insightSection = useInsightSection("transactions");
   const iconColor = theme.muted?.val ?? theme.color?.val ?? "#000000";
   const badgeColor = theme.primary?.val ?? iconColor;
 
@@ -138,6 +144,10 @@ function FeedToolbar({
           <TxCategoryBreakdown categories={controller.categoryBars} />
         </RevealInView>
       ) : null}
+      <InsightSection
+        vm={insightSection}
+        onReadFull={() => router.push(buildInsightFluidaParams("transactions"))}
+      />
       <AiInsightSurface dimension="transactions" />
     </YStack>
   );

--- a/features/wallet/screens/wallet-screen.tsx
+++ b/features/wallet/screens/wallet-screen.tsx
@@ -4,6 +4,7 @@ import type { ReactElement } from "react";
 import { Paragraph, XStack, YStack } from "tamagui";
 
 import { appRoutes, buildTickerDetailPath } from "@/core/navigation/routes";
+import { useInsightSection } from "@/features/insights/hooks/use-insight-section";
 import { WalletEntryForm } from "@/features/wallet/components/wallet-entry-form";
 import { WalletValuationCard } from "@/features/wallet/components/wallet-valuation-card";
 import { WalletValuationHistoryCard } from "@/features/wallet/components/wallet-valuation-history-card";
@@ -16,6 +17,10 @@ import { AppButton } from "@/shared/components/app-button";
 import { AppKeyValueRow } from "@/shared/components/app-key-value-row";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppQueryState } from "@/shared/components/app-query-state";
+import {
+  InsightSection,
+  buildInsightFluidaParams,
+} from "@/shared/insights";
 import { WalletEntryListSkeleton } from "@/shared/skeletons";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
@@ -34,6 +39,10 @@ const formatChangePercent = (value: number): string => {
 export function WalletScreen(): ReactElement {
   const controller = useWalletScreenController();
   const router = useRouter();
+  // Carteira has no dedicated insight dimension in the mobile contract
+  // (`wallet` only exists on the web side), so the recorte falls back to the
+  // `general` reading until the backend ships a wallet slice.
+  const insightSection = useInsightSection("general");
   const handleOpenOperations = (entryId: string): void => {
     router.push({
       pathname: appRoutes.private.walletOperations,
@@ -64,6 +73,10 @@ export function WalletScreen(): ReactElement {
   return (
     <AppScreen>
       <SummaryCard controller={controller} />
+      <InsightSection
+        vm={insightSection}
+        onReadFull={() => router.push(buildInsightFluidaParams("general"))}
+      />
       <WalletValuationCard />
       <WalletValuationHistoryCard />
       <AssetsListCard

--- a/shared/insights/index.ts
+++ b/shared/insights/index.ts
@@ -1,0 +1,20 @@
+export { InsightSection, type InsightSectionProps } from "@/shared/insights/insight-section";
+export {
+  buildInsightFluidaParams,
+  parseInsightDimensionParam,
+  INSIGHT_DIMENSION_PARAM,
+  INSIGHT_SECTION_DIMENSIONS,
+} from "@/shared/insights/insight-fluida-params";
+export {
+  toInsightSectionVM,
+  INSIGHT_SECTION_DEFAULT_MAX_HIGHLIGHTS,
+  type ToInsightSectionVMOptions,
+} from "@/shared/insights/insight-section-vm";
+export {
+  getInsightSectionDimensionLabel,
+  type InsightSectionDimension,
+  type InsightSectionHighlight,
+  type InsightSectionSeverity,
+  type InsightSectionSource,
+  type InsightSectionVM,
+} from "@/shared/insights/insight-section-contracts";

--- a/shared/insights/insight-fluida-params.test.ts
+++ b/shared/insights/insight-fluida-params.test.ts
@@ -1,0 +1,60 @@
+import {
+  INSIGHT_SECTION_DIMENSIONS,
+  buildInsightFluidaParams,
+  parseInsightDimensionParam,
+} from "@/shared/insights/insight-fluida-params";
+
+describe("buildInsightFluidaParams", () => {
+  it("targets the Fluida insights route", () => {
+    const href = buildInsightFluidaParams("transactions");
+
+    expect(href).toMatchObject({ pathname: "/insights" });
+  });
+
+  it("carries the dimension as a route param", () => {
+    const href = buildInsightFluidaParams("budgets");
+
+    expect(href).toMatchObject({
+      pathname: "/insights",
+      params: { dimension: "budgets" },
+    });
+  });
+
+  it.each(INSIGHT_SECTION_DIMENSIONS)(
+    "round-trips the %s dimension through build → parse",
+    (dimension) => {
+      const href = buildInsightFluidaParams(dimension);
+      const params = (href as unknown as { params: { dimension: string } })
+        .params;
+
+      expect(parseInsightDimensionParam(params.dimension)).toBe(dimension);
+    },
+  );
+});
+
+describe("parseInsightDimensionParam", () => {
+  it("returns the matching dimension for a known value", () => {
+    expect(parseInsightDimensionParam("goals")).toBe("goals");
+    expect(parseInsightDimensionParam("credit_cards")).toBe("credit_cards");
+  });
+
+  it("returns undefined for an unknown value", () => {
+    expect(parseInsightDimensionParam("wallet")).toBeUndefined();
+    expect(parseInsightDimensionParam("nope")).toBeUndefined();
+  });
+
+  it("returns undefined for an empty or missing value", () => {
+    expect(parseInsightDimensionParam("")).toBeUndefined();
+    expect(parseInsightDimensionParam(undefined)).toBeUndefined();
+  });
+
+  it("takes the first entry when the router passes an array param", () => {
+    expect(parseInsightDimensionParam(["transactions", "goals"])).toBe(
+      "transactions",
+    );
+  });
+
+  it("returns undefined for an empty array param", () => {
+    expect(parseInsightDimensionParam([])).toBeUndefined();
+  });
+});

--- a/shared/insights/insight-fluida-params.ts
+++ b/shared/insights/insight-fluida-params.ts
@@ -1,0 +1,56 @@
+import type { Href } from "expo-router";
+
+import { appRoutes } from "@/core/navigation/routes";
+import {
+  INSIGHT_SECTION_DIMENSIONS,
+  type InsightSectionDimension,
+} from "@/shared/insights/insight-section-contracts";
+
+export { INSIGHT_SECTION_DIMENSIONS };
+
+/**
+ * Query-param key carrying the pre-selected dimension into the Fluida screen.
+ */
+export const INSIGHT_DIMENSION_PARAM = "dimension";
+
+/**
+ * Builds the Expo Router target that opens the full "Fluida" reading already
+ * focused on a given dimension (e.g. `/insights?dimension=transactions`). Used
+ * by the per-feature "ler na íntegra" CTA.
+ *
+ * @param dimension Dimension to pre-select on the Fluida screen.
+ * @returns An Expo Router `Href` to the insights route with the dimension param.
+ */
+export const buildInsightFluidaParams = (
+  dimension: InsightSectionDimension,
+): Href => ({
+  pathname: appRoutes.private.insights,
+  params: { [INSIGHT_DIMENSION_PARAM]: dimension },
+});
+
+const isInsightSectionDimension = (
+  value: string,
+): value is InsightSectionDimension => {
+  return (INSIGHT_SECTION_DIMENSIONS as readonly string[]).includes(value);
+};
+
+/**
+ * Parses the raw `dimension` route param (Expo Router yields a string, a
+ * string array or `undefined`) into a validated {@link InsightSectionDimension},
+ * or `undefined` when absent/unknown — so the Fluida screen can fall back to
+ * its default dimension.
+ *
+ * @param raw Raw param value from `useLocalSearchParams`.
+ * @returns The matching dimension, or `undefined`.
+ */
+export const parseInsightDimensionParam = (
+  raw: string | readonly string[] | undefined,
+): InsightSectionDimension | undefined => {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+
+  if (typeof value !== "string" || value.length === 0) {
+    return undefined;
+  }
+
+  return isInsightSectionDimension(value) ? value : undefined;
+};

--- a/shared/insights/insight-section-contracts.ts
+++ b/shared/insights/insight-section-contracts.ts
@@ -1,0 +1,100 @@
+/**
+ * Insight dimension as far as the **compact section** is concerned. Mirrors
+ * the mobile `InsightDimension` enum (`features/insights/contracts`) as a
+ * self-contained literal union so this shared module owns no dependency on
+ * any feature — the insights selector that feeds the section maps the real
+ * enum onto this type, and the two unions are structurally identical.
+ *
+ * Note: the product handoff lists a `wallet` recorte, but `wallet` is not a
+ * dimension in the mobile contract (it only exists on the web side). The
+ * Carteira screen therefore falls back to `general` until the backend ships
+ * a wallet slice.
+ */
+export type InsightSectionDimension =
+  | "general"
+  | "transactions"
+  | "credit_cards"
+  | "goals"
+  | "budgets";
+
+/**
+ * Canonical list of section dimensions, used to validate route params and to
+ * drive parametrised tests.
+ */
+export const INSIGHT_SECTION_DIMENSIONS: readonly InsightSectionDimension[] = [
+  "general",
+  "transactions",
+  "credit_cards",
+  "goals",
+  "budgets",
+];
+
+/**
+ * Human-readable kicker label per dimension, shown above the section
+ * headline. Self-contained here (mirrors `getInsightDimensionLabel` from
+ * `features/insights`) so this shared module owns no feature dependency.
+ */
+const INSIGHT_SECTION_DIMENSION_LABELS: Record<InsightSectionDimension, string> = {
+  general: "Visao geral",
+  transactions: "Transacoes",
+  credit_cards: "Cartoes",
+  goals: "Metas",
+  budgets: "Orcamentos",
+};
+
+/**
+ * Returns the kicker label for a section dimension.
+ *
+ * @param dimension Section dimension.
+ * @returns Localised dimension label.
+ */
+export const getInsightSectionDimensionLabel = (
+  dimension: InsightSectionDimension,
+): string => {
+  return INSIGHT_SECTION_DIMENSION_LABELS[dimension];
+};
+
+/**
+ * Editorial severity of a section lead. Identical to the Fluida
+ * `InsightSeverity` so the full VM is assignable to {@link InsightSectionSource}.
+ */
+export type InsightSectionSeverity = "ok" | "attention" | "alert";
+
+/**
+ * One numeric highlight tile shown inside the compact section: a short label,
+ * a value and a one-line sub-caption.
+ */
+export interface InsightSectionHighlight {
+  readonly label: string;
+  readonly value: string;
+  readonly sub: string;
+}
+
+/**
+ * Structural input accepted by {@link toInsightSectionVM}. Declared with only
+ * the fields the section needs so the full Fluida VM
+ * (`InsightFluidaVM`) is assignable to it without this shared module
+ * importing the feature contract. Keeps the dependency arrow pointing the
+ * right way (feature → shared, never shared → feature).
+ */
+export interface InsightSectionSource {
+  readonly dimension: InsightSectionDimension;
+  readonly severity: InsightSectionSeverity;
+  readonly title: string;
+  readonly lead: string;
+  readonly highlights: readonly InsightSectionHighlight[];
+}
+
+/**
+ * Compact view model for the per-feature "Insights de IA" section: the
+ * editorial recorte of a single dimension — severity + headline, a short lead
+ * and one or two highlights — plus a CTA that opens the full Fluida reading on
+ * that theme.
+ */
+export interface InsightSectionVM {
+  readonly dimension: InsightSectionDimension;
+  readonly severity: InsightSectionSeverity;
+  readonly title: string;
+  readonly lead: string;
+  readonly highlights: readonly InsightSectionHighlight[];
+}

--- a/shared/insights/insight-section-severity.ts
+++ b/shared/insights/insight-section-severity.ts
@@ -1,0 +1,42 @@
+import type { InsightSectionSeverity } from "@/shared/insights/insight-section-contracts";
+
+/**
+ * Visual descriptor for the compact section severity chip. `colorToken` drives
+ * the text/dot colour and `tintToken` the chip background — both are Tamagui
+ * theme tokens so light/dark resolve automatically and nothing is hardcoded at
+ * the call site.
+ *
+ * Self-contained in `shared/insights` (it mirrors the Fluida severity visual)
+ * so this shared module owns no dependency on `features/insights`.
+ */
+export interface SectionSeverityVisual {
+  readonly label: string;
+  readonly colorToken: `$${string}`;
+  readonly tintToken: `$${string}`;
+}
+
+const SECTION_SEVERITY_VISUALS: Record<
+  InsightSectionSeverity,
+  SectionSeverityVisual
+> = {
+  ok: { label: "Tudo certo", colorToken: "$success", tintToken: "$successSubtle" },
+  attention: {
+    label: "Atenção",
+    colorToken: "$warning",
+    tintToken: "$warningSubtle",
+  },
+  alert: { label: "Alerta", colorToken: "$danger", tintToken: "$dangerSubtle" },
+};
+
+/**
+ * Resolves the colour/tint/label triple used to render the section severity
+ * chip.
+ *
+ * @param severity Editorial severity of the recorte.
+ * @returns Theme-token-based visual descriptor for the chip.
+ */
+export const resolveSectionSeverityVisual = (
+  severity: InsightSectionSeverity,
+): SectionSeverityVisual => {
+  return SECTION_SEVERITY_VISUALS[severity];
+};

--- a/shared/insights/insight-section-vm.test.ts
+++ b/shared/insights/insight-section-vm.test.ts
@@ -1,0 +1,59 @@
+import type { InsightSectionSource } from "@/shared/insights/insight-section-contracts";
+import { toInsightSectionVM } from "@/shared/insights/insight-section-vm";
+
+const buildSource = (
+  override: Partial<InsightSectionSource> = {},
+): InsightSectionSource => ({
+  dimension: "transactions",
+  severity: "attention",
+  title: "Dia leve, mês concentrado",
+  lead: "Ontem houve só uma compra pequena, mas a fatura pesa.",
+  highlights: [
+    { label: "Maior gasto do mês", value: "R$ 11.000,00", sub: "Fatura Maio" },
+    { label: "Único crédito", value: "R$ 27.675,37", sub: "Salário · 30/06" },
+    { label: "Gasto de ontem", value: "R$ 156,30", sub: "Eletrônicos" },
+  ],
+  ...override,
+});
+
+describe("toInsightSectionVM", () => {
+  it("carries the lead identity (dimension, severity, title, lead)", () => {
+    const vm = toInsightSectionVM(buildSource());
+
+    expect(vm).toMatchObject({
+      dimension: "transactions",
+      severity: "attention",
+      title: "Dia leve, mês concentrado",
+      lead: "Ontem houve só uma compra pequena, mas a fatura pesa.",
+    });
+  });
+
+  it("keeps at most two highlights by default (compact recorte)", () => {
+    const vm = toInsightSectionVM(buildSource());
+
+    expect(vm.highlights).toHaveLength(2);
+    expect(vm.highlights[0]).toMatchObject({ label: "Maior gasto do mês" });
+    expect(vm.highlights[1]).toMatchObject({ label: "Único crédito" });
+  });
+
+  it("honours a custom highlight cap", () => {
+    const vm = toInsightSectionVM(buildSource(), { maxHighlights: 1 });
+
+    expect(vm.highlights).toHaveLength(1);
+    expect(vm.highlights[0]).toMatchObject({ label: "Maior gasto do mês" });
+  });
+
+  it("tolerates a source with no highlights", () => {
+    const vm = toInsightSectionVM(buildSource({ highlights: [] }));
+
+    expect(vm.highlights).toEqual([]);
+  });
+
+  it("does not mutate the source highlights array", () => {
+    const source = buildSource();
+
+    toInsightSectionVM(source, { maxHighlights: 1 });
+
+    expect(source.highlights).toHaveLength(3);
+  });
+});

--- a/shared/insights/insight-section-vm.ts
+++ b/shared/insights/insight-section-vm.ts
@@ -1,0 +1,44 @@
+import type {
+  InsightSectionSource,
+  InsightSectionVM,
+} from "@/shared/insights/insight-section-contracts";
+
+/**
+ * Default number of highlights surfaced in the compact section. The recorte
+ * keeps it short (lead + one or two destaques) — the full reading carries the
+ * rest.
+ */
+export const INSIGHT_SECTION_DEFAULT_MAX_HIGHLIGHTS = 2;
+
+export interface ToInsightSectionVMOptions {
+  /** Cap on how many highlights to keep (default {@link INSIGHT_SECTION_DEFAULT_MAX_HIGHLIGHTS}). */
+  readonly maxHighlights?: number;
+}
+
+/**
+ * Condenses a full insight source (the Fluida VM is assignable) into the
+ * compact {@link InsightSectionVM} shown on each feature page: it keeps the
+ * lead identity (dimension, severity, title, lead) and trims the highlights to
+ * the first one or two so the section stays a recorte, not the full reading.
+ *
+ * Pure and side-effect free — the source array is sliced, never mutated.
+ *
+ * @param source Full insight source for a single dimension.
+ * @param options Optional highlight cap.
+ * @returns The compact section view model.
+ */
+export const toInsightSectionVM = (
+  source: InsightSectionSource,
+  options: ToInsightSectionVMOptions = {},
+): InsightSectionVM => {
+  const maxHighlights =
+    options.maxHighlights ?? INSIGHT_SECTION_DEFAULT_MAX_HIGHLIGHTS;
+
+  return {
+    dimension: source.dimension,
+    severity: source.severity,
+    title: source.title,
+    lead: source.lead,
+    highlights: source.highlights.slice(0, Math.max(0, maxHighlights)),
+  };
+};

--- a/shared/insights/insight-section.test.tsx
+++ b/shared/insights/insight-section.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { InsightSectionVM } from "@/shared/insights/insight-section-contracts";
+import { InsightSection } from "@/shared/insights/insight-section";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+const buildVM = (override: Partial<InsightSectionVM> = {}): InsightSectionVM => ({
+  dimension: "transactions",
+  severity: "attention",
+  title: "Dia leve, mês concentrado",
+  lead: "Ontem houve só uma compra pequena, mas a fatura pesa.",
+  highlights: [
+    { label: "Maior gasto do mês", value: "R$ 11.000,00", sub: "Fatura Maio" },
+    { label: "Único crédito", value: "R$ 27.675,37", sub: "Salário · 30/06" },
+  ],
+  ...override,
+});
+
+const renderSection = (
+  vm: InsightSectionVM | null,
+  onReadFull = jest.fn(),
+): ReturnType<typeof render> =>
+  render(
+    <TestProviders>
+      <InsightSection vm={vm} onReadFull={onReadFull} />
+    </TestProviders>,
+  );
+
+describe("InsightSection", () => {
+  it("renders nothing when the VM is null (flag OFF)", () => {
+    const { queryByTestId } = renderSection(null);
+
+    expect(queryByTestId("insight-section")).toBeNull();
+  });
+
+  it("renders the compact lead: severity chip and headline", () => {
+    const { getByTestId, getByText } = renderSection(buildVM());
+
+    expect(getByTestId("insight-section")).toBeTruthy();
+    expect(getByText("Atenção")).toBeTruthy();
+    expect(getByText("Dia leve, mês concentrado")).toBeTruthy();
+  });
+
+  it("renders the highlights of the recorte", () => {
+    const { getByText } = renderSection(buildVM());
+
+    expect(getByText("Maior gasto do mês")).toBeTruthy();
+    expect(getByText("R$ 11.000,00")).toBeTruthy();
+    expect(getByText("Único crédito")).toBeTruthy();
+  });
+
+  it("renders the 'ler na íntegra' CTA and fires onReadFull when pressed", () => {
+    const onReadFull = jest.fn();
+    const { getByTestId } = renderSection(buildVM(), onReadFull);
+
+    fireEvent.press(getByTestId("insight-section-read-full"));
+
+    expect(onReadFull).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the lead paragraph and stays compact without highlights", () => {
+    const { getByText, queryByTestId } = renderSection(
+      buildVM({ highlights: [] }),
+    );
+
+    expect(
+      getByText("Ontem houve só uma compra pequena, mas a fatura pesa."),
+    ).toBeTruthy();
+    expect(queryByTestId("insight-section-read-full")).toBeTruthy();
+  });
+
+  it("labels the section with an accessible severity for each level", () => {
+    const { getByText } = renderSection(buildVM({ severity: "alert" }));
+
+    expect(getByText("Alerta")).toBeTruthy();
+  });
+});

--- a/shared/insights/insight-section.tsx
+++ b/shared/insights/insight-section.tsx
@@ -1,0 +1,207 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import { borderWidths, letterSpacings } from "@/config/design-tokens";
+import { AppButton } from "@/shared/components/app-button";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+import {
+  getInsightSectionDimensionLabel,
+  type InsightSectionHighlight,
+  type InsightSectionSeverity,
+  type InsightSectionVM,
+} from "@/shared/insights/insight-section-contracts";
+import { resolveSectionSeverityVisual } from "@/shared/insights/insight-section-severity";
+
+export interface InsightSectionProps {
+  /**
+   * Compact recorte for this feature page, or `null` when the
+   * `app.insights.fluida` flag is OFF (the section then renders nothing).
+   */
+  readonly vm: InsightSectionVM | null;
+  /** Opens the full "Fluida" reading focused on this dimension. */
+  readonly onReadFull: () => void;
+}
+
+/**
+ * Compact, reusable "Insights de IA" section shown on each feature page
+ * (Transações, Metas, Orçamentos, Cartões, Carteira). Renders the recorte of a
+ * single dimension: a kicker + severity chip, a serif headline, a short lead,
+ * one or two highlights, and a "ler na íntegra" CTA that opens the full Fluida
+ * reading already on that theme.
+ *
+ * Lives in `shared/insights` so it is consumed across features without a
+ * feature-to-feature import; the data (`vm`) and navigation (`onReadFull`) are
+ * injected by the host screen. Renders `null` when `vm` is `null`.
+ *
+ * @param props The compact VM and the "ler na íntegra" handler.
+ * @returns The composed section, or `null` when there is no VM.
+ */
+export function InsightSection({
+  vm,
+  onReadFull,
+}: InsightSectionProps): ReactElement | null {
+  if (!vm) {
+    return null;
+  }
+
+  return (
+    <AppSurfaceCard
+      title="Insights de IA"
+      description={getInsightSectionDimensionLabel(vm.dimension)}
+      testID="insight-section"
+    >
+      <YStack gap="$3">
+        <SectionLead
+          dimension={vm.dimension}
+          severity={vm.severity}
+          title={vm.title}
+          lead={vm.lead}
+        />
+
+        {vm.highlights.length > 0 ? (
+          <YStack gap="$2" testID="insight-section-highlights">
+            {vm.highlights.map((highlight) => (
+              <SectionHighlight
+                key={highlight.label}
+                highlight={highlight}
+              />
+            ))}
+          </YStack>
+        ) : null}
+
+        <AppButton
+          tone="secondary"
+          size="sm"
+          onPress={onReadFull}
+          accessibilityLabel="Ler a leitura completa de insights"
+          testID="insight-section-read-full"
+        >
+          Ler na íntegra
+        </AppButton>
+      </YStack>
+    </AppSurfaceCard>
+  );
+}
+
+interface SectionLeadProps {
+  readonly dimension: InsightSectionVM["dimension"];
+  readonly severity: InsightSectionSeverity;
+  readonly title: string;
+  readonly lead: string;
+}
+
+function SectionLead({
+  dimension,
+  severity,
+  title,
+  lead,
+}: SectionLeadProps): ReactElement {
+  return (
+    <YStack gap="$2" testID="insight-section-lead">
+      <XStack alignItems="center" gap="$2" flexWrap="wrap">
+        <Paragraph
+          color="$primary"
+          fontFamily="$body"
+          fontSize="$1"
+          fontWeight="$7"
+          letterSpacing={letterSpacings.caps}
+          textTransform="uppercase"
+        >
+          {getInsightSectionDimensionLabel(dimension)}
+        </Paragraph>
+        <SectionSevChip severity={severity} />
+      </XStack>
+
+      <Paragraph
+        color="$color"
+        fontFamily="$serif"
+        fontSize="$6"
+        fontWeight="$6"
+        lineHeight="$6"
+        testID="insight-section-headline"
+      >
+        {title}
+      </Paragraph>
+
+      <Paragraph
+        color="$color"
+        fontFamily="$body"
+        fontSize="$3"
+        lineHeight="$4"
+        numberOfLines={3}
+      >
+        {lead}
+      </Paragraph>
+    </YStack>
+  );
+}
+
+function SectionSevChip({
+  severity,
+}: {
+  readonly severity: InsightSectionSeverity;
+}): ReactElement {
+  const visual = resolveSectionSeverityVisual(severity);
+
+  return (
+    <XStack
+      alignItems="center"
+      gap="$1"
+      paddingHorizontal="$2"
+      paddingVertical="$1"
+      borderRadius="$5"
+      borderWidth={borderWidths.hairline}
+      backgroundColor={visual.tintToken}
+      borderColor={visual.colorToken}
+      alignSelf="flex-start"
+      accessibilityRole="text"
+      accessibilityLabel={`Severidade: ${visual.label}`}
+    >
+      <Paragraph
+        color={visual.colorToken}
+        fontFamily="$body"
+        fontSize="$1"
+        fontWeight="$7"
+      >
+        {visual.label}
+      </Paragraph>
+    </XStack>
+  );
+}
+
+function SectionHighlight({
+  highlight,
+}: {
+  readonly highlight: InsightSectionHighlight;
+}): ReactElement {
+  return (
+    <XStack
+      alignItems="center"
+      justifyContent="space-between"
+      gap="$3"
+      paddingVertical="$2"
+      paddingHorizontal="$3"
+      borderRadius="$3"
+      backgroundColor="$backgroundPress"
+    >
+      <YStack flexShrink={1} gap="$1">
+        <Paragraph color="$color" fontFamily="$body" fontSize="$3" fontWeight="$6">
+          {highlight.label}
+        </Paragraph>
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$1">
+          {highlight.sub}
+        </Paragraph>
+      </YStack>
+      <Paragraph
+        color="$color"
+        fontFamily="$body"
+        fontSize="$4"
+        fontWeight="$7"
+        textAlign="right"
+      >
+        {highlight.value}
+      </Paragraph>
+    </XStack>
+  );
+}


### PR DESCRIPTION
## O quê

Etapa 4 do épico Insights Fluida: cada página de feature (Transações, Metas, Orçamentos, Cartões, Carteira) ganha uma **section "Insights de IA" compacta** — recorte daquela feature (lead curto: severity + título + 1–2 destaques) com um botão **"ler na íntegra"** que abre a tela Fluida **já na aba daquele tema**. Tudo atrás da flag `app.insights.fluida` (OFF, status `draft`); com a flag OFF as telas não mostram nada.

Closes #605

## Decisões de arquitetura

**`InsightSection` mora em `shared/insights/` (não viola "sem import lateral entre features").**
O componente reusável e a lógica vivem em `shared/insights/` e são consumidos pelas 5 features — `shared` não é uma feature, então não há import feature→feature. O módulo é **autocontido**: define os próprios literais de dimensão/severity, um mapper puro full→compacto (`toInsightSectionVM`) e o builder/parser de param do Expo Router (`buildInsightFluidaParams` / `parseInsightDimensionParam`). Nenhum arquivo de `features/insights` foi movido (isso exigiria perguntar) — apenas **exposto** o que era preciso.

**Seam de dados em `features/insights`.** O VM compacto vem de `useInsightSection(dimension)` (hook/seletor reutilizável de insights), gated pela flag, que seleciona do mock existente (`selectFluidaVM`, daily) e condensa via o mapper do shared. Isso mantém a seta de dependência correta (feature → shared, nunca shared → feature) e segue o precedente do `AiInsightSurface` (insights como provider cross-cutting). Quando o backend publicar o contrato, basta trocar `selectFluidaVM`.

**Navegação por dimensão.** O CTA chama `router.push(buildInsightFluidaParams(dim))` → `/insights?dimension=<dim>`. A rota `app/(private)/insights.tsx` lê o param com `useLocalSearchParams` + `parseInsightDimensionParam` e passa `initialDimension` ao screen; o controller do Fluida inicializa a aba naquela dimensão (e o usuário ainda pode trocar de aba normalmente).

## Telas que receberam a section

| Tela | Dimensão | Onde |
|------|----------|------|
| Transações | `transactions` | `transaction-feed-toolbar` (junto ao insight existente) |
| Metas | `goals` | `goals-screen` |
| Orçamentos | `budgets` | `budgets-screen` |
| Cartões | `credit_cards` | `credit-cards-screen` (após o hero) |
| Carteira | `general` (fallback) | `wallet-screen` |

**`wallet` não existe no enum `InsightDimension` do app** (só no contrato web). A Carteira usa o recorte `general` como fallback (CTA abre Fluida em `general`) até o backend publicar um slice de carteira; `useInsightSection` também normaliza qualquer dimensão desconhecida para `general`.

## TDD

Lógica primeiro (param build/parse, mapper compacto, gating do seletor, `initialDimension` no controller/screen), depois render da `InsightSection` (lead + destaque + CTA + gating por VM nulo).

## Quality gate

`npm run quality-check` **verde**: 408 suítes / 2620 testes / 6 snapshots passam; lint + typecheck + policy:check + contracts:check + codegen:check OK; cobertura ≥ 85% (arquivos novos com **100%**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx