### PR TITLE
feat(credit-cards): equaliza ações de despesas da fatura

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -91,6 +91,16 @@
       "repositories": ["auraxis-app", "auraxis-api", "auraxis-web"]
     },
     {
+      "key": "app.credit-cards.expense-actions",
+      "owner": "platform",
+      "createdAt": "2026-06-27",
+      "removeBy": "2026-12-31",
+      "type": "release",
+      "status": "enabled-dev",
+      "description": "Controla as acoes mobile de editar, duplicar e remover despesas dentro da fatura do cartao.",
+      "repositories": ["auraxis-app", "auraxis-api", "auraxis-web"]
+    },
+    {
       "key": "app.insights.contextual",
       "owner": "platform",
       "createdAt": "2026-05-19",

--- a/docs/runbooks/credit-card-expense-actions.md
+++ b/docs/runbooks/credit-card-expense-actions.md
@@ -1,0 +1,49 @@
+# Credit card expense actions
+
+## Overview
+
+The mobile credit card bill can manage bill expenses directly from the invoice
+item list. A card expense is the same backend `transactions` record with
+`creditCardId` filled; the app must not create a separate expense entity for the
+Cards domain.
+
+## Runtime flag
+
+- Key: `app.credit-cards.expense-actions`
+- Catalog: `config/feature-flags.json`
+- Initial status: `enabled-dev`
+
+When the flag is disabled by the runtime provider, invoice items render as a
+read-only list. When enabled, each item exposes edit, duplicate and remove
+actions plus the "Também em Transações" sync chip.
+
+## Behavior
+
+- Edit opens the shared expense sheet in `edit` mode, hydrated from the original
+  `TransactionRecord`.
+- Create keeps the previous "Lancar despesa" flow and supports installments and
+  down payment.
+- Edit hides create-only installment controls and updates the existing
+  transaction through `useUpdateTransactionMutation`.
+- Duplicate creates a simple pending transaction copy with the same date, card,
+  category, account, description and currency, plus the title suffix
+  ` (cópia)`. Recurrence and installment flags are intentionally not copied.
+- Remove confirms the action and deletes the occurrence from `transactions`,
+  making it disappear from both Cards and Transactions.
+
+After create, edit, duplicate or remove, invalidate `transactions`,
+`credit-cards` and `dashboard` query roots so bill totals, feeds and dashboard
+summaries converge without requiring an app restart.
+
+## Validation
+
+Focused coverage lives in:
+
+- `stores/expense-sheet-store.test.ts`
+- `features/credit-cards/hooks/use-expense-form.test.tsx`
+- `features/credit-cards/components/expense-sheet/expense-sheet.test.tsx`
+- `features/credit-cards/components/invoice-grouped-items.test.tsx`
+- `features/credit-cards/hooks/use-credit-card-bill-screen-controller.test.tsx`
+- `features/credit-cards/screens/credit-card-bill-screen.test.tsx`
+
+Run `npm run quality-check` before release.

--- a/features/credit-cards/components/card-detail-components.test.tsx
+++ b/features/credit-cards/components/card-detail-components.test.tsx
@@ -16,6 +16,7 @@ import { InvoiceGroupedItems } from "@/features/credit-cards/components/invoice-
 import { InvoiceHero } from "@/features/credit-cards/components/invoice-hero";
 import type { CategoryGroup } from "@/features/credit-cards/model/credit-card-aggregation";
 import type { EnrichedTransaction } from "@/features/credit-cards/model/card-transactions";
+import { transactionFixture } from "@/features/transactions/mocks";
 import { resolveCardGradient } from "@/shared/theme";
 
 const wrap = (node: React.ReactElement) =>
@@ -23,20 +24,38 @@ const wrap = (node: React.ReactElement) =>
 
 const gradient = resolveCardGradient({ id: "card-1", bank: "Inter", name: "Inter" });
 
-const tx = (overrides: Partial<EnrichedTransaction> = {}): EnrichedTransaction => ({
-  id: "tx-1",
-  title: "Renner",
-  amount: 938.57,
-  purchaseDate: "2026-06-25",
-  tagId: "tag-compras",
-  creditCardId: "card-1",
-  billMonth: "2026-06",
-  isInstallment: false,
-  installmentCount: null,
-  installmentGroupId: null,
-  status: "paid",
-  ...overrides,
-});
+const tx = (overrides: Partial<EnrichedTransaction> = {}): EnrichedTransaction => {
+  const item = {
+    id: "tx-1",
+    title: "Renner",
+    amount: 938.57,
+    purchaseDate: "2026-06-25",
+    tagId: "tag-compras",
+    creditCardId: "card-1",
+    billMonth: "2026-06",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "paid",
+    ...overrides,
+  };
+  return {
+    ...item,
+    transaction: overrides.transaction ?? {
+      ...transactionFixture,
+      id: item.id,
+      title: item.title,
+      amount: item.amount.toFixed(2),
+      dueDate: item.purchaseDate,
+      tagId: item.tagId,
+      creditCardId: item.creditCardId,
+      isInstallment: item.isInstallment,
+      installmentCount: item.installmentCount,
+      installmentGroupId: item.installmentGroupId,
+      status: "paid",
+    },
+  };
+};
 
 const category: CategoryGroup = {
   tagId: "tag-compras",

--- a/features/credit-cards/components/cards-home-components.test.tsx
+++ b/features/credit-cards/components/cards-home-components.test.tsx
@@ -14,6 +14,7 @@ import { OndeFoiGasto } from "@/features/credit-cards/components/onde-foi-gasto"
 import type { CreditCard } from "@/features/credit-cards/contracts";
 import type { AnalyticsViewModel } from "@/features/credit-cards/model/credit-card-analytics";
 import type { StatementViewModel } from "@/features/credit-cards/model/credit-card-statement";
+import { transactionFixture } from "@/features/transactions/mocks";
 
 const card: CreditCard = {
   id: "card-1",
@@ -51,6 +52,16 @@ const categories: StatementViewModel["categories"] = [
         installmentCount: null,
         installmentGroupId: null,
         status: "posted",
+        transaction: {
+          ...transactionFixture,
+          id: "tx-1",
+          title: "Renner",
+          amount: "938.57",
+          dueDate: "2026-06-25",
+          tagId: "t1",
+          creditCardId: "card-1",
+          status: "pending",
+        },
       },
     ],
   },

--- a/features/credit-cards/components/expense-sheet/expense-sheet-host.test.tsx
+++ b/features/credit-cards/components/expense-sheet/expense-sheet-host.test.tsx
@@ -5,6 +5,7 @@ import type {
   ExpenseFormController,
   ExpenseSubmitResult,
 } from "@/features/credit-cards/hooks/use-expense-form";
+import type { TransactionRecord } from "@/features/transactions/contracts";
 import { TestProviders } from "@/shared/testing/test-providers";
 import {
   resetExpenseSheetStore,
@@ -17,6 +18,39 @@ jest.mock("react-native-safe-area-context", () => ({
 
 const submitMock = jest.fn<Promise<ExpenseSubmitResult>, []>();
 const resetMock = jest.fn();
+const mockUseExpenseForm = jest.fn((_request: unknown) => mockController);
+
+const buildTransaction = (
+  override: Partial<TransactionRecord> = {},
+): TransactionRecord => ({
+  id: "tx-1",
+  title: "Mercado",
+  amount: "50.00",
+  type: "expense",
+  dueDate: "2026-06-20",
+  startDate: null,
+  endDate: null,
+  description: null,
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: null,
+  accountId: null,
+  creditCardId: "cc-1",
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: null,
+  updatedAt: null,
+  ...override,
+});
 
 const mockController: ExpenseFormController = {
   cards: [],
@@ -25,6 +59,7 @@ const mockController: ExpenseFormController = {
   title: "",
   amountText: "50.00",
   amount: 50,
+  formMode: "create",
   purchaseDate: "2026-06-20",
   creditCardId: null,
   tagId: null,
@@ -34,6 +69,7 @@ const mockController: ExpenseFormController = {
   installments: 3,
   hasDownPayment: false,
   downPaymentText: "",
+  description: "",
   plan: { downPayment: 0, financed: 50, perInstallment: 50 },
   distribution: [],
   faturaPreview: {
@@ -59,12 +95,13 @@ const mockController: ExpenseFormController = {
   setInstallments: jest.fn(),
   toggleDownPayment: jest.fn(),
   setDownPaymentText: jest.fn(),
+  setDescription: jest.fn(),
   submit: submitMock,
   reset: resetMock,
 };
 
 jest.mock("@/features/credit-cards/hooks/use-expense-form", () => ({
-  useExpenseForm: () => mockController,
+  useExpenseForm: (request: unknown) => mockUseExpenseForm(request),
 }));
 
 describe("ExpenseSheetHost", () => {
@@ -72,6 +109,7 @@ describe("ExpenseSheetHost", () => {
     resetExpenseSheetStore();
     submitMock.mockReset();
     resetMock.mockReset();
+    mockUseExpenseForm.mockClear();
     submitMock.mockResolvedValue({ created: 1, ok: true, error: null });
   });
 
@@ -90,6 +128,26 @@ describe("ExpenseSheetHost", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("expense-sheet")).toBeTruthy();
+    });
+  });
+
+  it("passa o request de edição do store para o formulário", async () => {
+    const transaction = buildTransaction();
+    render(
+      <TestProviders>
+        <ExpenseSheetHost />
+      </TestProviders>,
+    );
+
+    act(() => {
+      useExpenseSheetStore.getState().openEdit(transaction);
+    });
+
+    await waitFor(() => {
+      expect(mockUseExpenseForm).toHaveBeenLastCalledWith({
+        mode: "edit",
+        transaction,
+      });
     });
   });
 

--- a/features/credit-cards/components/expense-sheet/expense-sheet-host.tsx
+++ b/features/credit-cards/components/expense-sheet/expense-sheet-host.tsx
@@ -20,8 +20,9 @@ import { useExpenseSheetStore } from "@/stores/expense-sheet-store";
  */
 export function ExpenseSheetHost(): ReactElement {
   const isOpen = useExpenseSheetStore((state) => state.isOpen);
+  const request = useExpenseSheetStore((state) => state.request);
   const close = useExpenseSheetStore((state) => state.close);
-  const controller = useExpenseForm();
+  const controller = useExpenseForm(request);
   const sheetRef = useRef<BottomSheetModal>(null);
   const { reset } = controller;
 

--- a/features/credit-cards/components/expense-sheet/expense-sheet.test.tsx
+++ b/features/credit-cards/components/expense-sheet/expense-sheet.test.tsx
@@ -44,6 +44,7 @@ const buildController = (
   title: "",
   amountText: "120.00",
   amount: 120,
+  formMode: "create",
   purchaseDate: "2026-06-20",
   creditCardId: null,
   tagId: null,
@@ -53,6 +54,7 @@ const buildController = (
   installments: 3,
   hasDownPayment: false,
   downPaymentText: "",
+  description: "",
   plan: { downPayment: 0, financed: 120, perInstallment: 40 },
   distribution: [
     { key: "full", label: "jul", sub: "à vista", value: 120, isEntry: false },
@@ -80,6 +82,7 @@ const buildController = (
   setInstallments: jest.fn(),
   toggleDownPayment: jest.fn(),
   setDownPaymentText: jest.fn(),
+  setDescription: jest.fn(),
   submit: jest.fn(),
   reset: jest.fn(),
   ...overrides,
@@ -114,6 +117,7 @@ describe("ExpenseSheet", () => {
     expect(screen.getAllByText("Lançar despesa").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByTestId("expense-amount-field")).toBeTruthy();
     expect(screen.getByTestId("expense-card-chips")).toBeTruthy();
+    expect(screen.getByTestId("expense-description-input")).toBeTruthy();
     expect(screen.getByTestId("installment-section")).toBeTruthy();
     expect(screen.getByTestId("classification-section")).toBeTruthy();
     expect(screen.getByTestId("fatura-preview")).toBeTruthy();
@@ -163,5 +167,22 @@ describe("ExpenseSheet", () => {
     expect(screen.getByTestId("distribution-chip-p0")).toBeTruthy();
     expect(screen.getByTestId("distribution-chip-p1")).toBeTruthy();
     expect(screen.getByTestId("installment-down-payment-toggle")).toBeTruthy();
+  });
+
+  it("em modo edição exibe banner de vínculo e CTA de salvar", () => {
+    renderSheet(
+      buildController({
+        formMode: "edit",
+        creditCardId: "cc-1",
+        description: "Compra importada",
+      }),
+      { onClose: jest.fn(), onSubmit: jest.fn() },
+    );
+
+    expect(screen.getByText("Detalhes da despesa")).toBeTruthy();
+    expect(screen.getByText("Vinculada às Transações")).toBeTruthy();
+    expect(screen.getByText(/Qualquer alteração aqui é refletida/u)).toBeTruthy();
+    expect(screen.getByText("Salvar alterações")).toBeTruthy();
+    expect(screen.queryByTestId("installment-section")).toBeNull();
   });
 });

--- a/features/credit-cards/components/expense-sheet/expense-sheet.tsx
+++ b/features/credit-cards/components/expense-sheet/expense-sheet.tsx
@@ -40,10 +40,12 @@ export interface ExpenseSheetProps {
 }
 
 interface SheetHeaderProps {
+  readonly controller: ExpenseFormController;
   readonly onClose: () => void;
 }
 
-function SheetHeader({ onClose }: SheetHeaderProps): ReactElement {
+function SheetHeader({ controller, onClose }: SheetHeaderProps): ReactElement {
+  const isEdit = controller.formMode === "edit";
   return (
     <XStack
       paddingHorizontal="$5"
@@ -52,9 +54,11 @@ function SheetHeader({ onClose }: SheetHeaderProps): ReactElement {
       justifyContent="space-between"
     >
       <YStack>
-        <AppHeading level={2}>Lançar despesa</AppHeading>
+        <AppHeading level={2}>
+          {isEdit ? "Detalhes da despesa" : "Lançar despesa"}
+        </AppHeading>
         <AppText size="bodySm" tone="muted">
-          Compra, fatura e impacto
+          {isEdit ? "Editar despesa vinculada" : "Compra, fatura e impacto"}
         </AppText>
       </YStack>
       <XStack
@@ -80,6 +84,7 @@ interface SheetFooterProps {
 
 function SheetFooter({ controller, onSubmit }: SheetFooterProps): ReactElement {
   const insets = useSafeAreaInsets();
+  const isEdit = controller.formMode === "edit";
   return (
     <YStack
       paddingHorizontal="$5"
@@ -91,19 +96,27 @@ function SheetFooter({ controller, onSubmit }: SheetFooterProps): ReactElement {
       backgroundColor="$surfaceCard"
     >
       <AppText size="caption" tone="muted" textAlign="center">
-        {controller.creditCardId
-          ? "Lançar no cartão selecionado"
-          : "O cartão pode ser escolhido depois"}
+        {isEdit
+          ? "Alterações refletem em Cartões e Transações"
+          : controller.creditCardId
+            ? "Lançar no cartão selecionado"
+            : "O cartão pode ser escolhido depois"}
       </AppText>
       <AppButton
         fullWidth
         glow
         disabled={!controller.canSubmit || controller.isSubmitting}
-        accessibilityLabel="Lançar despesa"
+        accessibilityLabel={isEdit ? "Salvar alterações" : "Lançar despesa"}
         testID="expense-sheet-submit"
         onPress={onSubmit}
       >
-        {controller.isSubmitting ? "Lançando…" : "Lançar despesa"}
+        {controller.isSubmitting
+          ? isEdit
+            ? "Salvando…"
+            : "Lançando…"
+          : isEdit
+            ? "Salvar alterações"
+            : "Lançar despesa"}
       </AppButton>
     </YStack>
   );
@@ -124,13 +137,44 @@ interface SheetBodyProps {
   readonly controller: ExpenseFormController;
 }
 
+function SyncBanner(): ReactElement {
+  const theme = useTheme();
+  return (
+    <XStack
+      gap="$3"
+      padding="$3"
+      borderRadius="$3"
+      borderWidth={borderWidths.hairline}
+      borderColor="$primarySubtle"
+      backgroundColor="$surfaceRaised"
+      alignItems="flex-start"
+    >
+      <MaterialCommunityIcons
+        name="swap-horizontal"
+        size={iconSizes.md}
+        color={theme.primary?.val}
+      />
+      <YStack flex={1} gap="$1">
+        <AppText size="bodySm" fontWeight="$7">
+          Vinculada às Transações
+        </AppText>
+        <AppText size="caption" tone="muted">
+          Qualquer alteração aqui é refletida em Cartões e Transações.
+        </AppText>
+      </YStack>
+    </XStack>
+  );
+}
+
 /** Conteúdo rolável do sheet (todas as seções do formulário). */
 function SheetBody({ controller }: SheetBodyProps): ReactElement {
+  const isEdit = controller.formMode === "edit";
   return (
     <BottomSheetScrollView
       contentContainerStyle={{ paddingHorizontal: 20, paddingBottom: 24, gap: 16 }}
       keyboardShouldPersistTaps="handled"
     >
+      {isEdit ? <SyncBanner /> : null}
       <AmountField
         value={controller.amountText}
         onChangeAmount={controller.setAmountText}
@@ -158,8 +202,18 @@ function SheetBody({ controller }: SheetBodyProps): ReactElement {
           value={controller.purchaseDate}
           onChangeText={controller.setPurchaseDate}
         />
+        <AppInputField
+          id="expense-description"
+          label="Observações"
+          placeholder="Detalhes, contexto ou nota livre"
+          value={controller.description}
+          onChangeText={controller.setDescription}
+          multiline
+          numberOfLines={3}
+          testID="expense-description-input"
+        />
       </YStack>
-      {controller.installmentsEnabled ? (
+      {controller.installmentsEnabled && !isEdit ? (
         <InstallmentSection
           mode={controller.mode}
           installments={controller.installments}
@@ -221,7 +275,7 @@ export const ExpenseSheet = forwardRef<BottomSheetModal, ExpenseSheetProps>(
         onDismiss={onClose}
       >
         <YStack flex={1} testID="expense-sheet">
-          <SheetHeader onClose={onClose} />
+          <SheetHeader controller={controller} onClose={onClose} />
           <SheetBody controller={controller} />
           <SheetFooter controller={controller} onSubmit={onSubmit} />
         </YStack>

--- a/features/credit-cards/components/invoice-grouped-items.test.tsx
+++ b/features/credit-cards/components/invoice-grouped-items.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import { InvoiceGroupedItems } from "@/features/credit-cards/components/invoice-grouped-items";
+import type { CategoryGroup } from "@/features/credit-cards/model/credit-card-aggregation";
+import type { EnrichedTransaction } from "@/features/credit-cards/model/card-transactions";
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+const buildTransaction = (
+  override: Partial<TransactionRecord> = {},
+): TransactionRecord => ({
+  id: "tx-1",
+  title: "Mercado",
+  amount: "120.50",
+  type: "expense",
+  dueDate: "2026-06-20",
+  startDate: null,
+  endDate: null,
+  description: null,
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: "tag-food",
+  accountId: null,
+  creditCardId: "cc-1",
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: null,
+  updatedAt: null,
+  ...override,
+});
+
+const buildItem = (
+  override: Partial<EnrichedTransaction> = {},
+): EnrichedTransaction => {
+  const transaction = buildTransaction({
+    id: override.id ?? "tx-1",
+    title: override.title ?? "Mercado",
+  });
+  return {
+    id: transaction.id,
+    title: transaction.title,
+    amount: 120.5,
+    purchaseDate: "2026-06-20",
+    tagId: "tag-food",
+    creditCardId: "cc-1",
+    billMonth: "2026-06",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "pending",
+    transaction,
+    ...override,
+  };
+};
+
+const buildGroup = (items: readonly EnrichedTransaction[]): CategoryGroup => ({
+  tagId: "tag-food",
+  name: "Alimentação",
+  color: "#11A36B",
+  total: 120.5,
+  count: items.length,
+  items,
+});
+
+const renderItems = (
+  groups: readonly CategoryGroup[],
+  handlers = {
+    onEditExpense: jest.fn(),
+    onDuplicateExpense: jest.fn(),
+    onRequestDeleteExpense: jest.fn(),
+  },
+) =>
+  render(
+    <TestProviders>
+      <InvoiceGroupedItems groups={groups} {...handlers} />
+    </TestProviders>,
+  );
+
+describe("InvoiceGroupedItems", () => {
+  it("renderiza estado vazio", () => {
+    const { getByText } = renderItems([]);
+
+    expect(getByText("Sem lançamentos nesta fatura.")).toBeTruthy();
+  });
+
+  it("renderiza chip de vínculo e ações por lançamento", () => {
+    const item = buildItem();
+    const { getByText, getByTestId } = renderItems([buildGroup([item])]);
+
+    expect(getByText("Também em Transações")).toBeTruthy();
+    expect(getByTestId("invoice-item-open-tx-1")).toBeTruthy();
+    expect(getByTestId("invoice-item-edit-tx-1")).toBeTruthy();
+    expect(getByTestId("invoice-item-duplicate-tx-1")).toBeTruthy();
+    expect(getByTestId("invoice-item-delete-tx-1")).toBeTruthy();
+  });
+
+  it("dispara editar, duplicar e remover com a transação enriquecida", () => {
+    const item = buildItem();
+    const handlers = {
+      onEditExpense: jest.fn(),
+      onDuplicateExpense: jest.fn(),
+      onRequestDeleteExpense: jest.fn(),
+    };
+    const { getByTestId } = renderItems([buildGroup([item])], handlers);
+
+    fireEvent.press(getByTestId("invoice-item-open-tx-1"));
+    fireEvent.press(getByTestId("invoice-item-duplicate-tx-1"));
+    fireEvent.press(getByTestId("invoice-item-delete-tx-1"));
+
+    expect(handlers.onEditExpense).toHaveBeenCalledWith(item);
+    expect(handlers.onDuplicateExpense).toHaveBeenCalledWith(item);
+    expect(handlers.onRequestDeleteExpense).toHaveBeenCalledWith(item);
+  });
+});

--- a/features/credit-cards/components/invoice-grouped-items.tsx
+++ b/features/credit-cards/components/invoice-grouped-items.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 
+import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { XStack, YStack } from "tamagui";
 
 import type { CategoryGroup } from "@/features/credit-cards/model/credit-card-aggregation";
@@ -8,6 +9,7 @@ import { AppMoneyText } from "@/shared/components/app-money-text";
 import { AppSectionHeader } from "@/shared/components/app-section-header";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
 import { AppText } from "@/shared/components/app-text";
+import { iconSizes } from "@/shared/theme";
 import { formatCurrency } from "@/shared/utils/formatters";
 
 /** Quantidade máxima de categorias renderizadas. */
@@ -19,6 +21,9 @@ const MAX_ITEMS_PER_GROUP = 6;
 export interface InvoiceGroupedItemsProps {
   /** Grupos de categoria com seus itens (ordenados por total desc). */
   readonly groups: readonly CategoryGroup[];
+  readonly onEditExpense?: (item: EnrichedTransaction) => void;
+  readonly onDuplicateExpense?: (item: EnrichedTransaction) => void;
+  readonly onRequestDeleteExpense?: (item: EnrichedTransaction) => void;
   readonly testID?: string;
 }
 
@@ -49,30 +54,161 @@ function GroupHeader({ group }: { readonly group: CategoryGroup }): ReactElement
   );
 }
 
-function ItemRow({ item }: { readonly item: EnrichedTransaction }): ReactElement {
+interface ItemActionButtonProps {
+  readonly item: EnrichedTransaction;
+  readonly icon: keyof typeof MaterialCommunityIcons.glyphMap;
+  readonly label: string;
+  readonly tone?: "default" | "danger";
+  readonly testID: string;
+  readonly onPress?: (item: EnrichedTransaction) => void;
+}
+
+function ItemActionButton({
+  item,
+  icon,
+  label,
+  tone = "default",
+  testID,
+  onPress,
+}: ItemActionButtonProps): ReactElement {
   return (
-    <XStack alignItems="center" gap="$3">
-      <YStack flex={1} gap="$1">
-        <AppText size="body" fontWeight="$6" numberOfLines={1}>
-          {item.title}
-        </AppText>
-        <AppText size="caption" tone="muted" numberOfLines={1}>
-          {itemHelper(item)}
-        </AppText>
-      </YStack>
-      <AppMoneyText fontSize="$4">{formatCurrency(item.amount)}</AppMoneyText>
+    <XStack
+      accessibilityRole="button"
+      accessibilityLabel={`${label} ${item.title}`}
+      testID={testID}
+      width={44}
+      height={44}
+      borderRadius="$2"
+      borderWidth={1}
+      borderColor={tone === "danger" ? "$dangerSubtle" : "$borderColor"}
+      backgroundColor="$surfaceRaised"
+      alignItems="center"
+      justifyContent="center"
+      pressStyle={{ scale: 0.94 }}
+      onPress={() => onPress?.(item)}
+    >
+      <MaterialCommunityIcons
+        name={icon}
+        size={iconSizes.sm}
+        color={tone === "danger" ? "#C2414D" : "#087FA7"}
+      />
     </XStack>
   );
 }
 
-function CategorySection({ group }: { readonly group: CategoryGroup }): ReactElement {
+interface ItemRowProps {
+  readonly item: EnrichedTransaction;
+  readonly onEditExpense?: (item: EnrichedTransaction) => void;
+  readonly onDuplicateExpense?: (item: EnrichedTransaction) => void;
+  readonly onRequestDeleteExpense?: (item: EnrichedTransaction) => void;
+}
+
+function ItemRow({
+  item,
+  onEditExpense,
+  onDuplicateExpense,
+  onRequestDeleteExpense,
+}: ItemRowProps): ReactElement {
+  const hasActions = Boolean(
+    onEditExpense || onDuplicateExpense || onRequestDeleteExpense,
+  );
+  return (
+    <YStack gap="$2">
+      <XStack alignItems="center" gap="$3">
+        <YStack
+          flex={1}
+          gap="$1"
+          accessibilityRole="button"
+          accessibilityLabel={`Editar ${item.title}`}
+          testID={`invoice-item-open-${item.id}`}
+          onPress={() => onEditExpense?.(item)}
+          paddingVertical="$1"
+          pressStyle={{ opacity: 0.78 }}
+        >
+          <AppText size="body" fontWeight="$6" numberOfLines={1}>
+            {item.title}
+          </AppText>
+          <AppText size="caption" tone="muted" numberOfLines={1}>
+            {itemHelper(item)}
+          </AppText>
+        </YStack>
+        <AppMoneyText fontSize="$4">{formatCurrency(item.amount)}</AppMoneyText>
+      </XStack>
+      {hasActions ? (
+        <XStack alignItems="center" justifyContent="space-between" gap="$2">
+          <XStack
+            alignItems="center"
+            gap="$1"
+            paddingHorizontal="$2"
+            paddingVertical="$1"
+            borderRadius="$2"
+            backgroundColor="$primarySubtle"
+          >
+            <MaterialCommunityIcons
+              name="swap-horizontal"
+              size={iconSizes.xs}
+              color="#087FA7"
+            />
+            <AppText size="caption" color="$primary" fontWeight="$6">
+              Também em Transações
+            </AppText>
+          </XStack>
+          <XStack gap="$2">
+            <ItemActionButton
+              item={item}
+              icon="pencil-outline"
+              label="Editar"
+              testID={`invoice-item-edit-${item.id}`}
+              onPress={onEditExpense}
+            />
+            <ItemActionButton
+              item={item}
+              icon="content-copy"
+              label="Duplicar"
+              testID={`invoice-item-duplicate-${item.id}`}
+              onPress={onDuplicateExpense}
+            />
+            <ItemActionButton
+              item={item}
+              icon="trash-can-outline"
+              label="Remover"
+              tone="danger"
+              testID={`invoice-item-delete-${item.id}`}
+              onPress={onRequestDeleteExpense}
+            />
+          </XStack>
+        </XStack>
+      ) : null}
+    </YStack>
+  );
+}
+
+interface CategorySectionProps {
+  readonly group: CategoryGroup;
+  readonly onEditExpense?: (item: EnrichedTransaction) => void;
+  readonly onDuplicateExpense?: (item: EnrichedTransaction) => void;
+  readonly onRequestDeleteExpense?: (item: EnrichedTransaction) => void;
+}
+
+function CategorySection({
+  group,
+  onEditExpense,
+  onDuplicateExpense,
+  onRequestDeleteExpense,
+}: CategorySectionProps): ReactElement {
   const items = group.items.slice(0, MAX_ITEMS_PER_GROUP);
   return (
     <YStack gap="$3">
       <GroupHeader group={group} />
       <YStack gap="$3">
         {items.map((item) => (
-          <ItemRow key={item.id} item={item} />
+          <ItemRow
+            key={item.id}
+            item={item}
+            onEditExpense={onEditExpense}
+            onDuplicateExpense={onDuplicateExpense}
+            onRequestDeleteExpense={onRequestDeleteExpense}
+          />
         ))}
       </YStack>
     </YStack>
@@ -89,6 +225,9 @@ function CategorySection({ group }: { readonly group: CategoryGroup }): ReactEle
  */
 export function InvoiceGroupedItems({
   groups,
+  onEditExpense,
+  onDuplicateExpense,
+  onRequestDeleteExpense,
   testID,
 }: InvoiceGroupedItemsProps): ReactElement {
   const visibleGroups = groups
@@ -105,6 +244,9 @@ export function InvoiceGroupedItems({
               <CategorySection
                 key={group.tagId ?? "uncategorized"}
                 group={group}
+                onEditExpense={onEditExpense}
+                onDuplicateExpense={onDuplicateExpense}
+                onRequestDeleteExpense={onRequestDeleteExpense}
               />
             ))}
           </YStack>

--- a/features/credit-cards/expense-actions-config.ts
+++ b/features/credit-cards/expense-actions-config.ts
@@ -1,0 +1,2 @@
+export const CREDIT_CARD_EXPENSE_ACTIONS_FEATURE_FLAG_KEY =
+  "app.credit-cards.expense-actions";

--- a/features/credit-cards/hooks/use-credit-card-bill-screen-controller.test.tsx
+++ b/features/credit-cards/hooks/use-credit-card-bill-screen-controller.test.tsx
@@ -14,11 +14,18 @@ import { useCreditCardsQuery } from "@/features/credit-cards/hooks/use-credit-ca
 import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
 import type { TransactionRecord } from "@/features/transactions/contracts";
 import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
+import {
+  resetExpenseSheetStore,
+  useExpenseSheetStore,
+} from "@/stores/expense-sheet-store";
 import { resolveCardGradient } from "@/shared/theme";
 
 const mockRouterBack = jest.fn();
 const mockRouterReplace = jest.fn();
 let mockCanGoBack = true;
+const mockCreateTransaction = jest.fn<Promise<unknown>, [unknown]>();
+const mockDeleteTransaction = jest.fn<Promise<unknown>, [unknown]>();
+const mockInvalidateQueries = jest.fn<Promise<void>, [unknown]>();
 
 jest.mock("expo-router", () => ({
   useRouter: () => ({
@@ -42,6 +49,25 @@ jest.mock("@/features/tags/hooks/use-tags-query", () => ({
 jest.mock("@/features/transactions/hooks/use-transactions-query", () => ({
   useTransactionsQuery: jest.fn(),
 }));
+jest.mock("@/features/transactions/hooks/use-transaction-mutations", () => ({
+  useCreateTransactionMutation: () => ({
+    mutateAsync: (command: unknown) => mockCreateTransaction(command),
+    isPending: false,
+  }),
+  useDeleteTransactionMutation: () => ({
+    mutateAsync: (command: unknown) => mockDeleteTransaction(command),
+    isPending: false,
+  }),
+}));
+jest.mock("@tanstack/react-query", () => {
+  const actual = jest.requireActual("@tanstack/react-query");
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: (command: unknown) => mockInvalidateQueries(command),
+    }),
+  };
+});
 
 const mockedUseBillQuery = jest.mocked(useCreditCardBillQuery);
 const mockedUseCardsQuery = jest.mocked(useCreditCardsQuery);
@@ -123,6 +149,10 @@ const setTransactions = (transactions: readonly TransactionRecord[]): void => {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  resetExpenseSheetStore();
+  mockCreateTransaction.mockResolvedValue(undefined);
+  mockDeleteTransaction.mockResolvedValue(undefined);
+  mockInvalidateQueries.mockResolvedValue(undefined);
   mockCanGoBack = true;
   mockedUseCardsQuery.mockReturnValue({
     data: { creditCards: [buildCard()] },
@@ -156,6 +186,99 @@ beforeEach(() => {
       dueDate: "2026-05-08",
     }),
   ]);
+});
+
+describe("useCreditCardBillScreenController — ações de despesa", () => {
+  it("abre o sheet em modo edição com a transação original", () => {
+    const { result } = renderHook(() =>
+      useCreditCardBillScreenController({
+        creditCardId: "card-1",
+        initialMonth: "2026-05",
+      }),
+    );
+    const item = result.current.invoice?.groupedByCategory[0]?.items[0];
+
+    expect(item?.transaction.id).toBe("tx-1");
+    act(() => {
+      if (item) {
+        result.current.handleEditExpense(item);
+      }
+    });
+
+    expect(useExpenseSheetStore.getState().request).toEqual({
+      mode: "edit",
+      transaction: item?.transaction,
+    });
+  });
+
+  it("duplica despesa como uma transação simples pendente", async () => {
+    const { result } = renderHook(() =>
+      useCreditCardBillScreenController({
+        creditCardId: "card-1",
+        initialMonth: "2026-05",
+      }),
+    );
+    const item = result.current.invoice?.groupedByCategory[0]?.items[0];
+
+    await act(async () => {
+      if (item) {
+        await result.current.handleDuplicateExpense(item);
+      }
+    });
+
+    expect(mockCreateTransaction).toHaveBeenCalledWith({
+      title: "Renner (cópia)",
+      amount: "938.57",
+      type: "expense",
+      dueDate: "2026-05-05",
+      status: "pending",
+      tagId: "tag-compras",
+      accountId: null,
+      creditCardId: "card-1",
+      description: null,
+      currency: "BRL",
+      isRecurring: false,
+      isInstallment: false,
+      installmentCount: null,
+    });
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["credit-cards"],
+    });
+  });
+
+  it("remove a ocorrência após confirmação", async () => {
+    const { result } = renderHook(() =>
+      useCreditCardBillScreenController({
+        creditCardId: "card-1",
+        initialMonth: "2026-05",
+      }),
+    );
+    const item = result.current.invoice?.groupedByCategory[0]?.items[0];
+
+    act(() => {
+      if (item) {
+        result.current.requestDeleteExpense(item);
+      }
+    });
+
+    expect(result.current.deleteTarget).toEqual({
+      id: "tx-1",
+      title: "Renner",
+      isSeries: false,
+    });
+
+    await act(async () => {
+      await result.current.confirmDeleteExpense();
+    });
+
+    expect(mockDeleteTransaction).toHaveBeenCalledWith({
+      transactionId: "tx-1",
+      scope: "occurrence",
+    });
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ["credit-cards"],
+    });
+  });
 });
 
 describe("useCreditCardBillScreenController — base", () => {

--- a/features/credit-cards/hooks/use-credit-card-bill-screen-controller.ts
+++ b/features/credit-cards/hooks/use-credit-card-bill-screen-controller.ts
@@ -1,8 +1,10 @@
-import { useCallback, useMemo, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useMemo, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useLocalSearchParams, useRouter } from "expo-router";
 
 import { appRoutes } from "@/core/navigation/routes";
+import { queryKeys } from "@/core/query/query-keys";
 import type {
   CreditCard,
   CreditCardBillRecord,
@@ -21,13 +23,25 @@ import {
   groupCreditCardBillTransactionsByDate,
   shiftCreditCardBillMonth,
 } from "@/features/credit-cards/model/credit-card-bill-format";
-import { enrichCardTransactions } from "@/features/credit-cards/model/card-transactions";
+import {
+  enrichCardTransactions,
+  type EnrichedTransaction,
+} from "@/features/credit-cards/model/card-transactions";
 import {
   buildCreditCardInvoiceViewModel,
   type CreditCardInvoiceViewModel,
 } from "@/features/credit-cards/model/credit-card-invoice";
 import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
+import type {
+  CreateTransactionCommand,
+  TransactionRecord,
+} from "@/features/transactions/contracts";
+import {
+  useCreateTransactionMutation,
+  useDeleteTransactionMutation,
+} from "@/features/transactions/hooks/use-transaction-mutations";
 import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
+import { useExpenseSheetStore } from "@/stores/expense-sheet-store";
 
 // Re-exporta os helpers puros (movidos para o modelo) para preservar os imports
 // existentes a partir deste controller.
@@ -66,6 +80,15 @@ export interface CreditCardBillScreenController {
   readonly handleBack: () => void;
   /** Placeholder — pagar fatura ainda não tem backend (no-op intencional). */
   readonly handlePayBill: () => void;
+  readonly handleEditExpense: (item: EnrichedTransaction) => void;
+  readonly handleDuplicateExpense: (item: EnrichedTransaction) => Promise<void>;
+  readonly requestDeleteExpense: (item: EnrichedTransaction) => void;
+  readonly confirmDeleteExpense: () => Promise<void>;
+  readonly closeDeleteExpense: () => void;
+  readonly deleteTarget: CreditCardExpenseDeleteTarget | null;
+  readonly isDeletingExpense: boolean;
+  readonly duplicatingTransactionId: string | null;
+  readonly expenseActionError: unknown | null;
 }
 
 export interface CreditCardBillScreenControllerOptions {
@@ -92,6 +115,30 @@ interface InvoiceViewModelArgs {
 /** Forma mínima de transação consumida aqui (alias do contrato cru). */
 type TransactionRecordLike = Parameters<typeof enrichCardTransactions>[0][number];
 
+export interface CreditCardExpenseDeleteTarget {
+  readonly id: string;
+  readonly title: string;
+  readonly isSeries: boolean;
+}
+
+const buildDuplicateExpensePayload = (
+  transaction: TransactionRecord,
+): CreateTransactionCommand => ({
+  title: `${transaction.title} (cópia)`,
+  amount: transaction.amount,
+  type: transaction.type,
+  dueDate: transaction.dueDate,
+  status: "pending",
+  tagId: transaction.tagId,
+  accountId: transaction.accountId,
+  creditCardId: transaction.creditCardId,
+  description: transaction.description ?? transaction.observation ?? null,
+  currency: transaction.currency,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+});
+
 /**
  * Deriva o view-model da fatura cruzando transações + tags com a fatura oficial.
  * Isolado do controller para mantê-lo enxuto (DRY/legibilidade).
@@ -117,16 +164,22 @@ const useInvoiceViewModel = (
   }, [args.creditCard, args.transactions, args.tags, args.bill, args.month]);
 };
 
-export function useCreditCardBillScreenController(
-  options: CreditCardBillScreenControllerOptions = {},
-): CreditCardBillScreenController {
-  const router = useRouter();
-  const params = useLocalSearchParams<{ id?: string | string[] }>();
-  const creditCardId = options.creditCardId ?? resolveStringParam(params.id);
-  const [selectedMonth, setSelectedMonth] = useState(
-    () => options.initialMonth ?? getCurrentCreditCardBillMonth(),
-  );
+interface CreditCardBillData {
+  readonly creditCard: CreditCard | null;
+  readonly bill: CreditCardBillRecord | null;
+  readonly billQuery: ReturnType<typeof useCreditCardBillQuery>;
+  readonly creditCardsQuery: ReturnType<typeof useCreditCardsQuery>;
+  readonly tagsQuery: ReturnType<typeof useTagsQuery>;
+  readonly transactionsQuery: ReturnType<typeof useTransactionsQuery>;
+  readonly groupedTransactions: readonly CreditCardBillTransactionGroup[];
+  readonly cycleLabel: string | null;
+  readonly invoice: CreditCardInvoiceViewModel | null;
+}
 
+const useCreditCardBillData = (
+  creditCardId: string,
+  selectedMonth: string,
+): CreditCardBillData => {
   const creditCardsQuery = useCreditCardsQuery();
   const tagsQuery = useTagsQuery();
   const billQuery = useCreditCardBillQuery(creditCardId, selectedMonth);
@@ -161,13 +214,36 @@ export function useCreditCardBillScreenController(
     month: selectedMonth,
   });
 
+  return {
+    creditCard,
+    bill,
+    billQuery,
+    creditCardsQuery,
+    tagsQuery,
+    transactionsQuery,
+    groupedTransactions,
+    cycleLabel,
+    invoice,
+  };
+};
+
+interface BillNavigation {
+  readonly handlePreviousMonth: () => void;
+  readonly handleNextMonth: () => void;
+  readonly handleBack: () => void;
+}
+
+const useBillNavigation = (
+  setSelectedMonth: Dispatch<SetStateAction<string>>,
+): BillNavigation => {
+  const router = useRouter();
   const handlePreviousMonth = useCallback((): void => {
     setSelectedMonth((current) => shiftCreditCardBillMonth(current, -1));
-  }, []);
+  }, [setSelectedMonth]);
 
   const handleNextMonth = useCallback((): void => {
     setSelectedMonth((current) => shiftCreditCardBillMonth(current, 1));
-  }, []);
+  }, [setSelectedMonth]);
 
   const handleBack = useCallback((): void => {
     if (router.canGoBack()) {
@@ -177,24 +253,214 @@ export function useCreditCardBillScreenController(
     router.replace(appRoutes.private.creditCards);
   }, [router]);
 
+  return { handlePreviousMonth, handleNextMonth, handleBack };
+};
+
+interface ExpenseActions {
+  readonly handleEditExpense: (item: EnrichedTransaction) => void;
+  readonly handleDuplicateExpense: (item: EnrichedTransaction) => Promise<void>;
+  readonly requestDeleteExpense: (item: EnrichedTransaction) => void;
+  readonly confirmDeleteExpense: () => Promise<void>;
+  readonly closeDeleteExpense: () => void;
+  readonly deleteTarget: CreditCardExpenseDeleteTarget | null;
+  readonly isDeletingExpense: boolean;
+  readonly duplicatingTransactionId: string | null;
+  readonly expenseActionError: unknown | null;
+}
+
+interface ConfirmDeleteExpenseArgs {
+  readonly deleteTarget: CreditCardExpenseDeleteTarget | null;
+  readonly deleteTransactionMutation: ReturnType<typeof useDeleteTransactionMutation>;
+  readonly invalidateExpenseSurfaces: () => Promise<void>;
+  readonly setDeleteTarget: Dispatch<
+    SetStateAction<CreditCardExpenseDeleteTarget | null>
+  >;
+  readonly setDeletingTransactionId: Dispatch<SetStateAction<string | null>>;
+  readonly setExpenseActionError: Dispatch<SetStateAction<unknown | null>>;
+}
+
+const useConfirmDeleteExpense = (
+  args: ConfirmDeleteExpenseArgs,
+): (() => Promise<void>) => {
+  const {
+    deleteTarget,
+    deleteTransactionMutation,
+    invalidateExpenseSurfaces,
+    setDeleteTarget,
+    setDeletingTransactionId,
+    setExpenseActionError,
+  } = args;
+
+  return useCallback(async (): Promise<void> => {
+    if (!deleteTarget) {
+      return;
+    }
+    setDeletingTransactionId(deleteTarget.id);
+    setExpenseActionError(null);
+    try {
+      await deleteTransactionMutation.mutateAsync({
+        transactionId: deleteTarget.id,
+        scope: "occurrence",
+      });
+      await invalidateExpenseSurfaces();
+      setDeleteTarget(null);
+    } catch (error) {
+      setExpenseActionError(error);
+    } finally {
+      setDeletingTransactionId(null);
+    }
+  }, [
+    deleteTarget,
+    deleteTransactionMutation,
+    invalidateExpenseSurfaces,
+    setDeleteTarget,
+    setDeletingTransactionId,
+    setExpenseActionError,
+  ]);
+};
+
+const useExpenseActions = (): ExpenseActions => {
+  const queryClient = useQueryClient();
+  const openExpenseEdit = useExpenseSheetStore((state) => state.openEdit);
+  const createTransactionMutation = useCreateTransactionMutation();
+  const deleteTransactionMutation = useDeleteTransactionMutation();
+  const [deleteTarget, setDeleteTarget] =
+    useState<CreditCardExpenseDeleteTarget | null>(null);
+  const [duplicatingTransactionId, setDuplicatingTransactionId] = useState<
+    string | null
+  >(null);
+  const [deletingTransactionId, setDeletingTransactionId] = useState<string | null>(
+    null,
+  );
+  const [expenseActionError, setExpenseActionError] = useState<unknown | null>(null);
+
+  const invalidateExpenseSurfaces = useCallback(async (): Promise<void> => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.creditCards.root }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.root }),
+    ]);
+  }, [queryClient]);
+
+  const handleEditExpense = useCallback(
+    (item: EnrichedTransaction): void => {
+      openExpenseEdit(item.transaction);
+    },
+    [openExpenseEdit],
+  );
+
+  const handleDuplicateExpense = useCallback(
+    async (item: EnrichedTransaction): Promise<void> => {
+      setDuplicatingTransactionId(item.id);
+      setExpenseActionError(null);
+      try {
+        await createTransactionMutation.mutateAsync(
+          buildDuplicateExpensePayload(item.transaction),
+        );
+        await invalidateExpenseSurfaces();
+      } catch (error) {
+        setExpenseActionError(error);
+      } finally {
+        setDuplicatingTransactionId(null);
+      }
+    },
+    [createTransactionMutation, invalidateExpenseSurfaces],
+  );
+
+  const requestDeleteExpense = useCallback((item: EnrichedTransaction): void => {
+    setExpenseActionError(null);
+    setDeleteTarget({
+      id: item.transaction.id,
+      title: item.transaction.title,
+      isSeries: item.transaction.isRecurring || item.transaction.isInstallment,
+    });
+  }, []);
+
+  const closeDeleteExpense = useCallback((): void => {
+    setDeleteTarget(null);
+  }, []);
+
+  const confirmDeleteExpense = useConfirmDeleteExpense({
+    deleteTarget,
+    deleteTransactionMutation,
+    invalidateExpenseSurfaces,
+    setDeleteTarget,
+    setDeletingTransactionId,
+    setExpenseActionError,
+  });
+
+  return {
+    handleEditExpense,
+    handleDuplicateExpense,
+    requestDeleteExpense,
+    confirmDeleteExpense,
+    closeDeleteExpense,
+    deleteTarget,
+    isDeletingExpense:
+      deletingTransactionId !== null || deleteTransactionMutation.isPending,
+    duplicatingTransactionId,
+    expenseActionError,
+  };
+};
+
+interface BuildControllerArgs {
+  readonly creditCardId: string;
+  readonly selectedMonth: string;
+  readonly data: CreditCardBillData;
+  readonly navigation: BillNavigation;
+  readonly actions: ExpenseActions;
+}
+
+const buildController = (args: BuildControllerArgs): CreditCardBillScreenController => {
+  const { actions, creditCardId, data, navigation, selectedMonth } = args;
   return {
     creditCardId,
-    creditCard,
+    creditCard: data.creditCard,
     selectedMonth,
     selectedMonthLabel: formatCreditCardBillMonthLabel(selectedMonth),
-    bill,
-    billQuery,
-    creditCardsQuery,
-    tagsQuery,
-    transactionsQuery,
-    groupedTransactions,
-    cycleLabel,
-    invoice,
-    handlePreviousMonth,
-    handleNextMonth,
-    handleBack,
+    bill: data.bill,
+    billQuery: data.billQuery,
+    creditCardsQuery: data.creditCardsQuery,
+    tagsQuery: data.tagsQuery,
+    transactionsQuery: data.transactionsQuery,
+    groupedTransactions: data.groupedTransactions,
+    cycleLabel: data.cycleLabel,
+    invoice: data.invoice,
+    handlePreviousMonth: navigation.handlePreviousMonth,
+    handleNextMonth: navigation.handleNextMonth,
+    handleBack: navigation.handleBack,
     handlePayBill: noopPayBill,
+    handleEditExpense: actions.handleEditExpense,
+    handleDuplicateExpense: actions.handleDuplicateExpense,
+    requestDeleteExpense: actions.requestDeleteExpense,
+    confirmDeleteExpense: actions.confirmDeleteExpense,
+    closeDeleteExpense: actions.closeDeleteExpense,
+    deleteTarget: actions.deleteTarget,
+    isDeletingExpense: actions.isDeletingExpense,
+    duplicatingTransactionId: actions.duplicatingTransactionId,
+    expenseActionError: actions.expenseActionError,
   };
+};
+
+export function useCreditCardBillScreenController(
+  options: CreditCardBillScreenControllerOptions = {},
+): CreditCardBillScreenController {
+  const params = useLocalSearchParams<{ id?: string | string[] }>();
+  const creditCardId = options.creditCardId ?? resolveStringParam(params.id);
+  const [selectedMonth, setSelectedMonth] = useState(
+    () => options.initialMonth ?? getCurrentCreditCardBillMonth(),
+  );
+  const data = useCreditCardBillData(creditCardId, selectedMonth);
+  const navigation = useBillNavigation(setSelectedMonth);
+  const actions = useExpenseActions();
+
+  return buildController({
+    actions,
+    creditCardId,
+    data,
+    navigation,
+    selectedMonth,
+  });
 }
 
 /**

--- a/features/credit-cards/hooks/use-expense-form.test.tsx
+++ b/features/credit-cards/hooks/use-expense-form.test.tsx
@@ -1,8 +1,43 @@
 import { act, renderHook } from "@testing-library/react-native";
 
 import { useExpenseForm } from "@/features/credit-cards/hooks/use-expense-form";
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import { createTestHookWrapper } from "@/shared/testing/test-providers";
 
 const mockMutateAsync = jest.fn<Promise<unknown>, [unknown]>();
+const mockUpdateMutateAsync = jest.fn<Promise<unknown>, [unknown]>();
+
+const buildTransaction = (
+  override: Partial<TransactionRecord> = {},
+): TransactionRecord => ({
+  id: "tx-1",
+  title: "Mercado",
+  amount: "120.50",
+  type: "expense",
+  dueDate: "2026-06-20",
+  startDate: null,
+  endDate: null,
+  description: "Compra semanal",
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: "t-food",
+  accountId: "ac-1",
+  creditCardId: "cc-1",
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: null,
+  updatedAt: null,
+  ...override,
+});
 
 jest.mock("@/features/credit-cards/hooks/use-credit-cards-query", () => ({
   useCreditCardsQuery: () => ({
@@ -55,6 +90,10 @@ jest.mock("@/features/transactions/hooks/use-transaction-mutations", () => ({
     mutateAsync: (command: unknown) => mockMutateAsync(command),
     isPending: false,
   }),
+  useUpdateTransactionMutation: () => ({
+    mutateAsync: (command: unknown) => mockUpdateMutateAsync(command),
+    isPending: false,
+  }),
 }));
 
 jest.mock("@/shared/feature-flags", () => ({
@@ -63,12 +102,21 @@ jest.mock("@/shared/feature-flags", () => ({
 
 beforeEach(() => {
   mockMutateAsync.mockReset();
+  mockUpdateMutateAsync.mockReset();
   mockMutateAsync.mockResolvedValue(undefined);
+  mockUpdateMutateAsync.mockResolvedValue(undefined);
 });
+
+const renderExpenseForm = (
+  request?: Parameters<typeof useExpenseForm>[0],
+) =>
+  renderHook(() => useExpenseForm(request), {
+    wrapper: createTestHookWrapper(),
+  });
 
 describe("useExpenseForm", () => {
   it("começa vazio e não pode submeter sem valor", () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     expect(result.current.amount).toBe(0);
     expect(result.current.canSubmit).toBe(false);
     expect(result.current.creditCardId).toBeNull();
@@ -76,17 +124,19 @@ describe("useExpenseForm", () => {
     expect(result.current.cards).toHaveLength(1);
     expect(result.current.tags).toHaveLength(1);
     expect(result.current.accounts).toHaveLength(1);
+    expect(result.current.formMode).toBe("create");
+    expect(result.current.description).toBe("");
   });
 
   it("habilita submit quando o valor é maior que zero", () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     act(() => result.current.setAmountText("120000")); // R$ 1.200,00 (POS)
     expect(result.current.amount).toBe(1200);
     expect(result.current.canSubmit).toBe(true);
   });
 
   it("monta a distribuição parcelada", () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     act(() => result.current.setAmountText("120000"));
     act(() => {
       result.current.selectCard("cc-1");
@@ -98,7 +148,7 @@ describe("useExpenseForm", () => {
   });
 
   it("adiciona o chip de entrada quando há entrada", () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     act(() => result.current.setAmountText("120000"));
     act(() => {
       result.current.setMode("parcelado");
@@ -111,7 +161,7 @@ describe("useExpenseForm", () => {
   });
 
   it("preview da fatura: sem cartão pede definição; com cartão resolve o mês", () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     expect(result.current.faturaPreview.hasCard).toBe(false);
     act(() => result.current.selectCard("cc-1"));
     expect(result.current.faturaPreview.hasCard).toBe(true);
@@ -120,22 +170,84 @@ describe("useExpenseForm", () => {
   });
 
   it("submete uma única transação à vista", async () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     act(() => {
       result.current.setAmountText("50000"); // R$ 500
       result.current.setTitle("Mercado");
+      result.current.setDescription("  compra do mês  ");
     });
     let outcome: { created: number; ok: boolean } | undefined;
     await act(async () => {
       outcome = await result.current.submit();
     });
     expect(mockMutateAsync).toHaveBeenCalledTimes(1);
+    expect(mockMutateAsync).toHaveBeenCalledWith(
+      expect.objectContaining({ description: "compra do mês" }),
+    );
     expect(outcome?.ok).toBe(true);
     expect(outcome?.created).toBe(1);
   });
+});
+
+describe("useExpenseForm — edição", () => {
+  it("hidrata modo edição a partir da transação", () => {
+    const transaction = buildTransaction({
+      title: "Farmácia",
+      amount: "89.90",
+      dueDate: "2026-06-22",
+      description: "Remédio",
+      status: "paid",
+    });
+
+    const { result } = renderExpenseForm({ mode: "edit", transaction });
+
+    expect(result.current.formMode).toBe("edit");
+    expect(result.current.title).toBe("Farmácia");
+    expect(result.current.amountText).toBe("89.90");
+    expect(result.current.purchaseDate).toBe("2026-06-22");
+    expect(result.current.creditCardId).toBe("cc-1");
+    expect(result.current.tagId).toBe("t-food");
+    expect(result.current.accountId).toBe("ac-1");
+    expect(result.current.status).toBe("paid");
+    expect(result.current.description).toBe("Remédio");
+    expect(result.current.canSubmit).toBe(true);
+  });
+
+  it("salva edição usando update sem criar nova transação", async () => {
+    const transaction = buildTransaction();
+    const { result } = renderExpenseForm({ mode: "edit", transaction });
+
+    act(() => {
+      result.current.setTitle("Mercado atualizado");
+      result.current.setAmountText("130.75");
+      result.current.setDescription("  compra ajustada  ");
+    });
+
+    let outcome: { created: number; ok: boolean } | undefined;
+    await act(async () => {
+      outcome = await result.current.submit();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+    expect(mockUpdateMutateAsync).toHaveBeenCalledWith({
+      transactionId: "tx-1",
+      payload: expect.objectContaining({
+        title: "Mercado atualizado",
+        amount: "130.75",
+        type: "expense",
+        dueDate: "2026-06-20",
+        description: "compra ajustada",
+        creditCardId: "cc-1",
+        tagId: "t-food",
+        accountId: "ac-1",
+        status: "pending",
+      }),
+    });
+    expect(outcome).toEqual({ created: 0, ok: true, error: null });
+  });
 
   it("submete duas transações quando há entrada (entrada + financiado)", async () => {
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     act(() => {
       result.current.setAmountText("120000");
       result.current.setMode("parcelado");
@@ -153,7 +265,7 @@ describe("useExpenseForm", () => {
     mockMutateAsync
       .mockResolvedValueOnce(undefined)
       .mockRejectedValueOnce(new Error("boom"));
-    const { result } = renderHook(() => useExpenseForm());
+    const { result } = renderExpenseForm();
     act(() => {
       result.current.setAmountText("120000");
       result.current.setMode("parcelado");

--- a/features/credit-cards/hooks/use-expense-form.ts
+++ b/features/credit-cards/hooks/use-expense-form.ts
@@ -1,16 +1,30 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { useQueryClient } from "@tanstack/react-query";
+
+import { queryKeys } from "@/core/query/query-keys";
 import type { Account } from "@/features/accounts/contracts";
 import { useAccountsQuery } from "@/features/accounts/hooks/use-accounts-query";
 import type { CreditCard } from "@/features/credit-cards/contracts";
 import { useCreditCardsQuery } from "@/features/credit-cards/hooks/use-credit-cards-query";
 import type { Tag } from "@/features/tags/contracts";
 import { useTagsQuery } from "@/features/tags/hooks/use-tags-query";
-import type { TransactionStatus } from "@/features/transactions/contracts";
-import { useCreateTransactionMutation } from "@/features/transactions/hooks/use-transaction-mutations";
+import type {
+  TransactionRecord,
+  TransactionStatus,
+  UpdateTransactionCommand,
+} from "@/features/transactions/contracts";
+import {
+  useCreateTransactionMutation,
+  useUpdateTransactionMutation,
+} from "@/features/transactions/hooks/use-transaction-mutations";
 import { TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY } from "@/features/transactions/installments-config";
 import { isFeatureEnabled } from "@/shared/feature-flags";
-import { parseCurrencyCentsInput } from "@/shared/utils/currency";
+import {
+  parseCurrencyCentsInput,
+  serializeAmount,
+} from "@/shared/utils/currency";
+import type { ExpenseSheetRequest } from "@/stores/expense-sheet-store";
 
 import { resolveCreditCardBillingCycle } from "../model/billing-cycle";
 import { currentBillMonth, shiftMonthKey } from "../model/billing-month";
@@ -47,11 +61,14 @@ export interface ExpenseSubmitResult {
   readonly error: unknown;
 }
 
+export type ExpenseFormMode = "create" | "edit";
+
 /** API pública do controller do formulário de despesa. */
 export interface ExpenseFormController {
   readonly cards: readonly CreditCard[];
   readonly tags: readonly Tag[];
   readonly accounts: readonly Account[];
+  readonly formMode: ExpenseFormMode;
   readonly title: string;
   readonly amountText: string;
   readonly amount: number;
@@ -64,6 +81,7 @@ export interface ExpenseFormController {
   readonly installments: number;
   readonly hasDownPayment: boolean;
   readonly downPaymentText: string;
+  readonly description: string;
   readonly plan: InstallmentPlan;
   readonly distribution: readonly DistributionChip[];
   readonly faturaPreview: ExpenseFaturaPreview;
@@ -82,6 +100,7 @@ export interface ExpenseFormController {
   readonly setInstallments: (value: number) => void;
   readonly toggleDownPayment: (value: boolean) => void;
   readonly setDownPaymentText: (value: string) => void;
+  readonly setDescription: (value: string) => void;
   readonly submit: () => Promise<ExpenseSubmitResult>;
   readonly reset: () => void;
 }
@@ -94,6 +113,67 @@ const todayIso = (): string => {
 };
 
 const parseAmount = (text: string): number => parseCurrencyCentsInput(text) ?? 0;
+
+interface ExpenseFormInitialState {
+  readonly title: string;
+  readonly amountText: string;
+  readonly purchaseDate: string;
+  readonly creditCardId: string | null;
+  readonly tagId: string | null;
+  readonly accountId: string | null;
+  readonly status: TransactionStatus;
+  readonly mode: InstallmentMode;
+  readonly installments: number;
+  readonly hasDownPayment: boolean;
+  readonly downPaymentText: string;
+  readonly description: string;
+}
+
+const createBlankInitialState = (
+  request: Extract<ExpenseSheetRequest, { mode: "create" }>,
+): ExpenseFormInitialState => ({
+  title: "",
+  amountText: "",
+  purchaseDate:
+    request.presetMonth && /^\d{4}-\d{2}$/u.test(request.presetMonth)
+      ? `${request.presetMonth}-01`
+      : todayIso(),
+  creditCardId: request.presetCreditCardId ?? null,
+  tagId: null,
+  accountId: null,
+  status: "pending",
+  mode: "avista",
+  installments: DEFAULT_INSTALLMENTS,
+  hasDownPayment: false,
+  downPaymentText: "",
+  description: "",
+});
+
+const createEditInitialState = (
+  transaction: TransactionRecord,
+): ExpenseFormInitialState => ({
+  title: transaction.title,
+  amountText: transaction.amount,
+  purchaseDate: transaction.dueDate,
+  creditCardId: transaction.creditCardId,
+  tagId: transaction.tagId,
+  accountId: transaction.accountId,
+  status: transaction.status,
+  mode: transaction.isInstallment ? "parcelado" : "avista",
+  installments: transaction.installmentCount ?? DEFAULT_INSTALLMENTS,
+  hasDownPayment: false,
+  downPaymentText: "",
+  description: transaction.description ?? transaction.observation ?? "",
+});
+
+const createInitialState = (
+  request: ExpenseSheetRequest,
+): ExpenseFormInitialState =>
+  request.mode === "edit"
+    ? createEditInitialState(request.transaction)
+    : createBlankInitialState(request);
+
+const defaultCreateRequest: ExpenseSheetRequest = { mode: "create" };
 
 /**
  * Mês de fatura inicial da distribuição: usa o ciclo do cartão quando há cartão
@@ -161,6 +241,7 @@ interface ExpenseFormState {
   readonly installments: number;
   readonly hasDownPayment: boolean;
   readonly downPaymentText: string;
+  readonly description: string;
   readonly submitError: unknown;
   readonly setTitle: (value: string) => void;
   readonly setAmountText: (value: string) => void;
@@ -173,70 +254,79 @@ interface ExpenseFormState {
   readonly setInstallments: (value: number) => void;
   readonly toggleDownPayment: (value: boolean) => void;
   readonly setDownPaymentText: (value: string) => void;
+  readonly setDescription: (value: string) => void;
   readonly setSubmitError: (error: unknown) => void;
   readonly reset: () => void;
 }
 
 /** Estado bruto + setters do formulário (extraído para manter o hook enxuto). */
-const useExpenseFormState = (): ExpenseFormState => {
-  const [title, setTitle] = useState("");
-  const [amountText, setAmountText] = useState("");
-  const [purchaseDate, setPurchaseDate] = useState(todayIso);
-  const [creditCardId, setCreditCardId] = useState<string | null>(null);
-  const [tagId, setTagId] = useState<string | null>(null);
-  const [accountId, setAccountId] = useState<string | null>(null);
-  const [status, setStatus] = useState<TransactionStatus>("pending");
-  const [mode, setMode] = useState<InstallmentMode>("avista");
-  const [installments, setInstallmentsState] = useState(DEFAULT_INSTALLMENTS);
-  const [hasDownPayment, setHasDownPayment] = useState(false);
-  const [downPaymentText, setDownPaymentText] = useState("");
+const useExpenseFormState = (request: ExpenseSheetRequest): ExpenseFormState => {
+  const initialState = createInitialState(request);
+  const [values, setValues] = useState<ExpenseFormInitialState>(initialState);
   const [submitError, setSubmitError] = useState<unknown>(null);
 
+  const requestKey =
+    request.mode === "edit"
+      ? `edit:${request.transaction.id}:${request.transaction.updatedAt ?? ""}`
+      : `create:${request.presetCreditCardId ?? ""}:${request.presetMonth ?? ""}`;
+
+  useEffect(() => {
+    setValues(createInitialState(request));
+    setSubmitError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- requestKey captura o contexto externo relevante.
+  }, [requestKey]);
+
+  const updateField = useCallback(
+    <Key extends keyof ExpenseFormInitialState>(
+      key: Key,
+      value: ExpenseFormInitialState[Key],
+    ): void => {
+      setValues((current) => ({ ...current, [key]: value }));
+    },
+    [],
+  );
+
   const setInstallments = useCallback((value: number): void => {
-    setInstallmentsState(
+    updateField(
+      "installments",
       Math.min(MAX_INSTALLMENTS, Math.max(MIN_INSTALLMENTS, Math.floor(value))),
     );
-  }, []);
+  }, [updateField]);
+
+  const setField =
+    <Key extends keyof ExpenseFormInitialState>(key: Key) =>
+    (value: ExpenseFormInitialState[Key]): void => {
+      updateField(key, value);
+    };
+
+  const setStatusField = useCallback((value: TransactionStatus): void => {
+    updateField("status", value);
+  }, [updateField]);
+
+  const setModeField = useCallback((value: InstallmentMode): void => {
+    updateField("mode", value);
+  }, [updateField]);
 
   const reset = useCallback((): void => {
-    setTitle("");
-    setAmountText("");
-    setPurchaseDate(todayIso());
-    setCreditCardId(null);
-    setTagId(null);
-    setAccountId(null);
-    setStatus("pending");
-    setMode("avista");
-    setInstallmentsState(DEFAULT_INSTALLMENTS);
-    setHasDownPayment(false);
-    setDownPaymentText("");
+    setValues(createBlankInitialState(defaultCreateRequest));
     setSubmitError(null);
   }, []);
 
   return {
-    title,
-    amountText,
-    purchaseDate,
-    creditCardId,
-    tagId,
-    accountId,
-    status,
-    mode,
-    installments,
-    hasDownPayment,
-    downPaymentText,
+    ...values,
     submitError,
-    setTitle,
-    setAmountText,
-    setPurchaseDate,
-    selectCard: setCreditCardId,
-    selectTag: setTagId,
-    selectAccount: setAccountId,
-    setStatus,
-    setMode,
+    setTitle: setField("title"),
+    setAmountText: setField("amountText"),
+    setPurchaseDate: setField("purchaseDate"),
+    selectCard: setField("creditCardId"),
+    selectTag: setField("tagId"),
+    selectAccount: setField("accountId"),
+    setStatus: setStatusField,
+    setMode: setModeField,
     setInstallments,
-    toggleDownPayment: setHasDownPayment,
-    setDownPaymentText,
+    toggleDownPayment: setField("hasDownPayment"),
+    setDownPaymentText: setField("downPaymentText"),
+    setDescription: setField("description"),
     setSubmitError,
     reset,
   };
@@ -310,7 +400,7 @@ const useExpenseDerived = (
       installments: state.installments,
       hasDownPayment: state.hasDownPayment,
       downPayment,
-      description: "",
+      description: state.description,
     }),
     [
       amount,
@@ -324,9 +414,145 @@ const useExpenseDerived = (
       state.status,
       state.tagId,
       state.title,
+      state.description,
     ],
   );
   return { amount, downPayment, selectedCard, plan, distribution, faturaPreview, values };
+};
+
+const buildExpenseUpdatePayload = (
+  values: ExpenseFormValues,
+): UpdateTransactionCommand => {
+  const description = values.description.trim();
+  return {
+    title: values.title.trim(),
+    amount: serializeAmount(values.amount),
+    type: "expense",
+    dueDate: values.purchaseDate,
+    status: values.status,
+    creditCardId: values.creditCardId,
+    tagId: values.tagId,
+    accountId: values.accountId,
+    description: description.length > 0 ? description : null,
+  };
+};
+
+interface ExpenseFormControllerParts {
+  readonly cards: readonly CreditCard[];
+  readonly tags: readonly Tag[];
+  readonly accounts: readonly Account[];
+  readonly formMode: ExpenseFormMode;
+  readonly state: ExpenseFormState;
+  readonly derived: ExpenseDerived;
+  readonly isSubmitting: boolean;
+  readonly submit: () => Promise<ExpenseSubmitResult>;
+}
+
+const buildExpenseFormController = (
+  parts: ExpenseFormControllerParts,
+): ExpenseFormController => ({
+  cards: parts.cards,
+  tags: parts.tags,
+  accounts: parts.accounts,
+  formMode: parts.formMode,
+  title: parts.state.title,
+  amountText: parts.state.amountText,
+  amount: parts.derived.amount,
+  purchaseDate: parts.state.purchaseDate,
+  creditCardId: parts.state.creditCardId,
+  tagId: parts.state.tagId,
+  accountId: parts.state.accountId,
+  status: parts.state.status,
+  mode: parts.state.mode,
+  installments: parts.state.installments,
+  hasDownPayment: parts.state.hasDownPayment,
+  downPaymentText: parts.state.downPaymentText,
+  description: parts.state.description,
+  plan: parts.derived.plan,
+  distribution: parts.derived.distribution,
+  faturaPreview: parts.derived.faturaPreview,
+  canSubmit: parts.derived.amount > 0,
+  installmentsEnabled: isFeatureEnabled(TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY),
+  isSubmitting: parts.isSubmitting,
+  submitError: parts.state.submitError,
+  setTitle: parts.state.setTitle,
+  setAmountText: parts.state.setAmountText,
+  setPurchaseDate: parts.state.setPurchaseDate,
+  selectCard: parts.state.selectCard,
+  selectTag: parts.state.selectTag,
+  selectAccount: parts.state.selectAccount,
+  setStatus: parts.state.setStatus,
+  setMode: parts.state.setMode,
+  setInstallments: parts.state.setInstallments,
+  toggleDownPayment: parts.state.toggleDownPayment,
+  setDownPaymentText: parts.state.setDownPaymentText,
+  setDescription: parts.state.setDescription,
+  submit: parts.submit,
+  reset: parts.state.reset,
+});
+
+interface ExpenseSubmitArgs {
+  readonly request: ExpenseSheetRequest;
+  readonly values: ExpenseFormValues;
+  readonly createMutation: ReturnType<typeof useCreateTransactionMutation>;
+  readonly updateMutation: ReturnType<typeof useUpdateTransactionMutation>;
+  readonly setSubmitError: (error: unknown) => void;
+}
+
+const useExpenseSubmit = (args: ExpenseSubmitArgs): (() => Promise<ExpenseSubmitResult>) => {
+  const queryClient = useQueryClient();
+  const editTransactionId =
+    args.request.mode === "edit" ? args.request.transaction.id : null;
+
+  const invalidateExpenseSurfaces = useCallback(async (): Promise<void> => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: queryKeys.transactions.root }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.creditCards.root }),
+      queryClient.invalidateQueries({ queryKey: queryKeys.dashboard.root }),
+    ]);
+  }, [queryClient]);
+
+  const submitEdit = useCallback(async (): Promise<ExpenseSubmitResult> => {
+    if (editTransactionId === null) {
+      return { created: 0, ok: false, error: null };
+    }
+    args.setSubmitError(null);
+    try {
+      await args.updateMutation.mutateAsync({
+        transactionId: editTransactionId,
+        payload: buildExpenseUpdatePayload(args.values),
+      });
+      await invalidateExpenseSurfaces();
+      return { created: 0, ok: true, error: null };
+    } catch (error) {
+      args.setSubmitError(error);
+      return { created: 0, ok: false, error };
+    }
+  }, [args, editTransactionId, invalidateExpenseSurfaces]);
+
+  const submitCreate = useCallback(async (): Promise<ExpenseSubmitResult> => {
+    const payloads = buildExpensePayloads(args.values);
+    if (payloads.length === 0) {
+      return { created: 0, ok: false, error: null };
+    }
+    args.setSubmitError(null);
+    let created = 0;
+    try {
+      for (const payload of payloads) {
+        await args.createMutation.mutateAsync(payload);
+        created += 1;
+      }
+      await invalidateExpenseSurfaces();
+      return { created, ok: true, error: null };
+    } catch (error) {
+      args.setSubmitError(error);
+      return { created, ok: false, error };
+    }
+  }, [args, invalidateExpenseSurfaces]);
+
+  return useCallback(async (): Promise<ExpenseSubmitResult> => {
+    return args.request.mode === "edit" ? submitEdit() : submitCreate();
+  }, [args.request.mode, submitCreate, submitEdit]);
 };
 
 /**
@@ -337,12 +563,15 @@ const useExpenseDerived = (
  *
  * @returns Controller do formulário de despesa.
  */
-export const useExpenseForm = (): ExpenseFormController => {
+export const useExpenseForm = (
+  request: ExpenseSheetRequest = defaultCreateRequest,
+): ExpenseFormController => {
   const cardsQuery = useCreditCardsQuery();
   const tagsQuery = useTagsQuery();
   const accountsQuery = useAccountsQuery();
   const createMutation = useCreateTransactionMutation();
-  const state = useExpenseFormState();
+  const updateMutation = useUpdateTransactionMutation();
+  const state = useExpenseFormState(request);
 
   const cards = useMemo(
     () => cardsQuery.data?.creditCards ?? [],
@@ -351,61 +580,22 @@ export const useExpenseForm = (): ExpenseFormController => {
   const tags = tagsQuery.data?.tags ?? [];
   const accounts = accountsQuery.data?.accounts ?? [];
   const derived = useExpenseDerived(state, cards);
+  const submit = useExpenseSubmit({
+    createMutation,
+    request,
+    setSubmitError: state.setSubmitError,
+    updateMutation,
+    values: derived.values,
+  });
 
-  const submit = useCallback(async (): Promise<ExpenseSubmitResult> => {
-    const payloads = buildExpensePayloads(derived.values);
-    if (payloads.length === 0) {
-      return { created: 0, ok: false, error: null };
-    }
-    state.setSubmitError(null);
-    let created = 0;
-    try {
-      for (const payload of payloads) {
-        await createMutation.mutateAsync(payload);
-        created += 1;
-      }
-      return { created, ok: true, error: null };
-    } catch (error) {
-      state.setSubmitError(error);
-      return { created, ok: false, error };
-    }
-  }, [createMutation, derived.values, state]);
-
-  return {
+  return buildExpenseFormController({
     cards,
     tags,
     accounts,
-    title: state.title,
-    amountText: state.amountText,
-    amount: derived.amount,
-    purchaseDate: state.purchaseDate,
-    creditCardId: state.creditCardId,
-    tagId: state.tagId,
-    accountId: state.accountId,
-    status: state.status,
-    mode: state.mode,
-    installments: state.installments,
-    hasDownPayment: state.hasDownPayment,
-    downPaymentText: state.downPaymentText,
-    plan: derived.plan,
-    distribution: derived.distribution,
-    faturaPreview: derived.faturaPreview,
-    canSubmit: derived.amount > 0,
-    installmentsEnabled: isFeatureEnabled(TRANSACTION_INSTALLMENTS_FEATURE_FLAG_KEY),
-    isSubmitting: createMutation.isPending,
-    submitError: state.submitError,
-    setTitle: state.setTitle,
-    setAmountText: state.setAmountText,
-    setPurchaseDate: state.setPurchaseDate,
-    selectCard: state.selectCard,
-    selectTag: state.selectTag,
-    selectAccount: state.selectAccount,
-    setStatus: state.setStatus,
-    setMode: state.setMode,
-    setInstallments: state.setInstallments,
-    toggleDownPayment: state.toggleDownPayment,
-    setDownPaymentText: state.setDownPaymentText,
+    formMode: request.mode,
+    isSubmitting: createMutation.isPending || updateMutation.isPending,
+    state,
+    derived,
     submit,
-    reset: state.reset,
-  };
+  });
 };

--- a/features/credit-cards/model/card-transactions.ts
+++ b/features/credit-cards/model/card-transactions.ts
@@ -35,6 +35,8 @@ export interface EnrichedTransaction {
   readonly installmentCount: number | null;
   readonly installmentGroupId: string | null;
   readonly status: string;
+  /** Registro canônico de Transações usado para editar/duplicar/remover. */
+  readonly transaction: TransactionRecord;
 }
 
 /**
@@ -93,6 +95,7 @@ export const enrichCardTransactions = (
         installmentCount: tx.installmentCount,
         installmentGroupId: tx.installmentGroupId,
         status: tx.status,
+        transaction: tx,
       };
     });
 };

--- a/features/credit-cards/model/credit-card-aggregation.test.ts
+++ b/features/credit-cards/model/credit-card-aggregation.test.ts
@@ -12,6 +12,7 @@ import {
   topTransactions,
 } from "@/features/credit-cards/model/credit-card-aggregation";
 import type { Tag } from "@/features/tags/contracts";
+import { transactionFixture } from "@/features/transactions/mocks";
 import { categoryPalette } from "@/shared/theme";
 
 /**
@@ -20,20 +21,38 @@ import { categoryPalette } from "@/shared/theme";
  * @param partial Campos a sobrescrever.
  * @returns EnrichedTransaction completa.
  */
-const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
-  id: "tx-1",
-  title: "Compra",
-  amount: 100,
-  purchaseDate: "2026-06-02",
-  tagId: null,
-  creditCardId: "cc-1",
-  billMonth: "2026-06",
-  isInstallment: false,
-  installmentCount: null,
-  installmentGroupId: null,
-  status: "pending",
-  ...partial,
-});
+const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => {
+  const item = {
+    id: "tx-1",
+    title: "Compra",
+    amount: 100,
+    purchaseDate: "2026-06-02",
+    tagId: null,
+    creditCardId: "cc-1",
+    billMonth: "2026-06",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "pending",
+    ...partial,
+  };
+  return {
+    ...item,
+    transaction: partial.transaction ?? {
+      ...transactionFixture,
+      id: item.id,
+      title: item.title,
+      amount: item.amount.toFixed(2),
+      dueDate: item.purchaseDate,
+      tagId: item.tagId,
+      creditCardId: item.creditCardId,
+      isInstallment: item.isInstallment,
+      installmentCount: item.installmentCount,
+      installmentGroupId: item.installmentGroupId,
+      status: "pending",
+    },
+  };
+};
 
 /**
  * Monta um CreditCard completo com defaults para os testes.

--- a/features/credit-cards/model/credit-card-analytics.test.ts
+++ b/features/credit-cards/model/credit-card-analytics.test.ts
@@ -5,6 +5,7 @@ import type {
 import { buildAnalytics } from "@/features/credit-cards/model/credit-card-analytics";
 import type { EnrichedTransaction } from "@/features/credit-cards/model/card-transactions";
 import type { Tag } from "@/features/tags/contracts";
+import { transactionFixture } from "@/features/transactions/mocks";
 
 /**
  * Monta uma EnrichedTransaction com defaults para os testes.
@@ -12,20 +13,38 @@ import type { Tag } from "@/features/tags/contracts";
  * @param partial Campos a sobrescrever.
  * @returns EnrichedTransaction completa.
  */
-const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
-  id: "tx-1",
-  title: "Compra",
-  amount: 100,
-  purchaseDate: "2026-06-02",
-  tagId: null,
-  creditCardId: "cc-1",
-  billMonth: "2026-06",
-  isInstallment: false,
-  installmentCount: null,
-  installmentGroupId: null,
-  status: "pending",
-  ...partial,
-});
+const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => {
+  const item = {
+    id: "tx-1",
+    title: "Compra",
+    amount: 100,
+    purchaseDate: "2026-06-02",
+    tagId: null,
+    creditCardId: "cc-1",
+    billMonth: "2026-06",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "pending",
+    ...partial,
+  };
+  return {
+    ...item,
+    transaction: partial.transaction ?? {
+      ...transactionFixture,
+      id: item.id,
+      title: item.title,
+      amount: item.amount.toFixed(2),
+      dueDate: item.purchaseDate,
+      tagId: item.tagId,
+      creditCardId: item.creditCardId,
+      isInstallment: item.isInstallment,
+      installmentCount: item.installmentCount,
+      installmentGroupId: item.installmentGroupId,
+      status: "pending",
+    },
+  };
+};
 
 /**
  * Monta um CreditCard completo com defaults para os testes.

--- a/features/credit-cards/model/credit-card-detail.test.ts
+++ b/features/credit-cards/model/credit-card-detail.test.ts
@@ -3,6 +3,7 @@ import type {
   CreditCardUtilizationRecord,
 } from "@/features/credit-cards/contracts";
 import type { Tag } from "@/features/tags/contracts";
+import { transactionFixture } from "@/features/transactions/mocks";
 
 import type { EnrichedTransaction } from "./card-transactions";
 import {
@@ -33,20 +34,38 @@ const tags: readonly Tag[] = [
 
 const buildTx = (
   overrides: Partial<EnrichedTransaction> = {},
-): EnrichedTransaction => ({
-  id: "tx-1",
-  title: "Renner",
-  amount: 100,
-  purchaseDate: "2026-06-25",
-  tagId: "tag-compras",
-  creditCardId: "cc-1",
-  billMonth: "2026-06",
-  isInstallment: false,
-  installmentCount: null,
-  installmentGroupId: null,
-  status: "paid",
-  ...overrides,
-});
+): EnrichedTransaction => {
+  const item = {
+    id: "tx-1",
+    title: "Renner",
+    amount: 100,
+    purchaseDate: "2026-06-25",
+    tagId: "tag-compras",
+    creditCardId: "cc-1",
+    billMonth: "2026-06",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "paid",
+    ...overrides,
+  };
+  return {
+    ...item,
+    transaction: overrides.transaction ?? {
+      ...transactionFixture,
+      id: item.id,
+      title: item.title,
+      amount: item.amount.toFixed(2),
+      dueDate: item.purchaseDate,
+      tagId: item.tagId,
+      creditCardId: item.creditCardId,
+      isInstallment: item.isInstallment,
+      installmentCount: item.installmentCount,
+      installmentGroupId: item.installmentGroupId,
+      status: "paid",
+    },
+  };
+};
 
 const baseParams = (
   overrides: Partial<CreditCardDetailParams> = {},

--- a/features/credit-cards/model/credit-card-invoice.test.ts
+++ b/features/credit-cards/model/credit-card-invoice.test.ts
@@ -3,6 +3,7 @@ import type {
   CreditCardBillRecord,
 } from "@/features/credit-cards/contracts";
 import type { Tag } from "@/features/tags/contracts";
+import { transactionFixture } from "@/features/transactions/mocks";
 
 import type { EnrichedTransaction } from "./card-transactions";
 import {
@@ -33,20 +34,38 @@ const tags: readonly Tag[] = [
 
 const buildTx = (
   overrides: Partial<EnrichedTransaction> = {},
-): EnrichedTransaction => ({
-  id: "tx-1",
-  title: "Renner",
-  amount: 938.57,
-  purchaseDate: "2026-05-05",
-  tagId: "tag-compras",
-  creditCardId: "card-1",
-  billMonth: "2026-05",
-  isInstallment: false,
-  installmentCount: null,
-  installmentGroupId: null,
-  status: "paid",
-  ...overrides,
-});
+): EnrichedTransaction => {
+  const item = {
+    id: "tx-1",
+    title: "Renner",
+    amount: 938.57,
+    purchaseDate: "2026-05-05",
+    tagId: "tag-compras",
+    creditCardId: "card-1",
+    billMonth: "2026-05",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "paid",
+    ...overrides,
+  };
+  return {
+    ...item,
+    transaction: overrides.transaction ?? {
+      ...transactionFixture,
+      id: item.id,
+      title: item.title,
+      amount: item.amount.toFixed(2),
+      dueDate: item.purchaseDate,
+      tagId: item.tagId,
+      creditCardId: item.creditCardId,
+      isInstallment: item.isInstallment,
+      installmentCount: item.installmentCount,
+      installmentGroupId: item.installmentGroupId,
+      status: "paid",
+    },
+  };
+};
 
 const buildBill = (
   overrides: Partial<CreditCardBillRecord> = {},

--- a/features/credit-cards/model/credit-card-statement.test.ts
+++ b/features/credit-cards/model/credit-card-statement.test.ts
@@ -6,6 +6,7 @@ import type {
 import type { EnrichedTransaction } from "@/features/credit-cards/model/card-transactions";
 import { buildStatement } from "@/features/credit-cards/model/credit-card-statement";
 import type { Tag } from "@/features/tags/contracts";
+import { transactionFixture } from "@/features/transactions/mocks";
 
 /**
  * Monta uma EnrichedTransaction com defaults para os testes.
@@ -13,20 +14,38 @@ import type { Tag } from "@/features/tags/contracts";
  * @param partial Campos a sobrescrever.
  * @returns EnrichedTransaction completa.
  */
-const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => ({
-  id: "tx-1",
-  title: "Compra",
-  amount: 100,
-  purchaseDate: "2026-06-02",
-  tagId: null,
-  creditCardId: "cc-1",
-  billMonth: "2026-06",
-  isInstallment: false,
-  installmentCount: null,
-  installmentGroupId: null,
-  status: "pending",
-  ...partial,
-});
+const etx = (partial: Partial<EnrichedTransaction>): EnrichedTransaction => {
+  const item = {
+    id: "tx-1",
+    title: "Compra",
+    amount: 100,
+    purchaseDate: "2026-06-02",
+    tagId: null,
+    creditCardId: "cc-1",
+    billMonth: "2026-06",
+    isInstallment: false,
+    installmentCount: null,
+    installmentGroupId: null,
+    status: "pending",
+    ...partial,
+  };
+  return {
+    ...item,
+    transaction: partial.transaction ?? {
+      ...transactionFixture,
+      id: item.id,
+      title: item.title,
+      amount: item.amount.toFixed(2),
+      dueDate: item.purchaseDate,
+      tagId: item.tagId,
+      creditCardId: item.creditCardId,
+      isInstallment: item.isInstallment,
+      installmentCount: item.installmentCount,
+      installmentGroupId: item.installmentGroupId,
+      status: "pending",
+    },
+  };
+};
 
 /**
  * Monta um CreditCard completo com defaults para os testes.

--- a/features/credit-cards/screens/credit-card-bill-screen.test.tsx
+++ b/features/credit-cards/screens/credit-card-bill-screen.test.tsx
@@ -5,12 +5,18 @@ import { TestProviders } from "@/shared/testing/test-providers";
 import { CreditCardBillScreen } from "@/features/credit-cards/screens/credit-card-bill-screen";
 import type { CreditCardBillScreenController } from "@/features/credit-cards/hooks/use-credit-card-bill-screen-controller";
 import type { CreditCardInvoiceViewModel } from "@/features/credit-cards/model/credit-card-invoice";
+import type { TransactionRecord } from "@/features/transactions/contracts";
 import { resolveCardGradient } from "@/shared/theme";
 
 const mockHandleBack = jest.fn();
 const mockHandlePreviousMonth = jest.fn();
 const mockHandleNextMonth = jest.fn();
 const mockHandlePayBill = jest.fn();
+const mockHandleEditExpense = jest.fn();
+const mockHandleDuplicateExpense = jest.fn();
+const mockRequestDeleteExpense = jest.fn();
+const mockConfirmDeleteExpense = jest.fn();
+const mockCloseDeleteExpense = jest.fn();
 let mockController: Partial<CreditCardBillScreenController> = {};
 
 const mockCreditCard = {
@@ -25,6 +31,35 @@ const mockCreditCard = {
   description: null,
   benefits: [],
   validityDate: null,
+  createdAt: null,
+  updatedAt: null,
+};
+
+const mockTransaction: TransactionRecord = {
+  id: "tx-1",
+  title: "Renner",
+  amount: "938.57",
+  type: "expense",
+  dueDate: "2026-06-25",
+  startDate: null,
+  endDate: null,
+  description: null,
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: "tag-compras",
+  accountId: null,
+  creditCardId: "card-1",
+  status: "paid",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
   createdAt: null,
   updatedAt: null,
 };
@@ -58,6 +93,7 @@ const mockInvoice: CreditCardInvoiceViewModel = {
           installmentCount: null,
           installmentGroupId: null,
           status: "paid",
+          transaction: mockTransaction,
         },
       ],
     },
@@ -83,6 +119,15 @@ jest.mock("@/features/credit-cards/hooks/use-credit-card-bill-screen-controller"
       handleNextMonth: mockHandleNextMonth,
       handleBack: mockHandleBack,
       handlePayBill: mockHandlePayBill,
+      handleEditExpense: mockHandleEditExpense,
+      handleDuplicateExpense: mockHandleDuplicateExpense,
+      requestDeleteExpense: mockRequestDeleteExpense,
+      confirmDeleteExpense: mockConfirmDeleteExpense,
+      closeDeleteExpense: mockCloseDeleteExpense,
+      deleteTarget: null,
+      isDeletingExpense: false,
+      duplicatingTransactionId: null,
+      expenseActionError: null,
       ...mockController,
     }) as CreditCardBillScreenController,
 }));
@@ -118,6 +163,18 @@ describe("CreditCardBillScreen", () => {
     expect(getByText("Onde foi gasto")).toBeTruthy();
     expect(getByText("Itens da fatura")).toBeTruthy();
     expect(getByText("Renner")).toBeTruthy();
+  });
+
+  it("encaminha ações de despesa para o controller", () => {
+    const { getByTestId } = renderScreen();
+
+    fireEvent.press(getByTestId("invoice-item-edit-tx-1"));
+    fireEvent.press(getByTestId("invoice-item-duplicate-tx-1"));
+    fireEvent.press(getByTestId("invoice-item-delete-tx-1"));
+
+    expect(mockHandleEditExpense).toHaveBeenCalled();
+    expect(mockHandleDuplicateExpense).toHaveBeenCalled();
+    expect(mockRequestDeleteExpense).toHaveBeenCalled();
   });
 
   it("navega entre meses pelo hero", () => {

--- a/features/credit-cards/screens/credit-card-bill-screen.tsx
+++ b/features/credit-cards/screens/credit-card-bill-screen.tsx
@@ -7,11 +7,14 @@ import { InvoiceGroupedItems } from "@/features/credit-cards/components/invoice-
 import { InvoiceHero } from "@/features/credit-cards/components/invoice-hero";
 import { CardStickyCta } from "@/features/credit-cards/components/card-sticky-cta";
 import { OndeFoiGasto } from "@/features/credit-cards/components/onde-foi-gasto";
+import { CREDIT_CARD_EXPENSE_ACTIONS_FEATURE_FLAG_KEY } from "@/features/credit-cards/expense-actions-config";
 import {
   type CreditCardBillScreenController,
   useCreditCardBillScreenController,
 } from "@/features/credit-cards/hooks/use-credit-card-bill-screen-controller";
 import type { CreditCardInvoiceViewModel } from "@/features/credit-cards/model/credit-card-invoice";
+import { DeleteConfirmModal } from "@/features/transactions/components/transaction-action-modals";
+import { isFeatureEnabled } from "@/shared/feature-flags";
 import { AppEmptyState } from "@/shared/components/app-empty-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSkeletonBlock } from "@/shared/components/app-skeleton-block";
@@ -58,6 +61,22 @@ export function CreditCardBillScreen(): ReactElement {
         onBack={controller.handleBack}
       />
       <CreditCardBillBody controller={controller} invoice={controller.invoice} />
+      <DeleteConfirmModal
+        target={controller.deleteTarget}
+        isDeleting={controller.isDeletingExpense}
+        title="Remover despesa?"
+        description={
+          controller.deleteTarget
+            ? `${controller.deleteTarget.title} será removida desta fatura e das Transações. Esta ação não pode ser desfeita.`
+            : ""
+        }
+        occurrenceLabel="Remover"
+        showSeriesOption={false}
+        onClose={controller.closeDeleteExpense}
+        onConfirm={() => {
+          void controller.confirmDeleteExpense();
+        }}
+      />
       <CardStickyCta
         label={`Pagar fatura · ${formatCurrency(controller.invoice.total)}`}
         icon="lightning-bolt"
@@ -77,6 +96,9 @@ function CreditCardBillBody({
   controller,
   invoice,
 }: CreditCardBillBodyProps): ReactElement {
+  const expenseActionsEnabled = isFeatureEnabled(
+    CREDIT_CARD_EXPENSE_ACTIONS_FEATURE_FLAG_KEY,
+  );
   return (
     <ScrollView
       flex={1}
@@ -93,7 +115,22 @@ function CreditCardBillBody({
         onNextMonth={controller.handleNextMonth}
       />
       <OndeFoiGasto categories={invoice.groupedByCategory} />
-      <InvoiceGroupedItems groups={invoice.groupedByCategory} />
+      <InvoiceGroupedItems
+        groups={invoice.groupedByCategory}
+        onEditExpense={
+          expenseActionsEnabled ? controller.handleEditExpense : undefined
+        }
+        onDuplicateExpense={
+          expenseActionsEnabled
+            ? (item) => {
+                void controller.handleDuplicateExpense(item);
+              }
+            : undefined
+        }
+        onRequestDeleteExpense={
+          expenseActionsEnabled ? controller.requestDeleteExpense : undefined
+        }
+      />
     </ScrollView>
   );
 }

--- a/features/credit-cards/screens/credit-card-detail-screen.test.tsx
+++ b/features/credit-cards/screens/credit-card-detail-screen.test.tsx
@@ -5,6 +5,7 @@ import { TestProviders } from "@/shared/testing/test-providers";
 import { CreditCardDetailScreen } from "@/features/credit-cards/screens/credit-card-detail-screen";
 import type { CreditCardDetailScreenController } from "@/features/credit-cards/hooks/use-credit-card-detail-screen-controller";
 import type { CreditCardDetailViewModel } from "@/features/credit-cards/model/credit-card-detail";
+import { transactionFixture } from "@/features/transactions/mocks";
 import { resolveCardGradient } from "@/shared/theme";
 
 const mockHandleBack = jest.fn();
@@ -68,6 +69,16 @@ const mockDetail: CreditCardDetailViewModel = {
       installmentCount: null,
       installmentGroupId: null,
       status: "paid",
+      transaction: {
+        ...transactionFixture,
+        id: "tx-1",
+        title: "Renner",
+        amount: "938.57",
+        dueDate: "2026-06-25",
+        tagId: "tag-compras",
+        creditCardId: "cc-1",
+        status: "paid",
+      },
     },
   ],
 };

--- a/features/credit-cards/screens/credit-cards-screen.test.tsx
+++ b/features/credit-cards/screens/credit-cards-screen.test.tsx
@@ -7,6 +7,7 @@ import type { CardsHomeController } from "@/features/credit-cards/hooks/use-card
 import type { CreditCardsScreenController } from "@/features/credit-cards/hooks/use-credit-cards-screen-controller";
 import type { StatementViewModel } from "@/features/credit-cards/model/credit-card-statement";
 import type { AnalyticsViewModel } from "@/features/credit-cards/model/credit-card-analytics";
+import { transactionFixture } from "@/features/transactions/mocks";
 
 const mockSetView = jest.fn();
 const mockSelectCard = jest.fn();
@@ -61,6 +62,16 @@ const mockFaturas: StatementViewModel = {
           installmentCount: null,
           installmentGroupId: null,
           status: "posted",
+          transaction: {
+            ...transactionFixture,
+            id: "tx-1",
+            title: "Renner",
+            amount: "938.57",
+            dueDate: "2026-06-25",
+            tagId: "t1",
+            creditCardId: "card-1",
+            status: "pending",
+          },
         },
       ],
     },

--- a/features/transactions/components/transaction-action-modals.tsx
+++ b/features/transactions/components/transaction-action-modals.tsx
@@ -125,6 +125,10 @@ export interface DeleteConfirmModalProps {
   readonly isDeleting: boolean;
   readonly onConfirm: (transactionId: string, scope: TransactionDeleteScope) => void;
   readonly onClose: () => void;
+  readonly title?: string;
+  readonly description?: string;
+  readonly occurrenceLabel?: string;
+  readonly showSeriesOption?: boolean;
 }
 
 /**
@@ -137,18 +141,25 @@ export function DeleteConfirmModal({
   isDeleting,
   onConfirm,
   onClose,
+  title = "Excluir transacao",
+  description,
+  occurrenceLabel,
+  showSeriesOption = true,
 }: DeleteConfirmModalProps): ReactElement {
+  const resolvedDescription =
+    description ??
+    (target
+      ? target.isSeries
+        ? `"${target.title}" faz parte de uma serie. O que deseja excluir?`
+        : `Excluir "${target.title}"? Ela vai para a lixeira.`
+      : "");
+  const shouldShowSeriesOption = showSeriesOption && target?.isSeries;
+
   return (
     <ActionSheet visible={Boolean(target)} onClose={onClose}>
       <AppSurfaceCard
-        title="Excluir transacao"
-        description={
-          target
-            ? target.isSeries
-              ? `"${target.title}" faz parte de uma serie. O que deseja excluir?`
-              : `Excluir "${target.title}"? Ela vai para a lixeira.`
-            : ""
-        }
+        title={title}
+        description={resolvedDescription}
       >
         <YStack gap="$3">
           <AppButton
@@ -161,9 +172,9 @@ export function DeleteConfirmModal({
             disabled={isDeleting}
             testID="delete-occurrence"
           >
-            {target?.isSeries ? "Excluir somente esta" : "Excluir"}
+            {occurrenceLabel ?? (target?.isSeries ? "Excluir somente esta" : "Excluir")}
           </AppButton>
-          {target?.isSeries ? (
+          {shouldShowSeriesOption ? (
             <AppButton
               tone="danger"
               onPress={() => onConfirm(target.id, "series")}

--- a/stores/expense-sheet-store.test.ts
+++ b/stores/expense-sheet-store.test.ts
@@ -4,6 +4,39 @@ import {
   resetExpenseSheetStore,
   useExpenseSheetStore,
 } from "@/stores/expense-sheet-store";
+import type { TransactionRecord } from "@/features/transactions/contracts";
+
+const buildTransaction = (
+  override: Partial<TransactionRecord> = {},
+): TransactionRecord => ({
+  id: "tx-1",
+  title: "Mercado",
+  amount: "120.50",
+  type: "expense",
+  dueDate: "2026-06-20",
+  startDate: null,
+  endDate: null,
+  description: "Compra semanal",
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: "tag-food",
+  accountId: "acc-1",
+  creditCardId: "cc-1",
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: null,
+  updatedAt: null,
+  ...override,
+});
 
 describe("useExpenseSheetStore", () => {
   beforeEach(() => {
@@ -19,16 +52,47 @@ describe("useExpenseSheetStore", () => {
       useExpenseSheetStore.getState().open();
     });
     expect(useExpenseSheetStore.getState().isOpen).toBe(true);
+    expect(useExpenseSheetStore.getState().request).toEqual({ mode: "create" });
+  });
+
+  it("openCreate() abre com cartão e mês predefinidos", () => {
+    act(() => {
+      useExpenseSheetStore
+        .getState()
+        .openCreate({ presetCreditCardId: "cc-1", presetMonth: "2026-06" });
+    });
+
+    expect(useExpenseSheetStore.getState().isOpen).toBe(true);
+    expect(useExpenseSheetStore.getState().request).toEqual({
+      mode: "create",
+      presetCreditCardId: "cc-1",
+      presetMonth: "2026-06",
+    });
+  });
+
+  it("openEdit() abre com a transação de origem", () => {
+    const transaction = buildTransaction();
+
+    act(() => {
+      useExpenseSheetStore.getState().openEdit(transaction);
+    });
+
+    expect(useExpenseSheetStore.getState().isOpen).toBe(true);
+    expect(useExpenseSheetStore.getState().request).toEqual({
+      mode: "edit",
+      transaction,
+    });
   });
 
   it("close() fecha o sheet", () => {
     act(() => {
-      useExpenseSheetStore.getState().open();
+      useExpenseSheetStore.getState().openEdit(buildTransaction());
     });
     act(() => {
       useExpenseSheetStore.getState().close();
     });
     expect(useExpenseSheetStore.getState().isOpen).toBe(false);
+    expect(useExpenseSheetStore.getState().request).toEqual({ mode: "create" });
   });
 
   it("resetExpenseSheetStore() volta ao estado fechado", () => {

--- a/stores/expense-sheet-store.ts
+++ b/stores/expense-sheet-store.ts
@@ -1,5 +1,23 @@
 import { create } from "zustand";
 
+import type { TransactionRecord } from "@/features/transactions/contracts";
+
+export interface ExpenseSheetCreateOptions {
+  readonly presetCreditCardId?: string | null;
+  readonly presetMonth?: string | null;
+}
+
+export type ExpenseSheetRequest =
+  | ({
+      readonly mode: "create";
+    } & ExpenseSheetCreateOptions)
+  | {
+      readonly mode: "edit";
+      readonly transaction: TransactionRecord;
+    };
+
+const defaultRequest: ExpenseSheetRequest = { mode: "create" };
+
 /**
  * Estado global do bottom sheet "Lançar despesa".
  *
@@ -12,8 +30,14 @@ import { create } from "zustand";
 export interface ExpenseSheetState {
   /** `true` quando o sheet de lançar despesa deve estar visível. */
   readonly isOpen: boolean;
+  /** Contexto atual do sheet: criação simples, criação predefinida ou edição. */
+  readonly request: ExpenseSheetRequest;
   /** Abre o sheet de lançar despesa. */
   readonly open: () => void;
+  /** Abre o sheet em modo criação com contexto opcional. */
+  readonly openCreate: (options?: ExpenseSheetCreateOptions) => void;
+  /** Abre o sheet em modo edição para a transação informada. */
+  readonly openEdit: (transaction: TransactionRecord) => void;
   /** Fecha o sheet de lançar despesa. */
   readonly close: () => void;
 }
@@ -25,13 +49,25 @@ export interface ExpenseSheetState {
  */
 export const useExpenseSheetStore = create<ExpenseSheetState>((set) => ({
   isOpen: false,
-  open: (): void => set({ isOpen: true }),
-  close: (): void => set({ isOpen: false }),
+  request: defaultRequest,
+  open: (): void => set({ isOpen: true, request: defaultRequest }),
+  openCreate: (options = {}): void =>
+    set({
+      isOpen: true,
+      request: {
+        mode: "create",
+        presetCreditCardId: options.presetCreditCardId ?? undefined,
+        presetMonth: options.presetMonth ?? undefined,
+      },
+    }),
+  openEdit: (transaction): void =>
+    set({ isOpen: true, request: { mode: "edit", transaction } }),
+  close: (): void => set({ isOpen: false, request: defaultRequest }),
 }));
 
 /**
  * Reseta o store do sheet de despesa para o estado fechado (utilitário de teste).
  */
 export const resetExpenseSheetStore = (): void => {
-  useExpenseSheetStore.setState({ isOpen: false });
+  useExpenseSheetStore.setState({ isOpen: false, request: defaultRequest });
 };


### PR DESCRIPTION
## Resumo

Equaliza o App com a Web no fluxo de despesas dentro da fatura do cartão. A fatura deixa de ser uma lista apenas estática e passa a permitir abrir/editar, duplicar e remover despesas vinculadas às Transações, usando a entidade `transactions` existente e sem adicionar dependência nativa.

## O que este PR entrega

- Adiciona a feature flag `app.credit-cards.expense-actions` com status inicial `enabled-dev`.
- Evolui `useExpenseSheetStore` com `openCreate()` e `openEdit()`, preservando `open()` para compatibilidade.
- Evolui `ExpenseSheet` para modos `create` e `edit`, com header/CTA dinâmicos, banner “Vinculada às Transações”, campo Observações e ocultação dos controles create-only em edição.
- Evolui `useExpenseForm` para hidratar e salvar edição via `useUpdateTransactionMutation`, mantendo criação e parcelamento funcionando.
- Torna `InvoiceGroupedItems` acionável: abrir/editar ao tocar, chip “Também em Transações”, botões compactos de editar/duplicar/remover e labels acessíveis.
- Evolui `useCreditCardBillScreenController` para editar, duplicar e remover despesas da fatura usando mutações de Transações.
- Invalida `transactions.root`, `creditCards.root` e `dashboard.root` após create/update/duplicate/delete.
- Reaproveita o modal de confirmação de Transações com copy específica para “Remover despesa?”.
- Documenta o fluxo no runbook `docs/runbooks/credit-card-expense-actions.md`.

## Critérios de aceite

- [x] No App, cada item da fatura expõe ações de abrir/editar, duplicar e remover quando a flag está habilitada.
- [x] Edição usa a transação original e salva via mutation de update.
- [x] Duplicação cria cópia com sufixo ` (cópia)` preservando cartão, categoria, conta, status/observações e competência da fatura.
- [x] Remoção pede confirmação e remove a ocorrência da fatura e de Transações.
- [x] Alterações invalidam Cartões, Transações e Dashboard para refletir recálculo de totais/itens.
- [x] Criação de despesa continua funcionando, incluindo fluxo de parcelamento/entrada.
- [x] Não cria entidade nova; reaproveita `transactions`.
- [x] Não altera `app.json`, `eas.json` nem adiciona dependência nativa.
- [x] Feature fica governada por flag.
- [ ] QA visual mobile aprovado: bloqueado localmente por ausência do binário `maestro` neste ambiente.

## Screenshots / evidência visual

Screenshots mobile não foram anexados nesta rodada porque o ambiente local bloqueou os dois caminhos disponíveis:

- `npm run e2e:visual` falhou com `maestro: command not found`.
- Smoke via Expo Web chegou a subir Metro, mas o runtime web parou em `createTamagui() missing expected tokens.size.$true`, erro estrutural já existente da configuração web/Tamagui.

O PR fica em draft até alguém com Maestro/simulador configurado capturar e anexar os screenshots finais da tela de fatura, sheet de edição e modal de remoção.

## Validação executada

- `npm run quality-check` passou após a implementação e novamente após a refatoração para atender o pre-commit.
  - 410 test suites passed
  - 2660 tests passed
  - 6 snapshots passed
- Testes focados passaram:
  - `features/credit-cards/hooks/use-expense-form.test.tsx`
  - `features/credit-cards/hooks/use-credit-card-bill-screen-controller.test.tsx`
  - `features/credit-cards/components/invoice-grouped-items.test.tsx`
  - `features/credit-cards/screens/credit-card-bill-screen.test.tsx`
- Pre-commit passou:
  - gitleaks
  - governance/policy checks
  - lint-staged com ESLint/Prettier
  - frontend/api/openapi governance
- Pre-push passou:
  - policy checks
  - contract checks
  - TypeScript check
  - audit critical gate
  - Jest coverage advisory: 410 suites / 2660 tests / 6 snapshots

## Riscos e limitações

- A feature está em `enabled-dev`; ativação fora de dev deve seguir governança da flag.
- O audit critical gate passou, mas o `npm audit` ainda lista vulnerabilidades moderadas pré-existentes em dependências de tooling.
- QA visual mobile permanece pendente por bloqueio de ambiente, então este PR deve receber screenshots antes de sair de draft.

## Impacto esperado

- Usuário consegue corrigir, duplicar e remover despesas diretamente da fatura do cartão, com sincronização visual via caches de Cartões e Transações.
- A tela de fatura passa a ter paridade funcional com a Web para o handoff de editar despesa do cartão.