### PR TITLE
feat(payments-assistant): assistente de pagamentos (deck swipe, Premium)

### DIFF
--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -10,6 +10,7 @@ import { usePrivateRouteGuard } from "@/core/navigation/use-route-guards";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
 import { ExpenseSheetHost } from "@/features/credit-cards/components/expense-sheet/expense-sheet-host";
 import { useEntitlementsForegroundRefresh } from "@/features/entitlements/hooks/use-entitlements-foreground-refresh";
+import { PaymentAssistantHost } from "@/features/payments-assistant/screens/payment-assistant-host";
 import { useWeeklyInsight } from "@/features/insights/hooks/use-weekly-insight-query";
 import { WEEKLY_INSIGHT_FEATURE_FLAG_KEY } from "@/features/insights/weekly-insight-config";
 import { TourAnchorProvider } from "@/shared/coach-marks/tour-anchor-context";
@@ -106,6 +107,7 @@ function PrivateLayoutContent(): ReactElement | null {
         ))}
       </Tabs>
       <ExpenseSheetHost />
+      <PaymentAssistantHost />
     </TourAnchorProvider>
   );
 }

--- a/features/payments-assistant/components/payment-assistant-actions-bar.tsx
+++ b/features/payments-assistant/components/payment-assistant-actions-bar.tsx
@@ -1,0 +1,42 @@
+import type { ReactElement } from "react";
+
+import { YStack } from "tamagui";
+
+import { AppButton } from "@/shared/components/app-button";
+import { useT } from "@/shared/i18n";
+
+/** Props for the assistant's primary action buttons. */
+export interface PaymentAssistantActionsBarProps {
+  readonly payLabel: string;
+  readonly onPay: () => void;
+  readonly onDelete: () => void;
+  readonly onSkip: () => void;
+}
+
+/**
+ * Accessible button row mirroring the swipe gestures (pay / delete / skip).
+ *
+ * @param props Pay label and the three handlers.
+ * @returns The stacked action buttons.
+ */
+export function PaymentAssistantActionsBar({
+  payLabel,
+  onPay,
+  onDelete,
+  onSkip,
+}: PaymentAssistantActionsBarProps): ReactElement {
+  const { t } = useT();
+  return (
+    <YStack gap="$2">
+      <AppButton tone="primary" fullWidth onPress={onPay}>
+        {payLabel}
+      </AppButton>
+      <AppButton tone="danger" fullWidth onPress={onDelete}>
+        {t("paymentsAssistant.actions.delete")}
+      </AppButton>
+      <AppButton tone="secondary" fullWidth onPress={onSkip}>
+        {t("paymentsAssistant.actions.skip")}
+      </AppButton>
+    </YStack>
+  );
+}

--- a/features/payments-assistant/components/payment-assistant-card.tsx
+++ b/features/payments-assistant/components/payment-assistant-card.tsx
@@ -1,0 +1,110 @@
+import type { ReactElement } from "react";
+
+import { Paragraph, XStack, YStack } from "tamagui";
+
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import { AppMoneyText } from "@/shared/components/app-money-text";
+import { AppText } from "@/shared/components/app-text";
+import { safeFormatCurrency } from "@/shared/utils/currency";
+import { useT } from "@/shared/i18n";
+
+/** Formats a `YYYY-MM-DD` (or ISO) string as `dd/mm/yyyy` without timezone drift. */
+const formatDate = (value: string | null): string => {
+  if (!value) {
+    return "—";
+  }
+  const [year, month, day] = value.slice(0, 10).split("-");
+  return `${day}/${month}/${year}`;
+};
+
+/** Props for the assistant card. */
+export interface PaymentAssistantCardProps {
+  readonly transaction: TransactionRecord;
+}
+
+/**
+ * Presentational card for one overdue transaction in the assistant deck.
+ *
+ * Shows type, amount, title, description, created/due dates and observation.
+ * No gesture logic — the deck wraps it.
+ *
+ * @param props The transaction to render.
+ * @returns The card body.
+ */
+export function PaymentAssistantCard({ transaction }: PaymentAssistantCardProps): ReactElement {
+  const { t } = useT();
+  const isIncome = transaction.type === "income";
+
+  return (
+    <YStack
+      backgroundColor="$surfaceCard"
+      borderColor="$borderColor"
+      borderWidth={1}
+      borderRadius="$4"
+      padding="$4"
+      gap="$3"
+    >
+      <XStack alignItems="center" justifyContent="space-between">
+        <Paragraph
+          fontFamily="$body"
+          fontWeight="$7"
+          fontSize="$1"
+          color={isIncome ? "$success" : "$warning"}
+          borderColor={isIncome ? "$success" : "$warning"}
+          borderWidth={1}
+          paddingHorizontal="$2"
+          paddingVertical="$1"
+          borderRadius="$5"
+        >
+          {isIncome
+            ? t("paymentsAssistant.type.income")
+            : t("paymentsAssistant.type.expense")}
+        </Paragraph>
+        <AppMoneyText fontSize="$6" fontWeight="$7" color={isIncome ? "$success" : "$color"}>
+          {safeFormatCurrency(transaction.amount)}
+        </AppMoneyText>
+      </XStack>
+
+      <YStack gap="$1">
+        <AppText size="bodyLg" tone="default" numberOfLines={2}>
+          {transaction.title}
+        </AppText>
+        {transaction.description ? (
+          <AppText size="bodySm" tone="muted" numberOfLines={2}>
+            {transaction.description}
+          </AppText>
+        ) : null}
+      </YStack>
+
+      <XStack gap="$5">
+        <YStack gap="$1">
+          <AppText size="caption" tone="muted">
+            {t("paymentsAssistant.fields.createdAt")}
+          </AppText>
+          <AppText size="bodySm" tone="default">
+            {formatDate(transaction.createdAt)}
+          </AppText>
+        </YStack>
+        <YStack gap="$1">
+          <AppText size="caption" tone="muted">
+            {t("paymentsAssistant.fields.dueDate")}
+          </AppText>
+          <AppText size="bodySm" tone="default">
+            {formatDate(transaction.dueDate)}
+          </AppText>
+        </YStack>
+      </XStack>
+
+      {transaction.observation ? (
+        <YStack gap="$1">
+          <AppText size="caption" tone="muted">
+            {t("paymentsAssistant.fields.observation")}
+          </AppText>
+          <AppText size="bodySm" tone="default" numberOfLines={3}>
+            {transaction.observation}
+          </AppText>
+        </YStack>
+      ) : null}
+    </YStack>
+  );
+}

