### PR TITLE
chore(insights): ativa flag app.insights.fluida em producao

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -106,8 +106,8 @@
       "createdAt": "2026-06-21",
       "removeBy": "2026-12-31",
       "type": "release",
-      "status": "draft",
-      "description": "Controla a nova leitura editorial Fluida dos insights de IA no app (entrega incremental, default OFF).",
+      "status": "enabled-prod",
+      "description": "Controla a nova leitura editorial Fluida dos insights de IA no app (ativada em producao).",
       "repositories": ["auraxis-app", "auraxis-api"]
     }
   ]


### PR DESCRIPTION
## Objetivo

Ativacao em **producao (100%)** da feature **Insights de IA — Fluida** no app.

Promove a flag `app.insights.fluida` de `draft` para `enabled-prod` em `config/feature-flags.json`, seguindo o mesmo padrao das demais flags ja ativas em producao (ex.: `app.insights.contextual`, `app.insights.weekly`).

## Contexto

A implementacao da Fluida ja foi entregue e mergeada (issues #599, #601, #603, #605, #607 — PRs #600, #602, #604, #606, #608). Esta mudanca apenas liga o gate de release.

## Mudanca

- `app.insights.fluida`: `status` `draft` -> `enabled-prod`

No app, qualquer `enabled-*` faz `isFeatureEnabled` retornar `true`; `enabled-prod` e o status canonico de producao. A entrega do JS para os usuarios e feita via OTA (EAS Update) no canal `production`.

## Validacao

- `flags:check` (feature-flags-hygiene): OK (11 flags)
- Staging seletivo (apenas `config/feature-flags.json`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012jZX5Ur2XsT1DqQcEP4tjx