### PR TITLE
fix(transactions): evita crash Android ao abrir Transações

### DIFF
--- a/docs/runbooks/transactions-android-crash.md
+++ b/docs/runbooks/transactions-android-crash.md
@@ -1,0 +1,40 @@
+# Transactions Android crash
+
+## Overview
+
+On Android, the Transactions tab must open without mounting the native
+`ReanimatedSwipeable` wrapper for each feed card. The canonical action path is
+the tap-driven transaction action sheet; swipe is only a shortcut.
+
+## Root Cause
+
+The Transactions feed renders `TxCard` items inside `FlashList`. Each card used
+to mount `react-native-gesture-handler/ReanimatedSwipeable` on every platform.
+That native wrapper is the only Transactions-screen component that depends on
+the Android gesture/reanimated runtime during card mount and is mocked away in
+Jest, so unit tests did not exercise the same path that crashed in the Android
+app.
+
+The app already has a global `GestureHandlerRootView` and deduped compatible
+versions of `react-native-gesture-handler`, `react-native-reanimated` and
+`react-native-worklets`; the issue is localized to the feed card swipe wrapper.
+
+## Behavior
+
+- Android renders each `TxCard` as a plain pressable card.
+- Tapping the card still opens the transaction action sheet with pay, edit,
+  duplicate, installment-group and delete actions.
+- Accessibility actions for pay and delete stay available on Android.
+- Non-Android platforms keep the swipe shortcut.
+
+## Validation
+
+Focused coverage lives in:
+
+- `features/transactions/components/tx-components.test.tsx`
+
+The Android regression test asserts that `TxCard` does not mount
+`ReanimatedSwipeable` when `Platform.OS === "android"` and that tap,
+pay-accessibility and delete-accessibility handlers still fire.
+
+Run `npm run quality-check` before release.

--- a/features/transactions/components/tx-card.tsx
+++ b/features/transactions/components/tx-card.tsx
@@ -1,6 +1,6 @@
 import { memo, type ReactElement } from "react";
 
-import { Pressable, type AccessibilityActionEvent } from "react-native";
+import { Platform, Pressable, type AccessibilityActionEvent } from "react-native";
 import ReanimatedSwipeable from "react-native-gesture-handler/ReanimatedSwipeable";
 import { XStack } from "tamagui";
 
@@ -52,6 +52,26 @@ function TxCardComponent({
     }
   };
 
+  const card = (
+    <Pressable
+      testID={`tx-card-${item.id}`}
+      accessibilityRole="button"
+      accessibilityLabel={`${item.title}, ${item.signedDisplay}, ${item.categoryName}. Toque para ações.`}
+      accessibilityActions={[
+        ...(canPay ? [{ name: "pay", label: "Pagar" }] : []),
+        { name: "delete", label: "Excluir" },
+      ]}
+      onAccessibilityAction={handleAccessibilityAction}
+      onPress={() => onPress(item.id)}
+    >
+      <TxCardBody item={item} analytic={analytic} />
+    </Pressable>
+  );
+
+  if (Platform.OS === "android") {
+    return card;
+  }
+
   return (
     <ReanimatedSwipeable
       friction={1.6}
@@ -84,19 +104,7 @@ function TxCardComponent({
         </XStack>
       )}
     >
-      <Pressable
-        testID={`tx-card-${item.id}`}
-        accessibilityRole="button"
-        accessibilityLabel={`${item.title}, ${item.signedDisplay}, ${item.categoryName}. Toque para ações.`}
-        accessibilityActions={[
-          ...(canPay ? [{ name: "pay", label: "Pagar" }] : []),
-          { name: "delete", label: "Excluir" },
-        ]}
-        onAccessibilityAction={handleAccessibilityAction}
-        onPress={() => onPress(item.id)}
-      >
-        <TxCardBody item={item} analytic={analytic} />
-      </Pressable>
+      {card}
     </ReanimatedSwipeable>
   );
 }

--- a/features/transactions/components/tx-components.test.tsx
+++ b/features/transactions/components/tx-components.test.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { fireEvent, render } from "@testing-library/react-native";
+import { Platform } from "react-native";
 
 import { TestProviders } from "@/shared/testing/test-providers";
 