--- a/features/payments-assistant/components/payment-assistant-deck.tsx
+++ b/features/payments-assistant/components/payment-assistant-deck.tsx
@@ -1,0 +1,91 @@
+import { type ReactElement, useEffect } from "react";
+
+import { Dimensions } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  withTiming,
+} from "react-native-reanimated";
+
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import { PaymentAssistantCard } from "@/features/payments-assistant/components/payment-assistant-card";
+import { resolveSwipeOutcome } from "@/features/payments-assistant/services/payment-assistant-swipe";
+
+const SCREEN_WIDTH = Dimensions.get("window").width;
+/** Commit threshold: ~28% of the screen — generous, to avoid accidental swipes. */
+const SWIPE_THRESHOLD = Math.round(SCREEN_WIDTH * 0.28);
+/** Off-screen fly-out distance. */
+const FLY_OUT = SCREEN_WIDTH * 1.2;
+
+/** Props for the swipe deck. */
+export interface PaymentAssistantDeckProps {
+  /** The card currently on top, or null when the deck is exhausted. */
+  readonly card: TransactionRecord | null;
+  /** Swiped right past the threshold (pay/receive). */
+  readonly onPay: () => void;
+  /** Swiped left past the threshold (delete — caller confirms). */
+  readonly onDelete: () => void;
+}
+
+/**
+ * Tinder-style swipe deck: the top card follows the finger; releasing past the
+ * threshold flies it out and commits (right = pay, left = delete), otherwise it
+ * springs back. Built on Gesture Handler + Reanimated (no extra dependency).
+ *
+ * @param props Current card and commit callbacks.
+ * @returns The animated, swipeable top card.
+ */
+export function PaymentAssistantDeck({
+  card,
+  onPay,
+  onDelete,
+}: PaymentAssistantDeckProps): ReactElement | null {
+  const translateX = useSharedValue(0);
+
+  // Reset position whenever a new card becomes the top of the deck.
+  useEffect(() => {
+    translateX.value = 0;
+  }, [card?.id, translateX]);
+
+  const pan = Gesture.Pan()
+    .activeOffsetX([-12, 12])
+    .onUpdate((event) => {
+      translateX.value = event.translationX;
+    })
+    .onEnd((event) => {
+      const outcome = resolveSwipeOutcome(event.translationX, SWIPE_THRESHOLD);
+      if (outcome === "pay") {
+        translateX.value = withTiming(FLY_OUT, { duration: 180 }, () => {
+          runOnJS(onPay)();
+        });
+      } else if (outcome === "delete") {
+        translateX.value = withTiming(-FLY_OUT, { duration: 180 }, () => {
+          runOnJS(onDelete)();
+        });
+      } else {
+        translateX.value = withSpring(0);
+      }
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: translateX.value },
+      { rotateZ: `${(translateX.value / SCREEN_WIDTH) * 8}deg` },
+    ],
+  }));
+
+  if (!card) {
+    return null;
+  }
+
+  return (
+    <GestureDetector gesture={pan}>
+      <Animated.View style={animatedStyle} testID="payment-assistant-deck-card">
+        <PaymentAssistantCard transaction={card} />
+      </Animated.View>
+    </GestureDetector>
+  );
+}

--- a/features/payments-assistant/components/payment-assistant-footer.tsx
+++ b/features/payments-assistant/components/payment-assistant-footer.tsx
@@ -1,0 +1,53 @@
+import type { ReactElement } from "react";
+
+import { XStack, YStack } from "tamagui";
+
+import { AppButton } from "@/shared/components/app-button";
+import { useT } from "@/shared/i18n";
+
+/** Props for the assistant footer (undo / mark-all / close). */
+export interface PaymentAssistantFooterProps {
+  readonly canUndo: boolean;
+  readonly showMarkAll: boolean;
+  readonly onUndo: () => void;
+  readonly onMarkAll: () => void;
+  readonly onClose: () => void;
+}
+
+/**
+ * Footer row: undo (when an action can be reverted), mark-all-paid (when there
+ * is more than one card) and close.
+ *
+ * @param props Footer visibility flags and handlers.
+ * @returns The footer row.
+ */
+export function PaymentAssistantFooter({
+  canUndo,
+  showMarkAll,
+  onUndo,
+  onMarkAll,
+  onClose,
+}: PaymentAssistantFooterProps): ReactElement {
+  const { t } = useT();
+  return (
+    <XStack alignItems="center" justifyContent="space-between" gap="$2">
+      {canUndo ? (
+        <AppButton tone="secondary" onPress={onUndo}>
+          {t("paymentsAssistant.actions.undo")}
+        </AppButton>
+      ) : (
+        <YStack />
+      )}
+      <XStack gap="$2">
+        {showMarkAll ? (
+          <AppButton tone="secondary" onPress={onMarkAll}>
+            {t("paymentsAssistant.actions.markAllPaid")}
+          </AppButton>
+        ) : null}
+        <AppButton tone="secondary" onPress={onClose}>
+          {t("paymentsAssistant.actions.close")}
+        </AppButton>
+      </XStack>
+    </XStack>
+  );
+}

--- a/features/payments-assistant/components/payment-assistant-sections.tsx
+++ b/features/payments-assistant/components/payment-assistant-sections.tsx
@@ -1,0 +1,78 @@
+import type { ReactElement } from "react";
+
+import { YStack } from "tamagui";
+
+import type { PaymentAssistantController } from "@/features/payments-assistant/hooks/use-payment-assistant-controller";
+import { PaymentAssistantActionsBar } from "@/features/payments-assistant/components/payment-assistant-actions-bar";
+import { PaymentAssistantDeck } from "@/features/payments-assistant/components/payment-assistant-deck";
+import { AppText } from "@/shared/components/app-text";
+import { useT } from "@/shared/i18n";
+
+/** Props for the active (reviewing) section. */
+export interface PaymentAssistantActiveSectionProps {
+  readonly controller: PaymentAssistantController;
+  readonly payLabel: string;
+  readonly onDelete: () => void;
+}
+
+/**
+ * The reviewing section: progress, the swipe deck, the status hint and the
+ * accessible action buttons.
+ *
+ * @param props Controller, pay label and the (confirmed) delete handler.
+ * @returns The active section.
+ */
+export function PaymentAssistantActiveSection({
+  controller,
+  payLabel,
+  onDelete,
+}: PaymentAssistantActiveSectionProps): ReactElement {
+  const { t } = useT();
+  return (
+    <YStack gap="$3">
+      <AppText size="caption" tone="muted">
+        {t("paymentsAssistant.progress", {
+          current: controller.progress.current,
+          total: controller.progress.total,
+        })}
+      </AppText>
+      <PaymentAssistantDeck
+        card={controller.current}
+        onPay={(): void => {
+          void controller.pay();
+        }}
+        onDelete={onDelete}
+      />
+      <AppText size="caption" tone="muted">
+        {t("paymentsAssistant.statusHint")}
+      </AppText>
+      <PaymentAssistantActionsBar
+        payLabel={payLabel}
+        onPay={(): void => {
+          void controller.pay();
+        }}
+        onDelete={onDelete}
+        onSkip={controller.skipCard}
+      />
+    </YStack>
+  );
+}
+
+/**
+ * The done / empty state shown when there is no overdue backlog left.
+ *
+ * @returns The done state.
+ */
+export function PaymentAssistantDoneState(): ReactElement {
+  const { t } = useT();
+  return (
+    <YStack gap="$2" paddingVertical="$4" alignItems="center">
+      <AppText size="bodyLg" tone="default">
+        {t("paymentsAssistant.emptyTitle")}
+      </AppText>
+      <AppText size="bodySm" tone="muted">
+        {t("paymentsAssistant.emptyBody")}
+      </AppText>
+    </YStack>
+  );
+}

