### PR TITLE
feat(transactions): toggle auto-settle no form de transação (F4)

### DIFF
--- a/features/transactions/components/transaction-form.tsx
+++ b/features/transactions/components/transaction-form.tsx
@@ -59,6 +59,7 @@ const transactionToFormValues = (
       recurrenceInterval: 1,
       recurrenceUnit: "month",
       creditCardId: null,
+      autoSettle: false,
       isInstallment: false,
       installmentCount: null,
     };
@@ -75,6 +76,7 @@ const transactionToFormValues = (
     recurrenceInterval: transaction.recurrenceInterval,
     recurrenceUnit: transaction.recurrenceUnit,
     creditCardId: transaction.creditCardId,
+    autoSettle: transaction.autoSettle ?? false,
     isInstallment: transaction.isInstallment,
     installmentCount: transaction.installmentCount,
   };
@@ -131,6 +133,7 @@ export function TransactionForm({
           errors={form.formState.errors}
           setValue={form.setValue}
         />
+        <AutoSettleField control={form.control} />
         {installmentsEnabled ? (
           <TransactionInstallmentFields
             control={form.control}
@@ -191,6 +194,28 @@ function TypeToggle({
             Receita
           </AppButton>
         </XStack>
+      )}
+    />
+  );
+}
+
+function AutoSettleField({
+  control,
+}: {
+  readonly control: Control<CreateTransactionFormValues>;
+}): ReactElement {
+  return (
+    <Controller
+      control={control}
+      name="autoSettle"
+      render={({ field: { value, onChange } }) => (
+        <AppToggleRow
+          label="Marcar como pago/recebido automaticamente"
+          description="No vencimento, o Auraxis marca esta transacao como paga/recebida automaticamente. Voce pode desfazer quando quiser."
+          checked={Boolean(value)}
+          testID="transaction-auto-settle-toggle"
+          onCheckedChange={onChange}
+        />
       )}
     />
   );

--- a/features/transactions/contracts.ts
+++ b/features/transactions/contracts.ts
@@ -40,6 +40,8 @@ export interface TransactionRecord {
   readonly externalId: string | null;
   readonly bankName: string | null;
   readonly installmentGroupId: string | null;
+  /** Opt-in: auto-mark as paid/received when it comes due. */
+  readonly autoSettle?: boolean;
   readonly paidAt: string | null;
   readonly createdAt: string | null;
   readonly updatedAt: string | null;
@@ -101,6 +103,8 @@ export interface UpsertTransactionCommand {
   readonly tagId?: string | null;
   readonly accountId?: string | null;
   readonly creditCardId?: string | null;
+  /** Opt-in: auto-mark as paid/received when it comes due. Defaults to false. */
+  readonly autoSettle?: boolean;
   readonly status?: TransactionStatus;
   readonly currency?: string;
   readonly source?: string;

--- a/features/transactions/hooks/use-transactions-screen-controller.test.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.test.ts
@@ -77,6 +77,7 @@ const formValues = (
   recurrenceInterval: 1,
   recurrenceUnit: "month",
   creditCardId: null,
+  autoSettle: false,
   isInstallment: false,
   installmentCount: null,
   ...overrides,

--- a/features/transactions/hooks/use-transactions-screen-controller.ts
+++ b/features/transactions/hooks/use-transactions-screen-controller.ts
@@ -158,6 +158,7 @@ const buildSubmitPayload = (values: CreateTransactionFormValues) => ({
   dueDate: values.dueDate,
   description: values.description,
   isRecurring: values.isRecurring ?? false,
+  autoSettle: values.autoSettle ?? false,
   creditCardId: values.type === "expense" ? values.creditCardId : null,
   isInstallment:
     values.type === "expense" && values.creditCardId ? values.isInstallment : false,

--- a/features/transactions/services/transactions-service.ts
+++ b/features/transactions/services/transactions-service.ts
@@ -42,6 +42,7 @@ interface TransactionPayload {
   readonly external_id: string | null;
   readonly bank_name: string | null;
   readonly installment_group_id: string | null;
+  readonly auto_settle?: boolean;
   readonly paid_at: string | null;
   readonly created_at: string | null;
   readonly updated_at: string | null;
@@ -84,6 +85,7 @@ const mapTransaction = (payload: TransactionPayload): TransactionRecord => {
     externalId: payload.external_id,
     bankName: payload.bank_name,
     installmentGroupId: payload.installment_group_id,
+    autoSettle: payload.auto_settle ?? false,
     paidAt: payload.paid_at,
     createdAt: payload.created_at,
     updatedAt: payload.updated_at,
@@ -147,6 +149,7 @@ const buildTransactionPayload = (
     tag_id: command.tagId,
     account_id: command.accountId,
     credit_card_id: command.creditCardId,
+    auto_settle: command.autoSettle,
     status: command.status,
     currency: command.currency,
     source: command.source,

--- a/features/transactions/validators.ts
+++ b/features/transactions/validators.ts
@@ -111,6 +111,7 @@ export const createTransactionFieldsSchema = z.object({
     .default(1),
   recurrenceUnit: recurrenceUnitSchema.default("month"),
   creditCardId: creditCardIdSchema.default(null),
+  autoSettle: z.boolean().default(false),
   isInstallment: z.boolean().default(false),
   installmentCount: installmentCountSchema.default(null),
 });
@@ -132,6 +133,7 @@ export const updateTransactionSchema = z
     recurrenceInterval: z.number().int().min(1).max(365).optional(),
     recurrenceUnit: recurrenceUnitSchema.optional(),
     creditCardId: creditCardIdSchema.optional(),
+    autoSettle: z.boolean().optional(),
     isInstallment: z.boolean().optional(),
     installmentCount: installmentCountSchema.optional(),
     status: z

--- a/shared/types/generated/graphql.ts
+++ b/shared/types/generated/graphql.ts
@@ -1094,6 +1094,7 @@ export type MutationCreateTagArgs = {
 export type MutationCreateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount: Scalars['String']['input'];
+  autoSettle?: InputMaybe<Scalars['Boolean']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
@@ -1316,6 +1317,7 @@ export type MutationUpdateTagArgs = {
 export type MutationUpdateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount?: InputMaybe<Scalars['String']['input']>;
+  autoSettle?: InputMaybe<Scalars['Boolean']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
@@ -1970,6 +1972,7 @@ export type TransactionTypeObject = {
   __typename?: 'TransactionTypeObject';
   accountId?: Maybe<Scalars['String']['output']>;
   amount: Scalars['String']['output'];
+  autoSettle?: Maybe<Scalars['Boolean']['output']>;
   bankName?: Maybe<Scalars['String']['output']>;
   category?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
## O que muda

Adiciona o toggle **"Marcar como pago/recebido automaticamente"** (`autoSettle`, opt-in, default
OFF) no form de criar/editar transação (mobile). Liga o piloto automático da F4: no vencimento, o
backend marca a transação como paga/recebida. Reversível.

- `autoSettle` em `TransactionRecord` + `UpsertTransactionCommand` (contracts) e no Zod schema.
- Mapeado nos dois sentidos no `transactions-service` (camelCase ↔ `auto_settle`).
- Incluído no `buildSubmitPayload`; seedado ao editar; toggle `AppToggleRow` no form.
- Tipos GraphQL regenerados (codegen).

## Contexto

Closes #632
Frontend mobile da F4 (backend: auraxis-api #1519). Companheiro do web (auraxis-web #1096).

> **Dependência de CI:** `codegen:check` puxa o schema de `auraxis-api/master`
> (`GRAPHQL_SCHEMA_PATH`). O `autoSettle` no `graphql.ts` regenerado só existe após
> **auraxis-api #1519** entrar em master; até lá o `codegen:check` fica vermelho aqui. Local verde.

## Quality gates (local)

- [x] lint/typecheck/governance/contracts: PASS
- [x] testes: 2707 (transações 213); `npm run quality-check` local verde

## Risco

LOW — campo aditivo opt-in (default OFF); sem mudança de fluxo existente.