@@ -33,7 +34,7 @@ jest.mock("react-native-gesture-handler/ReanimatedSwipeable", () => {
   }): React.ReactNode =>
     ReactInner.createElement(
       View,
-      null,
+      { testID: "reanimated-swipeable" },
       renderRightActions
         ? renderRightActions({ value: 0 }, { value: 0 }, { close: () => undefined })
         : null,
@@ -44,6 +45,13 @@ jest.mock("react-native-gesture-handler/ReanimatedSwipeable", () => {
 
 const wrap = (node: React.ReactElement) =>
   render(<TestProviders>{node}</TestProviders>);
+
+const setPlatformOS = (os: typeof Platform.OS): void => {
+  Object.defineProperty(Platform, "OS", {
+    configurable: true,
+    get: () => os,
+  });
+};
 
 const kpis = { income: 27675.37, expense: 19906.3, result: 7769.07, count: 10 };
 
@@ -85,6 +93,10 @@ const bars: readonly CategoryBar[] = [
 
 beforeAll(async () => {
   await initI18n("pt");
+});
+
+afterEach(() => {
+  setPlatformOS("ios");
 });
 
 describe("TxHero", () => {
@@ -205,6 +217,35 @@ describe("TxCard", () => {
       />,
     );
     expect(queryByTestId("tx-invoice-chip")).toBeNull();
+  });
+
+  it("no Android evita montar o ReanimatedSwipeable e mantém o tap de ações", () => {
+    setPlatformOS("android");
+    const onPress = jest.fn();
+    const onMarkPaid = jest.fn();
+    const onDelete = jest.fn();
+    const { getByTestId, queryByTestId } = wrap(
+      <TxCard
+        item={item}
+        analytic={false}
+        onPress={onPress}
+        onMarkPaid={onMarkPaid}
+        onDelete={onDelete}
+      />,
+    );
+
+    expect(queryByTestId("reanimated-swipeable")).toBeNull();
+    fireEvent.press(getByTestId("tx-card-tx-1"));
+    fireEvent(getByTestId("tx-card-tx-1"), "accessibilityAction", {
+      nativeEvent: { actionName: "pay" },
+    });
+    fireEvent(getByTestId("tx-card-tx-1"), "accessibilityAction", {
+      nativeEvent: { actionName: "delete" },
+    });
+
+    expect(onPress).toHaveBeenCalledWith("tx-1");
+    expect(onMarkPaid).toHaveBeenCalledWith("tx-1");
+    expect(onDelete).toHaveBeenCalledWith("tx-1");
   });
 });
 


### PR DESCRIPTION
## Resumo

Corrige o crash no Android ao abrir a aba Transações. A tela mantém o fluxo principal por toque no card e action sheet, mas deixa de montar o `ReanimatedSwipeable` nos cards de Transações quando `Platform.OS === "android"`.

Closes: N/A — sem issue informado para este hotfix.

## Causa raiz

A tela de Transações renderiza `TxCard` dentro de `FlashList`. Cada card montava `react-native-gesture-handler/ReanimatedSwipeable` em todas as plataformas. Esse wrapper é o ponto da tela que depende diretamente do runtime Android de gesture/reanimated durante a montagem dos cards e era mockado nos testes, então o crash nativo não aparecia no Jest.

A configuração global do app já tem `GestureHandlerRootView`, e as versões de `react-native-gesture-handler`, `react-native-reanimated` e `react-native-worklets` estão deduplicadas. A correção ficou localizada no card do feed.

## O que este PR entrega

- No Android, `TxCard` renderiza como card pressable sem montar `ReanimatedSwipeable`.
- Mantém tap no card abrindo o action sheet de Transações.
- Mantém ações de acessibilidade para pagar e excluir no Android.
- Preserva o atalho de swipe em plataformas não Android.
- Adiciona teste regressivo cobrindo o comportamento Android.
- Documenta o diagnóstico em `docs/runbooks/transactions-android-crash.md`.

## Critérios de aceite

- [x] Abrir Transações no Android não passa mais pelo wrapper nativo `ReanimatedSwipeable` dos cards.
- [x] Tap no card continua acionando o action sheet.
- [x] Ações de acessibilidade para pagar/excluir continuam funcionando.
- [x] iOS/outras plataformas mantêm swipe shortcut.
- [x] Sem alteração em `app.json` ou `eas.json`.
- [x] Sem dependência nativa nova.
- [x] Correção é OTA-able por ser JS-only.
- [x] OTA Android publicado no canal `preview` para teste.

## OTA Preview

Publicado via EAS Update somente para Android no canal `preview`:

- Branch EAS: `preview`
- Runtime version: `1.0.0`
- Platform: `android`
- Update group ID: `a1333ff0-b24d-435c-9ddf-207a2e0b2f29`
- Android update ID: `019f0b84-aefc-721c-afdc-b3d29d19a440`
- Commit: `1cb4a98aec983ab8f3df4a0f737ee401df191719`
- Dashboard: https://expo.dev/accounts/italofelipe/projects/auraxis-app/updates/a1333ff0-b24d-435c-9ddf-207a2e0b2f29

## Screenshots / evidência visual

Não anexei screenshot do Android real neste ambiente porque não há `adb` disponível (`adb: command not found`) e não há emulador/simulador Android acessível por aqui. Evidência automatizada incluída: teste regressivo força `Platform.OS = "android"` e valida que o card não monta `ReanimatedSwipeable`, mas mantém tap/pagar/excluir. A OTA preview acima permite validar no aparelho/build Android.

## Validação executada

- RED: `npm test -- --runTestsByPath features/transactions/components/tx-components.test.tsx --runInBand` falhou antes do fix porque o Android ainda montava `reanimated-swipeable`.
- GREEN: a mesma suíte passou após o fix: 14 testes.
- Focado: `features/transactions/components/tx-components.test.tsx`, `features/transactions/screens/transactions-screen.test.tsx`, `features/transactions/hooks/use-transaction-feed-actions.test.ts`, `features/transactions/hooks/use-transactions-feed-controller.test.ts` reportaram 4 suítes / 36 testes verdes; a sessão foi interrompida depois do relatório por handle aberto pré-existente do Jest/FlashList.
- `npx eslint --max-warnings 0 --no-warn-ignored features/transactions/components/tx-card.tsx features/transactions/components/tx-components.test.tsx` passou.
- `npm run quality-check` passou:
  - 410 test suites passed
  - 2661 tests passed
  - 6 snapshots passed
- Pre-commit passou: gitleaks, governance e lint-staged.
- Pre-push passou: policy, contracts, TypeScript, audit critical gate e coverage advisory.
- EAS Update `preview` Android publicou com sucesso.

## Riscos e limitações

- O swipe shortcut fica desabilitado apenas no Android; o action sheet por toque continua sendo o caminho completo de ações.
- Validação manual em aparelho Android real ainda é necessária para confirmar o crash reportado pelo usuário.
- `npm audit` segue reportando vulnerabilidades moderadas pré-existentes em dependências de tooling; o gate crítico passou.