--- a/features/payments-assistant/hooks/use-payment-assistant-actions.ts
+++ b/features/payments-assistant/hooks/use-payment-assistant-actions.ts
@@ -1,0 +1,128 @@
+/**
+ * Action handlers for the Payments Assistant deck (mobile).
+ *
+ * Extracted from {@link usePaymentAssistantController} so the controller stays
+ * small. All side effects (mutations) flow through here; the pure deck reducer
+ * drives navigation.
+ */
+
+import { type Dispatch, type SetStateAction, useCallback } from "react";
+
+import type { UpdateTransactionCommand } from "@/features/transactions/contracts";
+import {
+  type DeckAction,
+  type DeckState,
+  advanceDeck,
+  currentCard,
+  undoDeck,
+} from "@/features/payments-assistant/services/payment-assistant-deck";
+
+/** A mutation surface exposing only the `mutateAsync` the assistant uses. */
+interface MutateAsync<TArgs> {
+  readonly mutateAsync: (args: TArgs) => Promise<unknown>;
+}
+
+/** The four transaction mutations the assistant drives. */
+export interface AssistantMutations {
+  readonly markPaid: MutateAsync<{ transactionId: string; paidAt: string }>;
+  readonly remove: MutateAsync<{ transactionId: string; scope: "occurrence" | "series" }>;
+  readonly update: MutateAsync<{ transactionId: string; payload: UpdateTransactionCommand }>;
+  readonly restore: { readonly mutateAsync: (id: string) => Promise<unknown> };
+}
+
+/** Dependencies the action handlers operate on. */
+export interface AssistantActionsDeps {
+  readonly deck: DeckState;
+  readonly setDeck: Dispatch<SetStateAction<DeckState>>;
+  readonly setLastAction: Dispatch<SetStateAction<DeckAction | null>>;
+  readonly mutations: AssistantMutations;
+  readonly now: () => Date;
+}
+
+/** The handler surface returned to the controller. */
+export interface AssistantActions {
+  readonly pay: () => Promise<void>;
+  readonly discard: () => Promise<void>;
+  readonly skipCard: () => void;
+  readonly markAllPaid: () => Promise<void>;
+  readonly undo: () => Promise<DeckAction | null>;
+}
+
+/** Formats a Date as a local `YYYY-MM-DD` calendar date. */
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Builds the deck action handlers over the given dependencies.
+ *
+ * @param deps Deck state, setters, mutations and clock.
+ * @returns The pay/discard/skip/markAll/undo handlers.
+ */
+export const useAssistantActions = (deps: AssistantActionsDeps): AssistantActions => {
+  const { deck, setDeck, setLastAction, mutations, now } = deps;
+
+  const pay = useCallback(async (): Promise<void> => {
+    const card = currentCard(deck);
+    if (!card) {
+      return;
+    }
+    await mutations.markPaid.mutateAsync({ transactionId: card.id, paidAt: toIsoDate(now()) });
+    setDeck((state) => advanceDeck(state, "paid"));
+    setLastAction({ kind: "paid", card });
+  }, [deck, mutations, now, setDeck, setLastAction]);
+
+  const discard = useCallback(async (): Promise<void> => {
+    const card = currentCard(deck);
+    if (!card) {
+      return;
+    }
+    await mutations.remove.mutateAsync({ transactionId: card.id, scope: "occurrence" });
+    setDeck((state) => advanceDeck(state, "deleted"));
+    setLastAction({ kind: "deleted", card });
+  }, [deck, mutations, setDeck, setLastAction]);
+
+  const skipCard = useCallback((): void => {
+    const card = currentCard(deck);
+    if (!card) {
+      return;
+    }
+    setDeck((state) => advanceDeck(state, "skipped"));
+    setLastAction({ kind: "skipped", card });
+  }, [deck, setDeck, setLastAction]);
+
+  const markAllPaid = useCallback(async (): Promise<void> => {
+    let working = deck;
+    let card = currentCard(working);
+    while (card) {
+      await mutations.markPaid.mutateAsync({ transactionId: card.id, paidAt: toIsoDate(now()) });
+      working = advanceDeck(working, "paid");
+      setLastAction({ kind: "paid", card });
+      card = currentCard(working);
+    }
+    setDeck(working);
+  }, [deck, mutations, now, setDeck, setLastAction]);
+
+  const undo = useCallback(async (): Promise<DeckAction | null> => {
+    const { deck: previous, undone } = undoDeck(deck);
+    if (!undone) {
+      return null;
+    }
+    setDeck(previous);
+    setLastAction(null);
+    if (undone.kind === "paid") {
+      await mutations.update.mutateAsync({
+        transactionId: undone.card.id,
+        payload: { status: "pending", paidAt: null },
+      });
+    } else if (undone.kind === "deleted") {
+      await mutations.restore.mutateAsync(undone.card.id);
+    }
+    return undone;
+  }, [deck, mutations, setDeck, setLastAction]);
+
+  return { pay, discard, skipCard, markAllPaid, undo };
+};

--- a/features/payments-assistant/hooks/use-payment-assistant-controller.test.ts
+++ b/features/payments-assistant/hooks/use-payment-assistant-controller.test.ts
@@ -1,0 +1,140 @@
+import { act, renderHook } from "@testing-library/react-native";
+
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import { usePaymentAssistantController } from "@/features/payments-assistant/hooks/use-payment-assistant-controller";
+import { resetPaymentAssistantSessionForTests } from "@/features/payments-assistant/services/payment-assistant-session";
+
+const mockMarkPaid = jest.fn();
+const mockRemove = jest.fn();
+const mockUpdate = jest.fn();
+const mockRestore = jest.fn();
+let mockStartupReady = true;
+let mockHasAccess = true;
+let mockTransactions: TransactionRecord[] = [];
+
+jest.mock("@/core/shell/app-shell-store", () => ({
+  useAppShellStore: (selector: (state: { startupReady: boolean }) => unknown) =>
+    selector({ startupReady: mockStartupReady }),
+}));
+jest.mock("@/features/entitlements/hooks/use-feature-access", () => ({
+  useFeatureAccess: () => ({ hasAccess: mockHasAccess, isLoading: false }),
+}));
+jest.mock("@/features/transactions/hooks/use-transactions-query", () => ({
+  useTransactionsQuery: () => ({ data: { transactions: mockTransactions } }),
+}));
+jest.mock("@/features/transactions/hooks/use-transaction-mutations", () => ({
+  useMarkTransactionPaidMutation: () => ({ mutateAsync: mockMarkPaid }),
+  useDeleteTransactionMutation: () => ({ mutateAsync: mockRemove }),
+  useUpdateTransactionMutation: () => ({ mutateAsync: mockUpdate }),
+  useRestoreTransactionMutation: () => ({ mutateAsync: mockRestore }),
+}));
+
+const NOW = (): Date => new Date(2026, 5, 29);
+
+const tx = (overrides: Partial<TransactionRecord> = {}): TransactionRecord =>
+  ({
+    id: "tx",
+    title: "Conta",
+    amount: "100.00",
+    type: "expense",
+    dueDate: "2026-04-01",
+    status: "pending",
+    description: null,
+    observation: null,
+    paidAt: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    ...overrides,
+  }) as TransactionRecord;
+
+const renderController = () => renderHook(() => usePaymentAssistantController({ now: NOW }));
+
+describe("usePaymentAssistantController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetPaymentAssistantSessionForTests();
+    mockStartupReady = true;
+    mockHasAccess = true;
+    mockTransactions = [
+      tx({ id: "a", dueDate: "2026-02-01" }),
+      tx({ id: "b", dueDate: "2026-03-01" }),
+      tx({ id: "recent", dueDate: "2026-06-25" }),
+      tx({ id: "settled", status: "paid", dueDate: "2026-01-01" }),
+    ];
+    mockMarkPaid.mockResolvedValue(undefined);
+    mockRemove.mockResolvedValue(undefined);
+    mockUpdate.mockResolvedValue(undefined);
+    mockRestore.mockResolvedValue(undefined);
+  });
+
+  it("auto-opens for a Premium user with overdue candidates, oldest first", () => {
+    const { result } = renderController();
+    expect(result.current.isVisible).toBe(true);
+    expect(result.current.current?.id).toBe("a");
+    expect(result.current.progress).toEqual({ current: 1, total: 2 });
+  });
+
+  it("does not auto-open for non-Premium users", () => {
+    mockHasAccess = false;
+    const { result } = renderController();
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("does not auto-open before startup is ready", () => {
+    mockStartupReady = false;
+    const { result } = renderController();
+    expect(result.current.isVisible).toBe(false);
+  });
+
+  it("pays the current card and advances", async () => {
+    const { result } = renderController();
+    await act(async () => {
+      await result.current.pay();
+    });
+    expect(mockMarkPaid).toHaveBeenCalledWith({ transactionId: "a", paidAt: "2026-06-29" });
+    expect(result.current.current?.id).toBe("b");
+  });
+
+  it("discards the current card via soft-delete and advances", async () => {
+    const { result } = renderController();
+    await act(async () => {
+      await result.current.discard();
+    });
+    expect(mockRemove).toHaveBeenCalledWith({ transactionId: "a", scope: "occurrence" });
+    expect(result.current.current?.id).toBe("b");
+  });
+
+  it("marks all remaining cards as paid", async () => {
+    const { result } = renderController();
+    await act(async () => {
+      await result.current.markAllPaid();
+    });
+    expect(mockMarkPaid).toHaveBeenCalledTimes(2);
+    expect(result.current.isDone).toBe(true);
+  });
+
+  it("undoes a payment by reverting to pending", async () => {
+    const { result } = renderController();
+    await act(async () => {
+      await result.current.pay();
+    });
+    await act(async () => {
+      await result.current.undo();
+    });
+    expect(mockUpdate).toHaveBeenCalledWith({
+      transactionId: "a",
+      payload: { status: "pending", paidAt: null },
+    });
+    expect(result.current.current?.id).toBe("a");
+  });
+
+  it("undoes a delete by restoring the transaction", async () => {
+    const { result } = renderController();
+    await act(async () => {
+      await result.current.discard();
+    });
+    await act(async () => {
+      await result.current.undo();
+    });
+    expect(mockRestore).toHaveBeenCalledWith("a");
+  });
+});

--- a/features/payments-assistant/hooks/use-payment-assistant-controller.ts
+++ b/features/payments-assistant/hooks/use-payment-assistant-controller.ts
@@ -1,0 +1,150 @@
+/**
+ * Controller for the Payments Assistant on mobile.
+ *
+ * Wires entitlement (Premium), the overdue-candidates query and the transaction
+ * mutations to a card deck, exposing a view model + actions for the host screen.
+ * Decision logic lives in the pure `services/payment-assistant-*` modules and
+ * the action handlers in `use-payment-assistant-actions`.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { useFeatureAccess } from "@/features/entitlements/hooks/use-feature-access";
+import type { TransactionListQuery, TransactionRecord } from "@/features/transactions/contracts";
+import { useTransactionsQuery } from "@/features/transactions/hooks/use-transactions-query";
+import {
+  useDeleteTransactionMutation,
+  useMarkTransactionPaidMutation,
+  useRestoreTransactionMutation,
+  useUpdateTransactionMutation,
+} from "@/features/transactions/hooks/use-transaction-mutations";
+
+import {
+  OVERDUE_THRESHOLD_DAYS,
+  selectOverdueCandidates,
+} from "@/features/payments-assistant/services/payment-assistant-eligibility";
+import {
+  type DeckAction,
+  type DeckProgress,
+  type DeckState,
+  createDeck,
+  currentCard,
+  deckProgress,
+  isDeckDone,
+} from "@/features/payments-assistant/services/payment-assistant-deck";
+import {
+  markShownThisSession,
+  shouldAutoOpenAssistant,
+  wasShownThisSession,
+} from "@/features/payments-assistant/services/payment-assistant-session";
+import {
+  type AssistantActions,
+  useAssistantActions,
+} from "@/features/payments-assistant/hooks/use-payment-assistant-actions";
+
+/** Entitlement that stands in for "Premium" on mobile (single paid tier). */
+const PREMIUM_FEATURE_KEY = "advanced_simulations" as const;
+/** Page size when pulling overdue candidates (overdue backlog is small in practice). */
+const CANDIDATE_PAGE_SIZE = 100;
+
+/** Options for {@link usePaymentAssistantController}. */
+export interface UsePaymentAssistantControllerOptions {
+  /** Clock injector (defaults to `() => new Date()`), overridable in tests. */
+  readonly now?: () => Date;
+}
+
+/** View model + actions exposed to the host screen. */
+export interface PaymentAssistantController extends AssistantActions {
+  readonly isVisible: boolean;
+  readonly current: TransactionRecord | null;
+  readonly progress: DeckProgress;
+  readonly isDone: boolean;
+  readonly lastAction: DeckAction | null;
+  readonly open: () => void;
+  readonly close: () => void;
+}
+
+/** Formats a Date as a local `YYYY-MM-DD` calendar date. */
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/** Builds the list filter that caps the fetch to entries past the overdue threshold. */
+const buildOverdueFilters = (now: () => Date): TransactionListQuery => {
+  const cutoff = now();
+  cutoff.setDate(cutoff.getDate() - OVERDUE_THRESHOLD_DAYS);
+  return { endDate: toIsoDate(cutoff), perPage: CANDIDATE_PAGE_SIZE };
+};
+
+/**
+ * Payments Assistant controller.
+ *
+ * @param options Optional clock injector.
+ * @returns View model + actions for the host screen.
+ */
+export const usePaymentAssistantController = (
+  options: UsePaymentAssistantControllerOptions = {},
+): PaymentAssistantController => {
+  const now = useMemo(() => options.now ?? ((): Date => new Date()), [options.now]);
+
+  const startupReady = useAppShellStore((state) => state.startupReady);
+  const { hasAccess: isPremium } = useFeatureAccess(PREMIUM_FEATURE_KEY, startupReady);
+
+  const transactionsQuery = useTransactionsQuery(buildOverdueFilters(now));
+  const candidates = useMemo(
+    () => selectOverdueCandidates(transactionsQuery.data?.transactions ?? [], now()),
+    [transactionsQuery.data, now],
+  );
+
+  const mutations = {
+    markPaid: useMarkTransactionPaidMutation(),
+    remove: useDeleteTransactionMutation(),
+    update: useUpdateTransactionMutation(),
+    restore: useRestoreTransactionMutation(),
+  };
+
+  const [isVisible, setIsVisible] = useState(false);
+  const [deck, setDeck] = useState<DeckState>(() => createDeck([]));
+  const [lastAction, setLastAction] = useState<DeckAction | null>(null);
+
+  const open = useCallback((): void => {
+    setDeck(createDeck(candidates));
+    setLastAction(null);
+    setIsVisible(true);
+    markShownThisSession();
+  }, [candidates]);
+
+  const close = useCallback((): void => {
+    setIsVisible(false);
+  }, []);
+
+  useEffect(() => {
+    if (
+      shouldAutoOpenAssistant({
+        startupReady,
+        isPremium,
+        shownThisSession: wasShownThisSession(),
+        candidateCount: candidates.length,
+      })
+    ) {
+      open();
+    }
+  }, [startupReady, isPremium, candidates, open]);
+
+  const actions = useAssistantActions({ deck, setDeck, setLastAction, mutations, now });
+
+  return {
+    isVisible,
+    current: currentCard(deck),
+    progress: deckProgress(deck),
+    isDone: isDeckDone(deck),
+    lastAction,
+    open,
+    close,
+    ...actions,
+  };
+};

--- a/features/payments-assistant/screens/payment-assistant-host.tsx
+++ b/features/payments-assistant/screens/payment-assistant-host.tsx
@@ -1,0 +1,111 @@
+import { type ReactElement, useCallback } from "react";
+
+import { Alert, Modal, Pressable } from "react-native";
+import { YStack } from "tamagui";
+
+import { usePaymentAssistantController } from "@/features/payments-assistant/hooks/use-payment-assistant-controller";
+import { PaymentAssistantFooter } from "@/features/payments-assistant/components/payment-assistant-footer";
+import {
+  PaymentAssistantActiveSection,
+  PaymentAssistantDoneState,
+} from "@/features/payments-assistant/components/payment-assistant-sections";
+import { AppText } from "@/shared/components/app-text";
+import { useT } from "@/shared/i18n";
+
+/** Backdrop kept in a variable (parity with existing sheets), 100% OTA. */
+const BACKDROP = "rgba(0,0,0,0.55)";
+const SHEET_RADIUS = 24;
+
+/**
+ * Host for the Payments Assistant on mobile.
+ *
+ * Self-triggers (1×/session, Premium) and presents a bottom-sheet `Modal` with a
+ * Tinder-style swipe deck: swipe right / tap to mark paid-received, swipe left /
+ * tap to delete (confirmed), skip, mark-all, and undo. "Mark paid" only updates
+ * Auraxis status — no real money moves.
+ *
+ * @returns The modal, or null while hidden.
+ */
+export function PaymentAssistantHost(): ReactElement | null {
+  const { t } = useT();
+  const controller = usePaymentAssistantController();
+
+  const canUndo =
+    controller.lastAction?.kind === "paid" || controller.lastAction?.kind === "deleted";
+  const payLabel =
+    controller.current?.type === "income"
+      ? t("paymentsAssistant.actions.payIncome")
+      : t("paymentsAssistant.actions.payExpense");
+
+  const confirmDelete = useCallback((): void => {
+    Alert.alert(
+      t("paymentsAssistant.confirmDeleteTitle"),
+      t("paymentsAssistant.confirmDelete"),
+      [
+        { text: t("paymentsAssistant.actions.cancel"), style: "cancel" },
+        {
+          text: t("paymentsAssistant.actions.delete"),
+          style: "destructive",
+          onPress: (): void => {
+            void controller.discard();
+          },
+        },
+      ],
+    );
+  }, [controller, t]);
+
+  if (!controller.isVisible) {
+    return null;
+  }
+
+  return (
+    <Modal visible transparent animationType="slide" onRequestClose={controller.close}>
+      <Pressable
+        style={{ flex: 1 }}
+        accessibilityRole="button"
+        accessibilityLabel={t("paymentsAssistant.actions.close")}
+        onPress={controller.close}
+      >
+        <YStack flex={1} backgroundColor={BACKDROP} justifyContent="flex-end">
+          <Pressable>
+            <YStack
+              testID="payment-assistant-host"
+              backgroundColor="$background"
+              padding="$4"
+              paddingBottom="$6"
+              gap="$3"
+              borderTopLeftRadius={SHEET_RADIUS}
+              borderTopRightRadius={SHEET_RADIUS}
+            >
+              <AppText size="bodyLg" tone="default">
+                {t("paymentsAssistant.title")}
+              </AppText>
+
+              {!controller.isDone && controller.current ? (
+                <PaymentAssistantActiveSection
+                  controller={controller}
+                  payLabel={payLabel}
+                  onDelete={confirmDelete}
+                />
+              ) : (
+                <PaymentAssistantDoneState />
+              )}
+
+              <PaymentAssistantFooter
+                canUndo={canUndo}
+                showMarkAll={!controller.isDone && controller.progress.total > 1}
+                onUndo={(): void => {
+                  void controller.undo();
+                }}
+                onMarkAll={(): void => {
+                  void controller.markAllPaid();
+                }}
+                onClose={controller.close}
+              />
+            </YStack>
+          </Pressable>
+        </YStack>
+      </Pressable>
+    </Modal>
+  );
+}

--- a/features/payments-assistant/services/payment-assistant-deck.test.ts
+++ b/features/payments-assistant/services/payment-assistant-deck.test.ts
@@ -1,0 +1,60 @@
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import {
+  advanceDeck,
+  createDeck,
+  currentCard,
+  deckProgress,
+  isDeckDone,
+  undoDeck,
+} from "@/features/payments-assistant/services/payment-assistant-deck";
+
+const card = (id: string): TransactionRecord =>
+  ({ id, title: id, dueDate: "2026-01-01", status: "pending" }) as TransactionRecord;
+
+const cards = [card("a"), card("b"), card("c")];
+
+describe("payment-assistant deck reducer", () => {
+  it("starts at the first card", () => {
+    const deck = createDeck(cards);
+    expect(currentCard(deck)?.id).toBe("a");
+    expect(deckProgress(deck)).toEqual({ current: 1, total: 3 });
+    expect(isDeckDone(deck)).toBe(false);
+  });
+
+  it("advances through cards recording the action", () => {
+    const deck = advanceDeck(createDeck(cards), "paid");
+    expect(currentCard(deck)?.id).toBe("b");
+    expect(deckProgress(deck)).toEqual({ current: 2, total: 3 });
+  });
+
+  it("is done after the last card is processed", () => {
+    let deck = createDeck(cards);
+    deck = advanceDeck(deck, "paid");
+    deck = advanceDeck(deck, "deleted");
+    deck = advanceDeck(deck, "skipped");
+    expect(isDeckDone(deck)).toBe(true);
+    expect(currentCard(deck)).toBeNull();
+    expect(deckProgress(deck)).toEqual({ current: 3, total: 3 });
+  });
+
+  it("undo steps back and returns the reverted action and card", () => {
+    const advanced = advanceDeck(createDeck(cards), "paid");
+    const { deck, undone } = undoDeck(advanced);
+    expect(currentCard(deck)?.id).toBe("a");
+    expect(undone).toEqual({ kind: "paid", card: cards[0] });
+  });
+
+  it("undo is a no-op at the start", () => {
+    const deck = createDeck(cards);
+    const result = undoDeck(deck);
+    expect(result.deck).toEqual(deck);
+    expect(result.undone).toBeNull();
+  });
+
+  it("treats an empty deck as immediately done", () => {
+    const deck = createDeck([]);
+    expect(isDeckDone(deck)).toBe(true);
+    expect(currentCard(deck)).toBeNull();
+    expect(deckProgress(deck)).toEqual({ current: 0, total: 0 });
+  });
+});

--- a/features/payments-assistant/services/payment-assistant-deck.ts
+++ b/features/payments-assistant/services/payment-assistant-deck.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure reducer for the Payments Assistant card deck.
+ *
+ * Immutable ordered list with a cursor. Paying, deleting or skipping advances
+ * the cursor and records the action; undo steps back and reports the action to
+ * revert. Keeps navigation/undo isolated from React and API mutations.
+ */
+
+import type { TransactionRecord } from "@/features/transactions/contracts";
+
+/** The kind of action taken on a card. */
+export type DeckActionKind = "paid" | "deleted" | "skipped";
+
+/** A recorded action against a specific card. */
+export interface DeckAction {
+  readonly kind: DeckActionKind;
+  readonly card: TransactionRecord;
+}
+
+/** Immutable deck state: the cards, the cursor, and the action history. */
+export interface DeckState {
+  readonly cards: readonly TransactionRecord[];
+  readonly index: number;
+  readonly history: readonly DeckAction[];
+}
+
+/** Progress through the deck, 1-based for display. */
+export interface DeckProgress {
+  readonly current: number;
+  readonly total: number;
+}
+
+/**
+ * Creates a fresh deck positioned at the first card.
+ *
+ * @param cards Ordered cards to review.
+ * @returns Initial deck state.
+ */
+export const createDeck = (cards: readonly TransactionRecord[]): DeckState => ({
+  cards,
+  index: 0,
+  history: [],
+});
+
+/**
+ * Returns the card under the cursor, or null when the deck is done.
+ *
+ * @param state Deck state.
+ * @returns Current card or null.
+ */
+export const currentCard = (state: DeckState): TransactionRecord | null =>
+  state.cards[state.index] ?? null;
+
+/**
+ * Whether every card has been processed.
+ *
+ * @param state Deck state.
+ * @returns True when the cursor is past the last card.
+ */
+export const isDeckDone = (state: DeckState): boolean => state.index >= state.cards.length;
+
+/**
+ * Computes 1-based progress, clamped to the deck size.
+ *
+ * @param state Deck state.
+ * @returns Progress `{ current, total }`.
+ */
+export const deckProgress = (state: DeckState): DeckProgress => ({
+  current: Math.min(state.index + (state.cards.length > 0 ? 1 : 0), state.cards.length),
+  total: state.cards.length,
+});
+
+/**
+ * Advances the cursor, recording the action taken on the current card.
+ *
+ * @param state Deck state.
+ * @param kind Action taken on the current card.
+ * @returns Next deck state (same state when already done).
+ */
+export const advanceDeck = (state: DeckState, kind: DeckActionKind): DeckState => {
+  const card = currentCard(state);
+  if (!card) {
+    return state;
+  }
+  return {
+    cards: state.cards,
+    index: state.index + 1,
+    history: [...state.history, { kind, card }],
+  };
+};
+
+/** Result of an undo: the new state and the action that was reverted (if any). */
+export interface UndoResult {
+  readonly deck: DeckState;
+  readonly undone: DeckAction | null;
+}
+
+/**
+ * Steps the cursor back one card, returning the action to revert.
+ *
+ * @param state Deck state.
+ * @returns The previous state and the reverted action, or the same state + null.
+ */
+export const undoDeck = (state: DeckState): UndoResult => {
+  if (state.index <= 0 || state.history.length === 0) {
+    return { deck: state, undone: null };
+  }
+  const undone = state.history[state.history.length - 1] ?? null;
+  return {
+    deck: {
+      cards: state.cards,
+      index: state.index - 1,
+      history: state.history.slice(0, -1),
+    },
+    undone,
+  };
+};

--- a/features/payments-assistant/services/payment-assistant-eligibility.test.ts
+++ b/features/payments-assistant/services/payment-assistant-eligibility.test.ts
@@ -1,0 +1,95 @@
+import type { TransactionRecord } from "@/features/transactions/contracts";
+import {
+  OVERDUE_THRESHOLD_DAYS,
+  isOverdueByAtLeastDays,
+  selectOverdueCandidates,
+} from "@/features/payments-assistant/services/payment-assistant-eligibility";
+
+const makeTransaction = (overrides: Partial<TransactionRecord> = {}): TransactionRecord => ({
+  id: "tx-1",
+  title: "Aluguel",
+  amount: "1200.00",
+  type: "expense",
+  dueDate: "2026-05-01",
+  startDate: null,
+  endDate: null,
+  description: null,
+  observation: null,
+  isRecurring: false,
+  isInstallment: false,
+  installmentCount: null,
+  recurrenceInterval: 1,
+  recurrenceUnit: "month",
+  tagId: null,
+  accountId: null,
+  creditCardId: null,
+  status: "pending",
+  currency: "BRL",
+  source: "manual",
+  externalId: null,
+  bankName: null,
+  installmentGroupId: null,
+  paidAt: null,
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: null,
+  ...overrides,
+});
+
+const TODAY = new Date(2026, 5, 29); // 2026-06-29 (local)
+
+describe("isOverdueByAtLeastDays", () => {
+  it("is true for a due date older than the threshold", () => {
+    expect(isOverdueByAtLeastDays("2026-04-01", 30, TODAY)).toBe(true);
+  });
+
+  it("is true exactly on the cutoff boundary (today - days)", () => {
+    expect(isOverdueByAtLeastDays("2026-05-30", 30, TODAY)).toBe(true);
+  });
+
+  it("is false one day inside the threshold window", () => {
+    expect(isOverdueByAtLeastDays("2026-05-31", 30, TODAY)).toBe(false);
+  });
+
+  it("is false for a future due date", () => {
+    expect(isOverdueByAtLeastDays("2026-07-15", 30, TODAY)).toBe(false);
+  });
+});
+
+describe("selectOverdueCandidates", () => {
+  it("keeps only pending/postponed transactions overdue beyond the threshold", () => {
+    const transactions = [
+      makeTransaction({ id: "pending-old", status: "pending", dueDate: "2026-04-10" }),
+      makeTransaction({ id: "postponed-old", status: "postponed", dueDate: "2026-03-20" }),
+      makeTransaction({ id: "paid-old", status: "paid", dueDate: "2026-04-10" }),
+      makeTransaction({ id: "cancelled-old", status: "cancelled", dueDate: "2026-04-10" }),
+      makeTransaction({ id: "pending-recent", status: "pending", dueDate: "2026-06-20" }),
+    ];
+
+    const result = selectOverdueCandidates(transactions, TODAY);
+
+    expect(result.map((t) => t.id)).toEqual(["postponed-old", "pending-old"]);
+  });
+
+  it("sorts by due date ascending (oldest first)", () => {
+    const transactions = [
+      makeTransaction({ id: "b", status: "pending", dueDate: "2026-04-15" }),
+      makeTransaction({ id: "a", status: "pending", dueDate: "2026-02-01" }),
+      makeTransaction({ id: "c", status: "pending", dueDate: "2026-05-01" }),
+    ];
+
+    expect(selectOverdueCandidates(transactions, TODAY).map((t) => t.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns an empty array when nothing qualifies", () => {
+    const transactions = [
+      makeTransaction({ status: "paid", dueDate: "2026-01-01" }),
+      makeTransaction({ status: "pending", dueDate: "2026-06-28" }),
+    ];
+
+    expect(selectOverdueCandidates(transactions, TODAY)).toEqual([]);
+  });
+
+  it("exposes a 30-day default threshold", () => {
+    expect(OVERDUE_THRESHOLD_DAYS).toBe(30);
+  });
+});

--- a/features/payments-assistant/services/payment-assistant-eligibility.ts
+++ b/features/payments-assistant/services/payment-assistant-eligibility.ts
@@ -1,0 +1,70 @@
+/**
+ * Pure eligibility rules for the Payments Assistant.
+ *
+ * Surfaces transactions that are still "open" (pending/postponed) and overdue by
+ * at least {@link OVERDUE_THRESHOLD_DAYS} days so the user can clear the backlog.
+ * Pure (no React, no fetch) — trivially unit-testable.
+ */
+
+import type { TransactionRecord, TransactionStatus } from "@/features/transactions/contracts";
+
+/** A transaction must be overdue by at least this many days to qualify. */
+export const OVERDUE_THRESHOLD_DAYS = 30;
+
+/** Statuses considered "open" (still actionable) by the assistant. */
+const ELIGIBLE_STATUSES: ReadonlySet<TransactionStatus> = new Set<TransactionStatus>([
+  "pending",
+  "postponed",
+]);
+
+/**
+ * Formats a Date as a local `YYYY-MM-DD` calendar date.
+ *
+ * @param date Date to format.
+ * @returns ISO calendar-date string.
+ */
+const toIsoDate = (date: Date): string => {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+};
+
+/**
+ * Whether a `dueDate` is overdue by at least `days` days relative to `today`.
+ *
+ * Calendar-date comparison only (lexicographic on `YYYY-MM-DD`). A due date
+ * exactly on the cutoff (`today - days`) counts as overdue.
+ *
+ * @param dueDate Due date as `YYYY-MM-DD`.
+ * @param days Minimum number of days overdue.
+ * @param today Reference "now" date.
+ * @returns True when `dueDate <= today - days`.
+ */
+export const isOverdueByAtLeastDays = (dueDate: string, days: number, today: Date): boolean => {
+  const cutoff = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+  cutoff.setDate(cutoff.getDate() - days);
+  return dueDate <= toIsoDate(cutoff);
+};
+
+/**
+ * Selects the transactions the assistant should present, oldest due date first.
+ *
+ * @param transactions Full set of candidate transactions.
+ * @param today Reference "now" date.
+ * @param thresholdDays Overdue threshold (defaults to {@link OVERDUE_THRESHOLD_DAYS}).
+ * @returns Filtered, sorted list of overdue open transactions.
+ */
+export const selectOverdueCandidates = (
+  transactions: readonly TransactionRecord[],
+  today: Date,
+  thresholdDays: number = OVERDUE_THRESHOLD_DAYS,
+): TransactionRecord[] =>
+  transactions
+    .filter(
+      (transaction) =>
+        ELIGIBLE_STATUSES.has(transaction.status) &&
+        isOverdueByAtLeastDays(transaction.dueDate, thresholdDays, today),
+    )
+    .slice()
+    .sort((a, b) => a.dueDate.localeCompare(b.dueDate));

--- a/features/payments-assistant/services/payment-assistant-session.test.ts
+++ b/features/payments-assistant/services/payment-assistant-session.test.ts
@@ -1,0 +1,50 @@
+import {
+  markShownThisSession,
+  resetPaymentAssistantSessionForTests,
+  shouldAutoOpenAssistant,
+  wasShownThisSession,
+} from "@/features/payments-assistant/services/payment-assistant-session";
+
+describe("payment-assistant session flag", () => {
+  beforeEach(() => {
+    resetPaymentAssistantSessionForTests();
+  });
+
+  it("reports not shown before being marked", () => {
+    expect(wasShownThisSession()).toBe(false);
+  });
+
+  it("persists the shown flag for the session", () => {
+    markShownThisSession();
+    expect(wasShownThisSession()).toBe(true);
+  });
+});
+
+describe("shouldAutoOpenAssistant", () => {
+  const base = {
+    startupReady: true,
+    isPremium: true,
+    shownThisSession: false,
+    candidateCount: 3,
+  };
+
+  it("opens when all conditions are met", () => {
+    expect(shouldAutoOpenAssistant(base)).toBe(true);
+  });
+
+  it("stays closed before startup is ready", () => {
+    expect(shouldAutoOpenAssistant({ ...base, startupReady: false })).toBe(false);
+  });
+
+  it("stays closed for non-Premium users", () => {
+    expect(shouldAutoOpenAssistant({ ...base, isPremium: false })).toBe(false);
+  });
+
+  it("stays closed when already shown this session", () => {
+    expect(shouldAutoOpenAssistant({ ...base, shownThisSession: true })).toBe(false);
+  });
+
+  it("stays closed when there are no candidates", () => {
+    expect(shouldAutoOpenAssistant({ ...base, candidateCount: 0 })).toBe(false);
+  });
+});

--- a/features/payments-assistant/services/payment-assistant-session.ts
+++ b/features/payments-assistant/services/payment-assistant-session.ts
@@ -1,0 +1,50 @@
+/**
+ * Session-scoped gating + auto-open decision for the Payments Assistant.
+ *
+ * The assistant appears at most once per app session (module-level flag, reset
+ * on cold start) and only after startup has resolved. The decision is pure and
+ * the flag is test-resettable.
+ */
+
+let shownThisSession = false;
+
+/**
+ * Whether the assistant has already been shown in this app session.
+ *
+ * @returns True once {@link markShownThisSession} has been called.
+ */
+export const wasShownThisSession = (): boolean => shownThisSession;
+
+/** Marks the assistant as shown for the remainder of this session. */
+export const markShownThisSession = (): void => {
+  shownThisSession = true;
+};
+
+/** Resets the session flag. Test-only. */
+export const resetPaymentAssistantSessionForTests = (): void => {
+  shownThisSession = false;
+};
+
+/** Inputs that decide whether the assistant should auto-open on entry. */
+export interface AutoOpenParams {
+  /** Whether app startup (fonts, session, theme) has resolved. */
+  readonly startupReady: boolean;
+  /** Whether the current user is entitled to Premium surfaces. */
+  readonly isPremium: boolean;
+  /** Whether the assistant was already shown in this session. */
+  readonly shownThisSession: boolean;
+  /** Number of overdue open transactions available to review. */
+  readonly candidateCount: number;
+}
+
+/**
+ * Decides whether the assistant should auto-open for the current entry.
+ *
+ * @param params Gating inputs.
+ * @returns True only when every condition is satisfied.
+ */
+export const shouldAutoOpenAssistant = (params: AutoOpenParams): boolean =>
+  params.startupReady &&
+  params.isPremium &&
+  !params.shownThisSession &&
+  params.candidateCount > 0;

--- a/features/payments-assistant/services/payment-assistant-swipe.test.ts
+++ b/features/payments-assistant/services/payment-assistant-swipe.test.ts
@@ -1,0 +1,21 @@
+import { resolveSwipeOutcome } from "@/features/payments-assistant/services/payment-assistant-swipe";
+
+describe("resolveSwipeOutcome", () => {
+  const THRESHOLD = 120;
+
+  it("returns 'pay' when swiped right past the threshold", () => {
+    expect(resolveSwipeOutcome(150, THRESHOLD)).toBe("pay");
+    expect(resolveSwipeOutcome(THRESHOLD, THRESHOLD)).toBe("pay");
+  });
+
+  it("returns 'delete' when swiped left past the threshold", () => {
+    expect(resolveSwipeOutcome(-150, THRESHOLD)).toBe("delete");
+    expect(resolveSwipeOutcome(-THRESHOLD, THRESHOLD)).toBe("delete");
+  });
+
+  it("returns 'none' for travel short of the threshold (snap back)", () => {
+    expect(resolveSwipeOutcome(40, THRESHOLD)).toBe("none");
+    expect(resolveSwipeOutcome(-40, THRESHOLD)).toBe("none");
+    expect(resolveSwipeOutcome(0, THRESHOLD)).toBe("none");
+  });
+});

--- a/features/payments-assistant/services/payment-assistant-swipe.ts
+++ b/features/payments-assistant/services/payment-assistant-swipe.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure swipe-gesture resolution for the Payments Assistant deck.
+ *
+ * Keeping the threshold decision pure makes the Tinder-style gesture testable
+ * without rendering Reanimated/Gesture Handler.
+ */
+
+/** Outcome of a horizontal swipe over a card. */
+export type SwipeOutcome = "pay" | "delete" | "none";
+
+/**
+ * Resolves a horizontal swipe into an action.
+ *
+ * Swiping right past the threshold marks paid/received; swiping left past it
+ * deletes; anything short snaps back (none). A generous threshold avoids
+ * accidental destructive swipes.
+ *
+ * @param translationX Horizontal travel in px (positive = right).
+ * @param threshold Minimum absolute travel to commit (px, must be > 0).
+ * @returns "pay", "delete", or "none".
+ */
+export const resolveSwipeOutcome = (translationX: number, threshold: number): SwipeOutcome => {
+  if (translationX >= threshold) {
+    return "pay";
+  }
+  if (translationX <= -threshold) {
+    return "delete";
+  }
+  return "none";
+};

--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -256,5 +256,33 @@
         "empty": "Wallet is empty."
       }
     }
+  },
+  "paymentsAssistant": {
+    "title": "Open items",
+    "progress": "{{current}} of {{total}}",
+    "statusHint": "Marking here only updates the status in Auraxis — no real money moves.",
+    "emptyTitle": "All caught up",
+    "emptyBody": "You have no open bills overdue by more than a month.",
+    "type": {
+      "income": "Income",
+      "expense": "Expense"
+    },
+    "fields": {
+      "createdAt": "Created on",
+      "dueDate": "Due date",
+      "observation": "Notes"
+    },
+    "confirmDeleteTitle": "Delete transaction",
+    "confirmDelete": "Are you sure? You can undo right after.",
+    "actions": {
+      "payExpense": "Mark as paid",
+      "payIncome": "Mark as received",
+      "delete": "Delete",
+      "skip": "Skip",
+      "markAllPaid": "Mark all as paid",
+      "undo": "Undo",
+      "close": "Close",
+      "cancel": "Cancel"
+    }
   }
 }

--- a/shared/i18n/locales/pt.json
+++ b/shared/i18n/locales/pt.json
@@ -256,5 +256,33 @@
         "empty": "Sua carteira esta vazia."
       }
     }
+  },
+  "paymentsAssistant": {
+    "title": "Pendências em aberto",
+    "progress": "{{current}} de {{total}}",
+    "statusHint": "Marcar aqui só atualiza o status no Auraxis — não move dinheiro de verdade.",
+    "emptyTitle": "Tudo em dia",
+    "emptyBody": "Você não tem contas em aberto vencidas há mais de um mês.",
+    "type": {
+      "income": "Receita",
+      "expense": "Despesa"
+    },
+    "fields": {
+      "createdAt": "Criada em",
+      "dueDate": "Vencimento",
+      "observation": "Observações"
+    },
+    "confirmDeleteTitle": "Excluir transação",
+    "confirmDelete": "Tem certeza? Você pode desfazer logo em seguida.",
+    "actions": {
+      "payExpense": "Marcar como pago",
+      "payIncome": "Marcar como recebido",
+      "delete": "Excluir",
+      "skip": "Pular",
+      "markAllPaid": "Marcar todas como pagas",
+      "undo": "Desfazer",
+      "close": "Fechar",
+      "cancel": "Cancelar"
+    }
   }
 }


### PR DESCRIPTION
## O que muda

Adiciona o **Assistente de Pagamentos** no app (mobile): um modal que aparece 1×/sessão para
usuários Premium e apresenta as transações **em aberto vencidas há mais de 30 dias**
(`pending`/`postponed`) num **deck de swipe estilo Tinder** — swipe à direita (ou botão) marca
como pago/recebido, swipe à esquerda (ou botão) exclui com confirmação, além de pular, marcar
todas e **desfazer**.

Semântica: "marcar como pago/recebido" apenas atualiza o status no Auraxis — **não move dinheiro
real**.

Arquitetura (paridade com o web):
- Serviços puros (testados): `eligibility` (filtro vencidas+abertas), `deck` (reducer de
  navegação/undo), `swipe` (resolução do gesto por threshold), `session` (auto-abertura 1×/sessão).
- `usePaymentAssistantController` + `useAssistantActions` (estado + mutations + undo).
- Deck com `react-native-gesture-handler` + `react-native-reanimated` (**sem dependência nova**),
  com threshold generoso e snap-back; componentes `card`/`deck`/`actions-bar`/`footer`/`sections`.
- `PaymentAssistantHost` montado no `app/(private)/_layout.tsx` (ao lado do `ExpenseSheetHost`),
  RN `Modal` + Tamagui; confirmação de exclusão via `Alert` nativo.
- Reuso total das mutations existentes (`useMarkTransactionPaidMutation`,
  `useDeleteTransactionMutation`, `useUpdateTransactionMutation` p/ undo de pago→pendente,
  `useRestoreTransactionMutation` p/ undo de exclusão). **Sem mudança de contrato.**
- Gate Premium via `useFeatureAccess("advanced_simulations")`.

## Contexto

Closes #630
Task no GitHub Projects: [APP] Assistente de Pagamentos.

Companheiro do web ([auraxis-web#1094](https://github.com/italofelipe/auraxis-web/pull/1094)) —
mesma feature, paridade de plataforma. Parte da sequência de design (2026-06-29).

## Como testar

- [ ] Como usuário Premium com transações `pending`/`postponed` vencidas há +30d: ao abrir a área
      logada, o modal aparece 1×/sessão.
- [ ] Swipe direita / botão "Marcar como pago" → `PATCH {status:"paid", paidAt}`; card avança.
- [ ] Swipe esquerda / botão "Excluir" → confirma no `Alert` → soft-delete; "Desfazer" restaura.
- [ ] "Marcar todas como pagas" quita o restante; estado vazio "Tudo em dia".
- [ ] Sem pendências, sem Premium, ou antes do startup → o modal não aparece.

## Quality gates

- [x] lint (expo lint): PASS
- [x] typecheck: PASS
- [x] policy/governance + contracts + codegen: PASS
- [x] testes: PASS (2707, sendo 32 novos da feature)
- [x] cobertura nos thresholds: PASS (`npm run quality-check` completo verde)

## Impacto de contrato

Nenhum — reusa endpoints e mutations existentes.

## Risco

LOW — feature aditiva, gate Premium, sem mudança de schema/contrato; ações reversíveis
(undo + soft-delete) e confirmação na exclusão; threshold de swipe evita disparo acidental.
