### PR TITLE
feat(app): redesenhar menu inferior liquido

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,6 +29,16 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - The visual layer is now a dedicated premium auth shell using the brand gradient, glass fields, white primary CTA and light status bar requested by the mobile handoff.
 - Login copy is read from `shared/i18n/locales/*.json`; the screen should not introduce new hardcoded product strings.
 
+## Private Navigation
+
+- The logged-in mobile shell uses Expo Router `Tabs` with a custom `AppTabBar` instead of native tabs.
+- The bottom navigation follows the mobile liquid menu handoff with five visible tabs: `Início`, `Transações`, `Insights`, `Cartões` and `Mais`.
+- `Planejamento` is no longer a first-level tab; it is exposed through `MoreHubScreen` together with other secondary destinations.
+- The former center `+` action is removed from the tab bar. Quick transaction creation remains available from the `Mais` hub through the shared expense sheet store.
+- Tab content transitions use `core/navigation/tab-carousel-transition.ts`, which provides a fixed 480 ms full-width horizontal scene interpolation while keeping tab screens mounted.
+- The active tab affordance lives in `core/navigation/app-tab-bar.tsx` as a Reanimated liquid blob with fixed spring parameters, a gradient surface and the active icon rendered in white.
+- The credit-cards guided tour no longer targets a `fab` anchor; its quick-transaction step is centered copy that points users to `Mais`.
+
 ## Validation
 
 - New or changed behavior must include tests in the same feature area.

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -29,6 +29,17 @@ No network call or database mutation is required until the user explicitly saves
 5. Successful login still consumes any stored auth redirect and navigates to the intended private route or dashboard.
 6. Session-expired and submit-error states render on the same screen without changing session policy.
 
+## Liquid Tab Navigation Flow
+
+1. `app/(private)/_layout.tsx` builds the logged-in tab navigator from `privateTabDefinitions`.
+2. `privateTabDefinitions` exposes `dashboard`, `transacoes`, `insights`, `cartoes` and `mais`; `planejamento` is registered as a hidden route.
+3. `AppTabBar` measures each rendered tab with `onLayout` and stores `{ x, width }` by route name.
+4. When the active route changes, the Reanimated shared values move the liquid blob to the measured tab center with fixed spring parameters and squish timing.
+5. The active icon is rendered inside the blob while the active tab column reserves icon space and keeps the label visible.
+6. The tab navigator uses `createTabCarouselSceneStyleInterpolator(width)` plus `tabCarouselTransitionSpec` so route content slides horizontally with a fixed 480 ms timing curve.
+7. `MoreHubScreen` handles displaced actions: route cards call `router.push(href)`, while `Nova transação` opens the shared expense sheet store directly.
+8. The credit-cards tour quick-transaction step is centered instructional copy, so it does not depend on a removed `fab` anchor.
+
 ## Testing Flow
 
 - Pure calculator behavior is verified before screen tests.

--- a/__tests__/app/private-layout.test.tsx
+++ b/__tests__/app/private-layout.test.tsx
@@ -13,16 +13,20 @@ const mockTabsScreens: {
   options?: Record<string, unknown>;
 }[] = [];
 let mockTabsScreenOptions: Record<string, unknown> | undefined;
+let mockTabsProps: Record<string, unknown> | undefined;
 
 jest.mock("expo-router", () => {
   function MockTabs({
     children,
     screenOptions,
+    ...props
   }: {
     readonly children: ReactNode;
     readonly screenOptions?: Record<string, unknown>;
+    readonly detachInactiveScreens?: boolean;
   }): ReactNode {
     mockTabsScreenOptions = screenOptions;
+    mockTabsProps = props;
     return children;
   }
 
@@ -92,6 +96,7 @@ describe("PrivateLayout", () => {
   beforeEach(() => {
     mockTabsScreens.length = 0;
     mockTabsScreenOptions = undefined;
+    mockTabsProps = undefined;
     mockedUsePrivateRouteGuard.mockReturnValue({ ready: true, redirectTo: null });
     mockedUseWeeklyInsight.mockReturnValue(buildInsightState(false));
     mockedIsFeatureEnabled.mockReturnValue(true);
@@ -142,5 +147,41 @@ describe("PrivateLayout", () => {
         borderTopColor: "#D8E3EF",
       },
     });
+  });
+
+  it("expõe as cinco tabs do handoff e move planejamento para rota oculta", () => {
+    renderPrivateLayout();
+
+    const visibleTabs = mockTabsScreens
+      .filter((screen) => screen.options?.href !== null)
+      .map((screen) => screen.name);
+    const hiddenTabs = mockTabsScreens
+      .filter((screen) => screen.options?.href === null)
+      .map((screen) => screen.name);
+
+    expect(visibleTabs).toEqual([
+      "dashboard",
+      "transacoes",
+      "insights",
+      "cartoes",
+      "mais",
+    ]);
+    expect(hiddenTabs).toContain("planejamento");
+    expect(hiddenTabs).not.toContain("insights");
+    expect(hiddenTabs).not.toContain("cartoes");
+  });
+
+  it("configura transição horizontal de tabs com timing fixo", () => {
+    renderPrivateLayout();
+
+    expect(mockTabsScreenOptions?.transitionSpec).toMatchObject({
+      animation: "timing",
+      config: { duration: 480 },
+    });
+    expect(mockTabsScreenOptions?.sceneStyleInterpolator).toEqual(expect.any(Function));
+    expect(mockTabsScreenOptions).toMatchObject({
+      lazy: false,
+    });
+    expect(mockTabsProps).toMatchObject({ detachInactiveScreens: false });
   });
 });

--- a/__tests__/e2e/dashboard.test.tsx
+++ b/__tests__/e2e/dashboard.test.tsx
@@ -55,6 +55,7 @@ jest.mock("@/core/session/session-store", () => ({
 }));
 
 const mockedDashboardService = jest.mocked(dashboardService);
+const waitForQuery = { timeout: 5000 } as const;
 
 // ---------------------------------------------------------------------------
 // Dashboard E2E: loading state, data, error state
@@ -87,7 +88,7 @@ describe("Dashboard E2E flow", () => {
     // After service resolves, data should be available
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
 
     expect(result.current.data?.totals.balance).toBe(
       dashboardOverviewFixture.totals.balance,
@@ -107,13 +108,14 @@ describe("Dashboard E2E flow", () => {
     } = require("@/features/dashboard/hooks/use-dashboard-screen-controller");
 
     const wrapper = createTestHookWrapper({ queryClient });
-    const { result } = renderHook(() => useDashboardScreenController(), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => useDashboardScreenController({ weeklyInsightEnabled: false }),
+      { wrapper },
+    );
 
     await waitFor(() => {
       expect(result.current.overviewQuery.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
 
     expect(typeof result.current.currentBalance).toBe("number");
     expect(result.current.currentBalance).toBe(
@@ -141,7 +143,7 @@ describe("Dashboard E2E flow", () => {
       () => {
         expect(result.current.isError).toBe(true);
       },
-      { timeout: 5000 },
+      waitForQuery,
     );
 
     expect(result.current.data).toBeUndefined();
@@ -160,7 +162,7 @@ describe("Dashboard E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
 
     expect(result.current.data?.series).toBeDefined();
     expect(result.current.data?.series.length).toBe(
@@ -175,14 +177,15 @@ describe("Dashboard E2E flow", () => {
     } = require("@/features/dashboard/hooks/use-dashboard-screen-controller");
 
     const wrapper = createTestHookWrapper({ queryClient });
-    const { result } = renderHook(() => useDashboardScreenController(), {
-      wrapper,
-    });
+    const { result } = renderHook(
+      () => useDashboardScreenController({ weeklyInsightEnabled: false }),
+      { wrapper },
+    );
 
     // monthOptions derives from trendsQuery.data — wait for it to load
     await waitFor(() => {
       expect(result.current.trendsQuery.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
 
     expect(result.current.monthOptions.length).toBeGreaterThan(0);
     expect(typeof result.current.selectedMonth).toBe("string");
@@ -203,7 +206,7 @@ describe("Dashboard E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
 
     expect(result.current.data?.topCategories.expense).toHaveLength(
       dashboardOverviewFixture.topCategories.expense.length,

--- a/__tests__/e2e/transactions.test.tsx
+++ b/__tests__/e2e/transactions.test.tsx
@@ -59,6 +59,7 @@ jest.mock("expo-router", () => ({
 }));
 
 const mockedTransactionsService = jest.mocked(transactionsService);
+const waitForQuery = { timeout: 5000 } as const;
 
 // ---------------------------------------------------------------------------
 // Transactions E2E: list, create, update, delete
@@ -93,7 +94,7 @@ describe("Transactions E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
 
     expect(result.current.data?.transactions).toHaveLength(
       transactionCollectionFixture.transactions.length,
@@ -126,7 +127,7 @@ describe("Transactions E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
     expect(mockedTransactionsService.createTransaction).toHaveBeenCalledWith(
       expect.objectContaining({
         title: "Nova transacao de teste",
@@ -156,7 +157,7 @@ describe("Transactions E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
     expect(mockedTransactionsService.updateTransaction).toHaveBeenCalledWith(
       transactionFixture.id,
       { title: "Salario atualizado" },
@@ -180,7 +181,7 @@ describe("Transactions E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.isSuccess).toBe(true);
-    });
+    }, waitForQuery);
     expect(mockedTransactionsService.deleteTransaction).toHaveBeenCalledWith(
       transactionFixture.id,
       "occurrence",
@@ -204,7 +205,7 @@ describe("Transactions E2E flow", () => {
       () => {
         expect(result.current.isError).toBe(true);
       },
-      { timeout: 5000 },
+      waitForQuery,
     );
   });
 
@@ -222,7 +223,7 @@ describe("Transactions E2E flow", () => {
 
     await waitFor(() => {
       expect(result.current.transactions.length).toBeGreaterThan(0);
-    });
+    }, waitForQuery);
 
     const firstTx = result.current.transactions[0];
     expect(firstTx).toHaveProperty("id");

--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -1,11 +1,16 @@
-import type { ReactElement } from "react";
+import { useMemo, type ReactElement } from "react";
 
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import { Redirect, Tabs } from "expo-router";
+import { useWindowDimensions } from "react-native";
 
 import { AppErrorBoundary } from "@/core/errors/app-error-boundary";
 import { AppTabBar } from "@/core/navigation/app-tab-bar";
 import { privateTabDefinitions } from "@/core/navigation/routes";
+import {
+  createTabCarouselSceneStyleInterpolator,
+  tabCarouselTransitionSpec,
+} from "@/core/navigation/tab-carousel-transition";
 import { usePrivateRouteGuard } from "@/core/navigation/use-route-guards";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
 import { ExpenseSheetHost } from "@/features/credit-cards/components/expense-sheet/expense-sheet-host";
@@ -32,9 +37,8 @@ const HIDDEN_TAB_NAMES: readonly string[] = [
   "carteira-operacoes",
   "tags",
   "contas",
-  "cartoes",
+  "planejamento",
   "orcamentos",
-  "insights",
   "foco",
   "onboarding",
   "simulador-meta",
@@ -47,8 +51,13 @@ const HIDDEN_TAB_NAMES: readonly string[] = [
 function PrivateLayoutContent(): ReactElement | null {
   const { ready, redirectTo } = usePrivateRouteGuard();
   const resolvedTheme = useResolvedTheme();
+  const { width } = useWindowDimensions();
   const tabTheme =
     resolvedTheme === "auraxis_dark" ? darkSemanticColors : lightSemanticColors;
+  const sceneStyleInterpolator = useMemo(
+    () => createTabCarouselSceneStyleInterpolator(width),
+    [width],
+  );
   const weeklyInsightEnabled = isFeatureEnabled(WEEKLY_INSIGHT_FEATURE_FLAG_KEY);
   const weeklyInsight = useWeeklyInsight({
     enabled: weeklyInsightEnabled && ready && !redirectTo,
@@ -66,9 +75,13 @@ function PrivateLayoutContent(): ReactElement | null {
   return (
     <TourAnchorProvider>
       <Tabs
+        detachInactiveScreens={false}
         tabBar={(props) => <AppTabBar {...props} />}
         screenOptions={{
           headerShown: false,
+          lazy: false,
+          transitionSpec: tabCarouselTransitionSpec,
+          sceneStyleInterpolator,
           tabBarActiveTintColor: tabTheme.primary,
           tabBarInactiveTintColor: tabTheme.subduedForeground,
           tabBarStyle: {

--- a/core/navigation/app-tab-bar.test.tsx
+++ b/core/navigation/app-tab-bar.test.tsx
@@ -3,10 +3,7 @@ import { fireEvent, render } from "@testing-library/react-native";
 import { AppTabBar } from "@/core/navigation/app-tab-bar";
 import { AppProviders } from "@/core/providers/app-providers";
 import { resetAppShellStore } from "@/core/shell/app-shell-store";
-import {
-  resetExpenseSheetStore,
-  useExpenseSheetStore,
-} from "@/stores/expense-sheet-store";
+import { resetExpenseSheetStore } from "@/stores/expense-sheet-store";
 
 jest.mock("react-native-safe-area-context", () => ({
   useSafeAreaInsets: () => ({ top: 0, bottom: 20, left: 0, right: 0 }),
@@ -16,7 +13,8 @@ const buildProps = (activeIndex = 0) => {
   const routes = [
     { key: "dashboard-key", name: "dashboard" },
     { key: "transacoes-key", name: "transacoes" },
-    { key: "planejamento-key", name: "planejamento" },
+    { key: "insights-key", name: "insights" },
+    { key: "cartoes-key", name: "cartoes" },
     { key: "mais-key", name: "mais" },
   ];
   const navigate = jest.fn();
@@ -37,9 +35,9 @@ describe("AppTabBar", () => {
     resetExpenseSheetStore();
   });
 
-  it("renderiza os quatro destinos e o botao central de acao rapida", () => {
+  it("renderiza os cinco destinos do handoff sem botao central", () => {
     const { props } = buildProps();
-    const { getByTestId } = render(
+    const { getByTestId, queryByTestId } = render(
       <AppProviders>
         <AppTabBar {...props} />
       </AppProviders>,
@@ -47,9 +45,10 @@ describe("AppTabBar", () => {
 
     expect(getByTestId("tab-dashboard")).toBeTruthy();
     expect(getByTestId("tab-transacoes")).toBeTruthy();
-    expect(getByTestId("tab-planejamento")).toBeTruthy();
+    expect(getByTestId("tab-insights")).toBeTruthy();
+    expect(getByTestId("tab-cartoes")).toBeTruthy();
     expect(getByTestId("tab-mais")).toBeTruthy();
-    expect(getByTestId("tour-fab")).toBeTruthy();
+    expect(queryByTestId("tour-fab")).toBeNull();
   });
 
   it("navega ao tocar numa tab nao focada e ignora a tab ja ativa", () => {
@@ -60,41 +59,14 @@ describe("AppTabBar", () => {
       </AppProviders>,
     );
 
-    fireEvent.press(getByTestId("tab-transacoes"));
-    expect(navigate).toHaveBeenCalledWith("transacoes");
+    fireEvent.press(getByTestId("tab-cartoes"));
+    expect(navigate).toHaveBeenCalledWith("cartoes");
 
     fireEvent.press(getByTestId("tab-dashboard"));
     expect(navigate).toHaveBeenCalledTimes(1);
   });
 
-  it("abre o sheet de despesa ao tocar no FAB central", () => {
-    const { props } = buildProps();
-    const { getByTestId } = render(
-      <AppProviders>
-        <AppTabBar {...props} />
-      </AppProviders>,
-    );
-
-    expect(useExpenseSheetStore.getState().isOpen).toBe(false);
-    fireEvent.press(getByTestId("tour-fab"));
-    expect(useExpenseSheetStore.getState().isOpen).toBe(true);
-  });
-
-  it("ao pressionar e segurar o FAB abre as acoes rapidas e navega para criar transacao", () => {
-    const { props, navigate } = buildProps();
-    const { getByTestId } = render(
-      <AppProviders>
-        <AppTabBar {...props} />
-      </AppProviders>,
-    );
-
-    fireEvent(getByTestId("tour-fab"), "longPress");
-    fireEvent.press(getByTestId("quick-action-create"));
-
-    expect(navigate).toHaveBeenCalledWith("transacoes", { intent: "create" });
-  });
-
-  it("renderiza o indicador animado da aba ativa", () => {
+  it("renderiza o blob liquido com o icone da aba ativa", () => {
     const { props } = buildProps(0);
     const { getByTestId } = render(
       <AppProviders>
@@ -102,7 +74,10 @@ describe("AppTabBar", () => {
       </AppProviders>,
     );
 
-    expect(getByTestId("tab-active-indicator")).toBeTruthy();
+    expect(getByTestId("tab-liquid-blob")).toBeTruthy();
+    expect(getByTestId("tab-liquid-blob-icon").props.accessibilityLabel).toBe(
+      "Ícone ativo view-dashboard-outline",
+    );
   });
 
   it("renderiza com reduced motion ativo sem quebrar a navegacao", () => {
@@ -114,7 +89,7 @@ describe("AppTabBar", () => {
       </AppProviders>,
     );
 
-    expect(getByTestId("tab-active-indicator")).toBeTruthy();
+    expect(getByTestId("tab-liquid-blob")).toBeTruthy();
     fireEvent.press(getByTestId("tab-dashboard"));
     expect(navigate).toHaveBeenCalledWith("dashboard");
   });

--- a/core/navigation/app-tab-bar.tsx
+++ b/core/navigation/app-tab-bar.tsx
@@ -1,9 +1,8 @@
-import { useCallback, useEffect, useState, type ReactElement } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactElement } from "react";
 
 import { MaterialCommunityIcons } from "@expo/vector-icons";
 import type { BottomTabBarProps } from "@react-navigation/bottom-tabs";
 import {
-  Modal,
   Pressable,
   type LayoutChangeEvent,
   type StyleProp,
@@ -18,54 +17,46 @@ import Animated, {
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { Paragraph, XStack, YStack } from "tamagui";
 
-import { appRoutes, privateTabDefinitions } from "@/core/navigation/routes";
+import { privateTabDefinitions } from "@/core/navigation/routes";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
-import {
-  useTourAnchor,
-  type MeasurableHandle,
-} from "@/shared/coach-marks/tour-anchor-context";
-import { AppButton } from "@/shared/components/app-button";
+import { AppGradient } from "@/shared/components/app-gradient";
 import { triggerHapticImpact } from "@/shared/feedback/haptics";
-import { useExpenseSheetStore } from "@/stores/expense-sheet-store";
 import {
   darkSemanticColors,
-  darkSemanticGlows,
   lightSemanticColors,
-  lightSemanticGlows,
-  semanticShadows,
 } from "@/shared/theme";
-import { motionDurations } from "@/shared/theme/motion";
 
-const TAB_BAR_RADIUS = 24;
-const CENTER_BUTTON_SIZE = 56;
-const INDICATOR_WIDTH = 28;
-const INDICATOR_HEIGHT = 3;
-// Spring suave (sem overshoot exagerado): o sublinhado desliza entre abas
-// com um "settle" premium, não um bounce de brinquedo.
-const INDICATOR_SPRING = { damping: 20, stiffness: 210, mass: 0.6 } as const;
+const TAB_BAR_RADIUS = 32;
+const TAB_BAR_HEIGHT = 64;
+const LIQUID_BLOB_SIZE = 48;
+const LIQUID_BLOB_TOP = -10;
+const LIQUID_BLOB_SPRING = { damping: 13, stiffness: 150, mass: 1 } as const;
+const LIQUID_SQUISH_DURATION_MS = 260;
+const LIQUID_ICON_FADE_DURATION_MS = 160;
 
 /** Posição/largura de uma aba, medidas via onLayout, relativas à tab bar. */
 type TabLayout = { readonly x: number; readonly width: number };
 type TabLayoutMap = Record<string, TabLayout>;
 
-interface ActiveTabIndicator {
+interface LiquidTabIndicator {
   readonly indicatorStyle: StyleProp<ViewStyle>;
   readonly handleTabLayout: (name: string, layout: TabLayout) => void;
 }
 
 /**
- * Anima o sublinhado da aba ativa: mede cada aba via onLayout e desliza o
- * indicador (translateX) para a aba focada com spring. Respeita
- * `reducedMotionEnabled` (posiciona sem animar).
+ * Mede cada aba via onLayout e move a gota líquida para o centro da aba focada.
+ * A física fica em valores fixos para manter paridade iOS/Android.
  */
-function useActiveTabIndicator(
+function useLiquidTabIndicator(
   activeRouteName: string | undefined,
   reducedMotion: boolean,
-): ActiveTabIndicator {
+): LiquidTabIndicator {
   const [tabLayouts, setTabLayouts] = useState<TabLayoutMap>({});
-  const indicatorX = useSharedValue(0);
-  const indicatorOpacity = useSharedValue(0);
+  const blobX = useSharedValue(0);
+  const blobOpacity = useSharedValue(0);
+  const blobScaleX = useSharedValue(1);
+  const blobScaleY = useSharedValue(1);
 
   const handleTabLayout = useCallback((name: string, layout: TabLayout): void => {
     setTabLayouts((previous) => {
@@ -82,132 +73,54 @@ function useActiveTabIndicator(
     if (!layout) {
       return;
     }
-    const target = layout.x + (layout.width - INDICATOR_WIDTH) / 2;
+    const target = layout.x + (layout.width - LIQUID_BLOB_SIZE) / 2;
     if (reducedMotion) {
-      indicatorX.value = target;
-      indicatorOpacity.value = 1;
+      blobX.value = target;
+      blobOpacity.value = 1;
+      blobScaleX.value = 1;
+      blobScaleY.value = 1;
       return;
     }
-    indicatorX.value = withSpring(target, INDICATOR_SPRING);
-    indicatorOpacity.value = withTiming(1, { duration: motionDurations.normal });
-  }, [activeRouteName, tabLayouts, reducedMotion, indicatorX, indicatorOpacity]);
+    blobX.value = withSpring(target, LIQUID_BLOB_SPRING);
+    blobOpacity.value = withTiming(1, { duration: LIQUID_ICON_FADE_DURATION_MS });
+    blobScaleX.value = withTiming(
+      1.32,
+      { duration: LIQUID_SQUISH_DURATION_MS / 2 },
+      () => {
+        blobScaleX.value = withTiming(1, {
+          duration: LIQUID_SQUISH_DURATION_MS / 2,
+        });
+      },
+    );
+    blobScaleY.value = withTiming(
+      0.9,
+      { duration: LIQUID_SQUISH_DURATION_MS / 2 },
+      () => {
+        blobScaleY.value = withTiming(1, {
+          duration: LIQUID_SQUISH_DURATION_MS / 2,
+        });
+      },
+    );
+  }, [
+    activeRouteName,
+    tabLayouts,
+    reducedMotion,
+    blobX,
+    blobOpacity,
+    blobScaleX,
+    blobScaleY,
+  ]);
 
   const indicatorStyle = useAnimatedStyle(() => ({
-    opacity: indicatorOpacity.value,
-    transform: [{ translateX: indicatorX.value }],
+    opacity: blobOpacity.value,
+    transform: [
+      { translateX: blobX.value },
+      { scaleX: blobScaleX.value },
+      { scaleY: blobScaleY.value },
+    ],
   }));
 
   return { indicatorStyle: indicatorStyle as StyleProp<ViewStyle>, handleTabLayout };
-}
-
-interface QuickCreateActions {
-  readonly visible: boolean;
-  readonly open: () => void;
-  readonly close: () => void;
-  readonly navigateToCreate: () => void;
-}
-
-/** Estado + handlers do sheet de ação rápida do botão central [+]. */
-function useQuickCreateActions(
-  navigation: BottomTabBarProps["navigation"],
-): QuickCreateActions {
-  const [visible, setVisible] = useState(false);
-
-  const open = useCallback((): void => {
-    triggerHapticImpact("medium");
-    setVisible(true);
-  }, []);
-
-  const close = useCallback((): void => {
-    setVisible(false);
-  }, []);
-
-  const navigateToCreate = useCallback((): void => {
-    setVisible(false);
-    navigation.navigate("transacoes", { intent: "create" });
-  }, [navigation]);
-
-  return { visible, open, close, navigateToCreate };
-}
-
-interface QuickActionsSheetProps {
-  readonly visible: boolean;
-  readonly onClose: () => void;
-  readonly onNavigateToCreate: () => void;
-}
-
-/**
- * Sheet de ação rápida do botão central [+]: atalhos para registrar
- * receita/despesa — paridade com os CTAs "Nova Receita"/"Nova Despesa"
- * do dashboard web.
- */
-function QuickActionsSheet({
-  visible,
-  onClose,
-  onNavigateToCreate,
-}: QuickActionsSheetProps): ReactElement {
-  return (
-    <Modal visible={visible} transparent animationType="slide" onRequestClose={onClose}>
-      <Pressable
-        style={{ flex: 1 }}
-        accessibilityLabel="Fechar ações rápidas"
-        onPress={onClose}
-      >
-        <YStack flex={1} backgroundColor="rgba(10,22,40,0.45)" justifyContent="flex-end">
-          <Pressable>
-            <YStack
-              backgroundColor="$surfaceCard"
-              padding="$5"
-              paddingBottom="$7"
-              gap="$3"
-              borderTopLeftRadius={TAB_BAR_RADIUS}
-              borderTopRightRadius={TAB_BAR_RADIUS}
-            >
-              <Paragraph fontFamily="$body" fontWeight="$6" fontSize="$5" color="$color">
-                Registrar movimento
-              </Paragraph>
-              <AppButton testID="quick-action-create" onPress={onNavigateToCreate}>
-                Nova transação
-              </AppButton>
-              <AppButton tone="secondary" onPress={onClose}>
-                Cancelar
-              </AppButton>
-            </YStack>
-          </Pressable>
-        </YStack>
-      </Pressable>
-    </Modal>
-  );
-}
-
-interface TabActiveIndicatorProps {
-  readonly color: string;
-  readonly animatedStyle: StyleProp<ViewStyle>;
-}
-
-/** O sublinhado animado que desliza sob a aba ativa. */
-function TabActiveIndicator({
-  color,
-  animatedStyle,
-}: TabActiveIndicatorProps): ReactElement {
-  return (
-    <Animated.View
-      testID="tab-active-indicator"
-      pointerEvents="none"
-      style={[
-        {
-          position: "absolute",
-          top: 0,
-          left: 0,
-          width: INDICATOR_WIDTH,
-          height: INDICATOR_HEIGHT,
-          borderRadius: INDICATOR_HEIGHT,
-          backgroundColor: color,
-        },
-        animatedStyle,
-      ]}
-    />
-  );
 }
 
 interface TabItemProps {
@@ -217,6 +130,64 @@ interface TabItemProps {
   readonly inactiveColor: string;
   readonly onPress: () => void;
   readonly onMeasure: (name: string, layout: TabLayout) => void;
+}
+
+interface LiquidTabBlobProps {
+  readonly iconName: (typeof privateTabDefinitions)[number]["icon"];
+  readonly iconColor: string;
+  readonly animatedStyle: StyleProp<ViewStyle>;
+}
+
+function LiquidTabBlob({
+  iconName,
+  iconColor,
+  animatedStyle,
+}: LiquidTabBlobProps): ReactElement {
+  return (
+    <Animated.View
+      testID="tab-liquid-blob"
+      pointerEvents="none"
+      style={[
+        {
+          position: "absolute",
+          top: LIQUID_BLOB_TOP,
+          left: 0,
+          width: LIQUID_BLOB_SIZE,
+          height: LIQUID_BLOB_SIZE,
+          zIndex: 2,
+          shadowColor: "#0B7E8A",
+          shadowOffset: { width: 0, height: 10 },
+          shadowOpacity: 0.42,
+          shadowRadius: 20,
+          elevation: 10,
+        },
+        animatedStyle,
+      ]}
+    >
+      <AppGradient
+        testID="tab-liquid-blob-gradient"
+        colors={["#16A8C4", "#0B7E8A"]}
+        start={{ x: 0.25, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={{
+          flex: 1,
+          alignItems: "center",
+          justifyContent: "center",
+          borderTopLeftRadius: 25,
+          borderTopRightRadius: 23,
+          borderBottomRightRadius: 26,
+          borderBottomLeftRadius: 22,
+        }}
+      >
+        <YStack
+          testID="tab-liquid-blob-icon"
+          accessibilityLabel={`Ícone ativo ${iconName}`}
+        >
+          <MaterialCommunityIcons name={iconName} size={24} color={iconColor} />
+        </YStack>
+      </AppGradient>
+    </Animated.View>
+  );
 }
 
 function TabItem({
@@ -239,21 +210,35 @@ function TabItem({
         const { x, width } = event.nativeEvent.layout;
         onMeasure(tab.name, { x, width });
       }}
-      // Press-scale aplicado direto no Pressable (transform é pós-layout, não
-      // afeta o flex:1) — evita o wrapper Animated.View que quebra a divisão
-      // de linha de itens flex lado a lado.
       style={({ pressed }) => [
-        { flex: 1, alignItems: "center", gap: 2, paddingVertical: 6 },
-        pressed ? { opacity: 0.7, transform: [{ scale: 0.92 }] } : null,
+        {
+          flex: 1,
+          minHeight: 54,
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 2,
+          paddingTop: 8,
+          paddingBottom: 6,
+        },
+        pressed ? { opacity: 0.72, transform: [{ scale: 0.94 }] } : null,
       ]}
     >
-      <MaterialCommunityIcons name={tab.icon} size={24} color={tint} />
+      {isFocused ? (
+        <YStack width={24} height={24} />
+      ) : (
+        <MaterialCommunityIcons
+          testID={`tab-${tab.name}-icon`}
+          name={tab.icon}
+          size={22}
+          color={tint}
+        />
+      )}
       <Paragraph
         numberOfLines={1}
         fontFamily="$body"
-        fontSize="$1"
+        fontSize={10}
         color={tint}
-        fontWeight={isFocused ? "$6" : "$4"}
+        fontWeight="$6"
       >
         {tab.title}
       </Paragraph>
@@ -261,88 +246,32 @@ function TabItem({
   );
 }
 
-interface CenterActionButtonProps {
-  readonly backgroundColor: string;
-  readonly iconColor: string;
-  readonly glow: ViewStyle;
-  readonly onPress: () => void;
-  readonly onLongPress: () => void;
-  /** Ref de âncora do tour (registra o FAB como alvo do spotlight). */
-  readonly anchorRef: (node: MeasurableHandle | null) => void;
-  /** onLayout de âncora do tour (gatilho de registro barato). */
-  readonly anchorOnLayout: (event: LayoutChangeEvent) => void;
-}
-
-function CenterActionButton({
-  backgroundColor,
-  iconColor,
-  glow,
-  onPress,
-  onLongPress,
-  anchorRef,
-  anchorOnLayout,
-}: CenterActionButtonProps): ReactElement {
-  return (
-    <YStack width={CENTER_BUTTON_SIZE + 16} alignItems="center">
-      <Pressable
-        ref={anchorRef}
-        accessibilityRole="button"
-        accessibilityLabel="Lançar despesa"
-        accessibilityHint="Toque para lançar uma despesa. Pressione e segure para mais ações."
-        testID="tour-fab"
-        onPress={onPress}
-        onLongPress={onLongPress}
-        onLayout={anchorOnLayout}
-        style={({ pressed }) => ({
-          width: CENTER_BUTTON_SIZE,
-          height: CENTER_BUTTON_SIZE,
-          borderRadius: CENTER_BUTTON_SIZE / 2,
-          marginTop: -(CENTER_BUTTON_SIZE / 2),
-          alignItems: "center",
-          justifyContent: "center",
-          backgroundColor,
-          // Glow de marca (shadowColor colorido) resolvido por tema — 100%
-          // OTA-able, sem gradiente/blur nativo.
-          ...glow,
-          transform: pressed ? [{ scale: 0.94 }] : undefined,
-        })}
-      >
-        <MaterialCommunityIcons name="plus" size={30} color={iconColor} />
-      </Pressable>
-    </YStack>
-  );
-}
-
 /**
- * Tab bar customizada do redesign (F2 — épico #540, refinamento premium #570):
- * superfície com cantos superiores arredondados, quatro destinos e botão
- * central [+] elevado. A aba ativa ganha um indicador (sublinhado) que desliza
- * entre as abas com spring, respeitando `reducedMotionEnabled`.
+ * Tab bar customizada do handoff "menu liquido": cinco destinos, pill flutuante
+ * e gota animada que carrega o icone branco da aba ativa.
  */
 export function AppTabBar({ state, navigation }: BottomTabBarProps): ReactElement {
   const insets = useSafeAreaInsets();
   const isDark = useResolvedTheme() === "auraxis_dark";
   const palette = isDark ? darkSemanticColors : lightSemanticColors;
-  const glows = isDark ? darkSemanticGlows : lightSemanticGlows;
   const reducedMotion = useAppShellStore((store) => store.reducedMotionEnabled);
 
   const activeRouteName = state.routes[state.index]?.name;
-  const { indicatorStyle, handleTabLayout } = useActiveTabIndicator(
+  const activeTab = useMemo(
+    () =>
+      privateTabDefinitions.find((tab) => tab.name === activeRouteName) ??
+      privateTabDefinitions[0],
+    [activeRouteName],
+  );
+  const { indicatorStyle, handleTabLayout } = useLiquidTabIndicator(
     activeRouteName,
     reducedMotion,
   );
-  const quickActions = useQuickCreateActions(navigation);
-  const openExpenseSheet = useExpenseSheetStore((store) => store.open);
-  const fabAnchor = useTourAnchor("fab");
-
-  const handleFabPress = useCallback((): void => {
-    triggerHapticImpact("medium");
-    openExpenseSheet();
-  }, [openExpenseSheet]);
 
   const navigateToTab = useCallback(
     (routeName: string): void => {
       if (state.routes[state.index]?.name !== routeName) {
+        triggerHapticImpact("light");
         navigation.navigate(routeName);
       }
     },
@@ -362,43 +291,37 @@ export function AppTabBar({ state, navigation }: BottomTabBarProps): ReactElemen
   );
 
   return (
-    <>
+    <YStack
+      paddingHorizontal={14}
+      paddingBottom={Math.max(insets.bottom, 10)}
+      pointerEvents="box-none"
+    >
       <XStack
         testID="app-tab-bar"
         backgroundColor="$surfaceCard"
-        borderTopLeftRadius={TAB_BAR_RADIUS}
-        borderTopRightRadius={TAB_BAR_RADIUS}
-        borderTopWidth={1}
-        borderTopColor="$borderColor"
-        paddingTop="$2"
-        paddingHorizontal="$3"
-        paddingBottom={Math.max(insets.bottom, 10)}
+        borderRadius={TAB_BAR_RADIUS}
+        borderWidth={1}
+        borderColor="$borderColor"
+        height={TAB_BAR_HEIGHT}
+        paddingHorizontal="$2"
         alignItems="center"
-        {...semanticShadows.lg}
+        position="relative"
+        overflow="visible"
+        style={{
+          shadowColor: isDark ? "#000000" : "#0D2840",
+          shadowOffset: { width: 0, height: 14 },
+          shadowOpacity: isDark ? 0.3 : 0.16,
+          shadowRadius: 34,
+          elevation: 10,
+        }}
       >
-        <TabActiveIndicator color={palette.primary} animatedStyle={indicatorStyle} />
-        {privateTabDefinitions.slice(0, 2).map(renderTab)}
-        <CenterActionButton
-          backgroundColor={palette.primary}
+        <LiquidTabBlob
+          iconName={activeTab.icon}
           iconColor={palette.primaryForeground}
-          glow={glows.brand}
-          onPress={handleFabPress}
-          onLongPress={quickActions.open}
-          anchorRef={fabAnchor.ref}
-          anchorOnLayout={fabAnchor.onLayout}
+          animatedStyle={indicatorStyle}
         />
-        {privateTabDefinitions.slice(2).map(renderTab)}
+        {privateTabDefinitions.map(renderTab)}
       </XStack>
-      <QuickActionsSheet
-        visible={quickActions.visible}
-        onClose={quickActions.close}
-        onNavigateToCreate={quickActions.navigateToCreate}
-      />
-    </>
+    </YStack>
   );
 }
-
-export const quickCreateTransactionHref = {
-  pathname: appRoutes.private.transactions,
-  params: { intent: "create" },
-} as const;

--- a/core/navigation/more-hub-screen.test.tsx
+++ b/core/navigation/more-hub-screen.test.tsx
@@ -2,6 +2,10 @@ import { fireEvent, render } from "@testing-library/react-native";
 
 import { MoreHubScreen } from "@/core/navigation/more-hub-screen";
 import { AppProviders } from "@/core/providers/app-providers";
+import {
+  resetExpenseSheetStore,
+  useExpenseSheetStore,
+} from "@/stores/expense-sheet-store";
 
 const mockPush = jest.fn();
 
@@ -13,6 +17,11 @@ jest.mock("expo-router", () => ({
 describe("MoreHubScreen", () => {
   beforeEach(() => {
     mockPush.mockClear();
+    resetExpenseSheetStore();
+  });
+
+  afterEach(() => {
+    resetExpenseSheetStore();
   });
 
   it("renderiza os destinos que sairam da tab bar", () => {
@@ -27,6 +36,17 @@ describe("MoreHubScreen", () => {
     }
   });
 
+  it("inclui planejamento e nova transacao como destinos deslocados do menu", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <MoreHubScreen />
+      </AppProviders>,
+    );
+
+    expect(getByTestId("hub-item-planning")).toBeTruthy();
+    expect(getByTestId("hub-item-quickTransaction")).toBeTruthy();
+  });
+
   it("navega para a rota do item tocado", () => {
     const { getByTestId } = render(
       <AppProviders>
@@ -36,5 +56,18 @@ describe("MoreHubScreen", () => {
 
     fireEvent.press(getByTestId("hub-item-wallet"));
     expect(mockPush).toHaveBeenCalledWith("/carteira");
+  });
+
+  it("abre o sheet rapido ao tocar em nova transacao", () => {
+    const { getByTestId } = render(
+      <AppProviders>
+        <MoreHubScreen />
+      </AppProviders>,
+    );
+
+    expect(useExpenseSheetStore.getState().isOpen).toBe(false);
+    fireEvent.press(getByTestId("hub-item-quickTransaction"));
+    expect(useExpenseSheetStore.getState().isOpen).toBe(true);
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });

--- a/core/navigation/more-hub-screen.tsx
+++ b/core/navigation/more-hub-screen.tsx
@@ -12,27 +12,40 @@ import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
 import { usePressScaleAnimation } from "@/shared/animations/use-press-scale-animation";
 import { AppHeading } from "@/shared/components/app-heading";
 import { AppScreen } from "@/shared/components/app-screen";
+import { triggerHapticImpact } from "@/shared/feedback/haptics";
 import { darkSemanticColors, lightSemanticColors } from "@/shared/theme";
+import { useExpenseSheetStore } from "@/stores/expense-sheet-store";
 
 type HubIconName =
   | "wallet-outline"
+  | "plus-circle-outline"
   | "tools"
   | "bell-outline"
-  | "lightbulb-on-outline"
+  | "target"
   | "account-circle-outline"
-  | "credit-card-outline"
   | "bank-outline"
   | "tag-multiple-outline"
   | "crown-outline"
   | "shield-account-outline";
 
-interface HubItem {
+interface HubBaseItem {
   readonly key: string;
   readonly title: string;
   readonly description: string;
   readonly icon: HubIconName;
-  readonly href: Href;
 }
+
+interface HubRouteItem extends HubBaseItem {
+  readonly href: Href;
+  readonly action?: never;
+}
+
+interface HubActionItem extends HubBaseItem {
+  readonly href?: never;
+  readonly action: "quickTransaction";
+}
+
+type HubItem = HubRouteItem | HubActionItem;
 
 const HUB_ITEMS: readonly HubItem[] = [
   {
@@ -41,6 +54,20 @@ const HUB_ITEMS: readonly HubItem[] = [
     description: "Investimentos e patrimônio",
     icon: "wallet-outline",
     href: appRoutes.private.wallet,
+  },
+  {
+    key: "quickTransaction",
+    title: "Nova transação",
+    description: "Registrar despesa rapidamente",
+    icon: "plus-circle-outline",
+    action: "quickTransaction",
+  },
+  {
+    key: "planning",
+    title: "Planejamento",
+    description: "Metas, orçamento e foco",
+    icon: "target",
+    href: appRoutes.private.planning,
   },
   {
     key: "tools",
@@ -57,25 +84,11 @@ const HUB_ITEMS: readonly HubItem[] = [
     href: appRoutes.private.alerts,
   },
   {
-    key: "insights",
-    title: "Insights",
-    description: "Leituras com IA",
-    icon: "lightbulb-on-outline",
-    href: appRoutes.private.insights,
-  },
-  {
     key: "accounts",
     title: "Contas",
     description: "Contas bancárias",
     icon: "bank-outline",
     href: appRoutes.private.accounts,
-  },
-  {
-    key: "creditCards",
-    title: "Cartões",
-    description: "Faturas e ciclos",
-    icon: "credit-card-outline",
-    href: appRoutes.private.creditCards,
   },
   {
     key: "tags",
@@ -157,6 +170,7 @@ function HubCard({ item, accentColor, onPress }: HubCardProps): ReactElement {
 export function MoreHubScreen(): ReactElement {
   const router = useRouter();
   const resolvedTheme = useResolvedTheme();
+  const openExpenseSheet = useExpenseSheetStore((store) => store.open);
   const palette =
     resolvedTheme === "auraxis_dark" ? darkSemanticColors : lightSemanticColors;
 
@@ -172,7 +186,14 @@ export function MoreHubScreen(): ReactElement {
               key={item.key}
               item={item}
               accentColor={palette.primary}
-              onPress={() => router.push(item.href)}
+              onPress={() => {
+                if (item.action === "quickTransaction") {
+                  triggerHapticImpact("medium");
+                  openExpenseSheet();
+                  return;
+                }
+                router.push(item.href);
+              }}
             />
           ))}
         </XStack>

--- a/core/navigation/routes.test.ts
+++ b/core/navigation/routes.test.ts
@@ -3,6 +3,7 @@ import {
   buildCreditCardBillPath,
   buildGoalScenarioPath,
   buildTickerDetailPath,
+  privateTabDefinitions,
 } from "@/core/navigation/routes";
 
 describe("app routes", () => {
@@ -30,5 +31,15 @@ describe("app routes", () => {
   it("keeps static private routes as direct href strings", () => {
     expect(appRoutes.private.dashboard).toBe("/dashboard");
     expect(appRoutes.private.insights).toBe("/insights");
+  });
+
+  it("exposes the mobile handoff tabs in the expected order", () => {
+    expect(privateTabDefinitions.map((tab) => tab.name)).toEqual([
+      "dashboard",
+      "transacoes",
+      "insights",
+      "cartoes",
+      "mais",
+    ]);
   });
 });

--- a/core/navigation/routes.ts
+++ b/core/navigation/routes.ts
@@ -7,7 +7,10 @@ type MaterialCommunityIconName =
   | "bell-outline"
   | "flag-outline"
   | "swap-horizontal"
+  | "star-four-points-outline"
+  | "credit-card-outline"
   | "target"
+  | "dots-horizontal"
   | "view-grid-outline";
 
 export const appRoutes = {
@@ -145,15 +148,14 @@ export interface AppRouteDefinition {
 }
 
 export interface PrivateTabDefinition {
-  readonly name: "dashboard" | "transacoes" | "planejamento" | "mais";
+  readonly name: "dashboard" | "transacoes" | "insights" | "cartoes" | "mais";
   readonly href: PrivateAppRoute;
   readonly title: string;
   readonly icon: MaterialCommunityIconName;
 }
 
-// Destinos das tabs (redesign F2 — épico #540): Transações ganha lugar de
-// destaque; Carteira/Ferramentas/Alertas/Metas vivem no hub "Mais" e no
-// Planejamento. O slot central [+] é renderizado pela AppTabBar.
+// Destinos das tabs (handoff menu liquido): Insights e Cartoes ganham acesso
+// direto; Planejamento e demais destinos ficam no hub "Mais".
 export const privateTabDefinitions: readonly PrivateTabDefinition[] = [
   {
     name: "dashboard",
@@ -168,16 +170,22 @@ export const privateTabDefinitions: readonly PrivateTabDefinition[] = [
     icon: "swap-horizontal",
   },
   {
-    name: "planejamento",
-    href: appRoutes.private.planning,
-    title: "Planejar",
-    icon: "target",
+    name: "insights",
+    href: appRoutes.private.insights,
+    title: "Insights",
+    icon: "star-four-points-outline",
+  },
+  {
+    name: "cartoes",
+    href: appRoutes.private.creditCards,
+    title: "Cartões",
+    icon: "credit-card-outline",
   },
   {
     name: "mais",
     href: appRoutes.private.moreHub,
     title: "Mais",
-    icon: "view-grid-outline",
+    icon: "dots-horizontal",
   },
 ] as const;
 
@@ -291,7 +299,7 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
     key: "planning",
     path: appRoutes.private.planning,
     access: "private",
-    tabVisible: true,
+    tabVisible: false,
     supportsHostedCheckoutReturn: false,
   },
   {
@@ -361,7 +369,7 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
     key: "creditCards",
     path: appRoutes.private.creditCards,
     access: "private",
-    tabVisible: false,
+    tabVisible: true,
     supportsHostedCheckoutReturn: false,
   },
   {
@@ -375,7 +383,7 @@ export const appRouteRegistry: readonly AppRouteDefinition[] = [
     key: "insights",
     path: appRoutes.private.insights,
     access: "private",
-    tabVisible: false,
+    tabVisible: true,
     supportsHostedCheckoutReturn: false,
   },
   {

--- a/core/navigation/tab-carousel-transition.ts
+++ b/core/navigation/tab-carousel-transition.ts
@@ -1,0 +1,32 @@
+import type { BottomTabNavigationOptions } from "@react-navigation/bottom-tabs";
+import { Easing } from "react-native";
+
+export const TAB_CAROUSEL_TRANSITION_DURATION_MS = 480;
+
+export const tabCarouselTransitionSpec = {
+  animation: "timing",
+  config: {
+    duration: TAB_CAROUSEL_TRANSITION_DURATION_MS,
+    easing: Easing.bezier(0.5, 1, 0.34, 1),
+  },
+} satisfies NonNullable<BottomTabNavigationOptions["transitionSpec"]>;
+
+export const createTabCarouselSceneStyleInterpolator = (
+  screenWidth: number,
+): NonNullable<BottomTabNavigationOptions["sceneStyleInterpolator"]> => {
+  const distance = Math.max(screenWidth, 1);
+
+  return ({ current }) => ({
+    sceneStyle: {
+      transform: [
+        {
+          translateX: current.progress.interpolate({
+            inputRange: [-1, 0, 1],
+            outputRange: [-distance, 0, distance],
+            extrapolate: "clamp",
+          }),
+        },
+      ],
+    },
+  });
+};

--- a/docs/superpowers/plans/2026-06-30-mobile-menu-redesign.md
+++ b/docs/superpowers/plans/2026-06-30-mobile-menu-redesign.md
@@ -1,0 +1,68 @@
+# Mobile Menu Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current four-tab plus center-action menu with the five-tab liquid menu from the mobile handoff.
+
+**Architecture:** Keep Expo Router `Tabs` as the navigation host, promote `Insights` and `Cartoes` to visible tabs, move `Planejamento` into `Mais`, and implement the liquid indicator inside `AppTabBar`. Use React Navigation scene interpolation for horizontal full-width tab transitions so tab state remains mounted.
+
+**Tech Stack:** Expo Router, React Navigation bottom tabs, React Native Reanimated, Expo Linear Gradient, Tamagui, Jest/RNTL.
+
+---
+
+### Task 1: Route Contract
+
+**Files:**
+- Modify: `core/navigation/routes.ts`
+- Test: `core/navigation/routes.test.ts`
+
+- [ ] Write a failing test asserting `privateTabDefinitions` has five tabs in the order `dashboard`, `transacoes`, `insights`, `cartoes`, `mais`.
+- [ ] Run `npm test -- core/navigation/routes.test.ts --runInBand` and verify the new assertion fails on the current four-tab contract.
+- [ ] Update `PrivateTabDefinition`, icon types and `privateTabDefinitions` to match the handoff.
+- [ ] Run the route test again and verify it passes.
+
+### Task 2: Private Layout Transition
+
+**Files:**
+- Create: `core/navigation/tab-carousel-transition.ts`
+- Modify: `app/(private)/_layout.tsx`
+- Test: `__tests__/app/private-layout.test.tsx`
+
+- [ ] Write failing layout tests asserting visible tab screens include `insights` and `cartoes`, hide `planejamento`, and set the custom horizontal transition spec.
+- [ ] Run `npm test -- __tests__/app/private-layout.test.tsx --runInBand` and verify the assertions fail.
+- [ ] Add the tab carousel transition helper and wire it into `Tabs` screen options using current window width.
+- [ ] Update hidden routes so `planejamento` is hidden and `insights`/`cartoes` are visible.
+- [ ] Run the layout test again and verify it passes.
+
+### Task 3: Liquid Tab Bar
+
+**Files:**
+- Modify: `core/navigation/app-tab-bar.tsx`
+- Test: `core/navigation/app-tab-bar.test.tsx`
+
+- [ ] Replace tests for the old center FAB with failing tests for five equal tabs, no `tour-fab`, `tab-liquid-blob`, and active icon in the blob.
+- [ ] Run `npm test -- core/navigation/app-tab-bar.test.tsx --runInBand` and verify the new assertions fail.
+- [ ] Replace the underline/FAB implementation with a pill surface, liquid gradient blob, active-icon overlay, fixed Reanimated spring/timing values and a quick-create action rendered outside the tab row.
+- [ ] Run the tab bar test again and verify it passes.
+
+### Task 4: More Hub Access
+
+**Files:**
+- Modify: `core/navigation/more-hub-screen.tsx`
+- Test: `core/navigation/more-hub-screen.test.tsx`
+
+- [ ] Write failing tests asserting `Mais` includes `Planejamento` and `Nova transacao`.
+- [ ] Run `npm test -- core/navigation/more-hub-screen.test.tsx --runInBand` and verify the assertions fail.
+- [ ] Add both hub cards and wire `Nova transacao` to the shared expense sheet store.
+- [ ] Run the hub test again and verify it passes.
+
+### Task 5: Documentation And Gate
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+- Modify: `DATAFLOW.md`
+
+- [ ] Document the five-tab menu, moved planning entry, quick-create entry and tab transition data flow.
+- [ ] Run focused navigation tests.
+- [ ] Run `npm run quality-check`.
+- [ ] Commit, push and open a draft PR with `Closes #634`.

--- a/features/credit-cards/cards-tour/cards-tour-steps.test.ts
+++ b/features/credit-cards/cards-tour/cards-tour-steps.test.ts
@@ -11,12 +11,14 @@ describe("cardsTourSteps", () => {
     expect(CARDS_TOUR_TOTAL_STEPS).toBe(8);
   });
 
-  it("marca apenas o primeiro e o último como centralizados (sem âncora)", () => {
+  it("marca passos centralizados sem âncora", () => {
     expect(cardsTourSteps[0].center).toBe(true);
     expect(cardsTourSteps[0].anchorKey).toBeNull();
+    expect(cardsTourSteps[5].center).toBe(true);
+    expect(cardsTourSteps[5].anchorKey).toBeNull();
     expect(cardsTourSteps[7].center).toBe(true);
     expect(cardsTourSteps[7].anchorKey).toBeNull();
-    const middle = cardsTourSteps.slice(1, 7);
+    const middle = cardsTourSteps.slice(1, 7).filter((step) => step.id !== "more");
     for (const step of middle) {
       expect(step.center).toBe(false);
       expect(step.anchorKey).not.toBeNull();
@@ -30,18 +32,18 @@ describe("cardsTourSteps", () => {
       "views",
       "months",
       "fatura",
-      "fab",
+      null,
       "theme",
       null,
     ]);
   });
 
-  it("usa o raio de pílula para FAB e tema, e geral para os demais", () => {
+  it("usa o raio de pílula para tema, e geral para os demais", () => {
     const byId = Object.fromEntries(
       cardsTourSteps.map((step) => [step.id, step]),
     );
-    expect(byId.fab.radius).toBe(coachMarks.radiusPill);
     expect(byId.theme.radius).toBe(coachMarks.radiusPill);
+    expect(byId.more.radius).toBe(coachMarks.radiusGeneral);
     expect(byId.cards.radius).toBe(coachMarks.radiusGeneral);
     expect(byId.views.radius).toBe(coachMarks.radiusGeneral);
     expect(byId.months.radius).toBe(coachMarks.radiusGeneral);
@@ -68,7 +70,7 @@ describe("cardsTourSteps", () => {
       "Dois níveis de detalhe",
       "Navegue no tempo",
       "Do resumo ao extrato",
-      "Lançar despesa leva segundos",
+      "Nova transação mora em Mais",
       "Claro ou escuro, você decide",
       "Você já sabe o essencial",
     ]);
@@ -76,7 +78,7 @@ describe("cardsTourSteps", () => {
 
   it("mantém os marcadores de negrito do corpo (parseáveis e com trechos bold)", () => {
     // Passos com negrito conhecido devem render ao menos um segmento bold.
-    const boldSteps = ["cards", "views", "months", "fatura", "fab", "done"];
+    const boldSteps = ["cards", "views", "months", "fatura", "more", "done"];
     for (const step of cardsTourSteps) {
       const segments = parseBoldSegments(step.body);
       const hasBold = segments.some((segment) => segment.bold);
@@ -96,9 +98,8 @@ describe("cardsTourSteps", () => {
     expect(byId.months.body).toContain("**aberta**");
     expect(byId.months.body).toContain("**fechada**");
     expect(byId.fatura.body).toContain("**extrato completo**");
-    expect(byId.fab.body).toContain("**+**");
-    expect(byId.fab.body).toContain("**opcional**");
-    expect(byId.fab.body).toContain("**entrada**");
+    expect(byId.more.body).toContain("**Mais**");
+    expect(byId.more.body).toContain("**Nova transação**");
     expect(byId.done.body).toContain("**?**");
   });
 
@@ -118,7 +119,7 @@ describe("cardsTourSteps", () => {
     expect(before[3]).toEqual({ setView: "faturas", scroll: "top" });
     // 5 → setView faturas + scrollToFatura
     expect(before[4]).toEqual({ setView: "faturas", scroll: "fatura" });
-    // 6 → FAB sempre visível (sem setup)
+    // 6 → explicação centralizada sobre Mais (sem setup)
     expect(before[5]).toEqual({});
     // 7 → scrollTop
     expect(before[6]).toEqual({ scroll: "top" });
@@ -130,7 +131,7 @@ describe("cardsTourSteps", () => {
     const byId = Object.fromEntries(
       cardsTourSteps.map((step) => [step.id, step]),
     );
-    expect(byId.fab.padding).toBe(6);
+    expect(byId.more.padding).toBe(0);
     expect(byId.theme.padding).toBe(6);
     expect(byId.cards.padding).toBe(8);
     expect(byId.fatura.padding).toBe(8);

--- a/features/credit-cards/cards-tour/cards-tour-steps.ts
+++ b/features/credit-cards/cards-tour/cards-tour-steps.ts
@@ -18,7 +18,6 @@ export type CardsTourAnchorKey =
   | "views"
   | "months"
   | "fatura"
-  | "fab"
   | "theme";
 
 /** Alvos de rolagem que o `before()` pode acionar antes de medir. */
@@ -129,14 +128,14 @@ export const cardsTourSteps: readonly CardsTourStepConfig[] = [
     before: { setView: "faturas", scroll: "fatura" },
   },
   {
-    id: "fab",
+    id: "more",
     eyebrow: "PASSO 6 DE 8",
-    title: "Lançar despesa leva segundos",
-    body: "Toque no **+** a qualquer momento. O cartão é **opcional**: registre agora e defina depois. Comprou parcelado? Informe as parcelas — e, se houver **entrada**, o Auraxis distribui o restante nas próximas faturas, automaticamente.",
-    anchorKey: "fab",
-    center: false,
-    padding: ROUND_PADDING,
-    radius: coachMarks.radiusPill,
+    title: "Nova transação mora em Mais",
+    body: "O botão **+** saiu da barra para deixar a navegação líquida respirar. Quando precisar registrar rápido, abra **Mais** e toque em **Nova transação**.",
+    anchorKey: null,
+    center: true,
+    padding: 0,
+    radius: coachMarks.radiusGeneral,
     before: {},
   },
   {

--- a/features/credit-cards/cards-tour/use-cards-tour.test.ts
+++ b/features/credit-cards/cards-tour/use-cards-tour.test.ts
@@ -205,7 +205,7 @@ describe("useCardsTour", () => {
     expect(scrollTo).not.toHaveBeenCalled();
   });
 
-  it("before() do FAB não altera view nem rola (sempre visível)", async () => {
+  it("before() do passo Mais não altera view nem rola", async () => {
     const handlers = makeHandlers();
     const { ref, scrollTo } = makeScrollRef();
     const { result } = renderHook(() =>
@@ -217,9 +217,9 @@ describe("useCardsTour", () => {
       }),
     );
 
-    const fabStep = result.current.steps.find((step) => step.id === "fab");
+    const moreStep = result.current.steps.find((step) => step.id === "more");
     await act(async () => {
-      await fabStep?.before?.();
+      await moreStep?.before?.();
     });
     expect(handlers.setView).not.toHaveBeenCalled();
     expect(handlers.selectCard).not.toHaveBeenCalled();

--- a/shared/types/generated/graphql.ts
+++ b/shared/types/generated/graphql.ts
@@ -191,6 +191,15 @@ export type AlertPreferenceType = {
   globalOptOut: Scalars['Boolean']['output'];
 };
 
+export type AskFinancialQuestionPayload = {
+  __typename?: 'AskFinancialQuestionPayload';
+  answer?: Maybe<Scalars['String']['output']>;
+  costUsd?: Maybe<Scalars['Float']['output']>;
+  model?: Maybe<Scalars['String']['output']>;
+  ok: Scalars['Boolean']['output'];
+  tokensUsed?: Maybe<Scalars['Int']['output']>;
+};
+
 export type AuthPayloadType = {
   __typename?: 'AuthPayloadType';
   message: Scalars['String']['output'];
@@ -841,6 +850,13 @@ export type Mutation = {
   addTicker?: Maybe<AddTickerPayload>;
   /** @deprecated ADR-0002: use POST /wallet */
   addWalletEntry?: Maybe<AddWalletEntryMutation>;
+  /**
+   * GraphQL parity for POST /ai/chat (Ask anything).
+   *
+   * Snapshot-grounded finance chat. Entitlement, LGPD consent, per-user cost
+   * budget and audit are enforced inside AIAdvisoryService.
+   */
+  askFinancialQuestion?: Maybe<AskFinancialQuestionPayload>;
   /** @deprecated ADR-0002: use DELETE /fiscal/receivables/{id} */
   cancelReceivable?: Maybe<ReceivablePayload>;
   /** @deprecated ADR-0004: use POST /subscription/cancel */
@@ -983,6 +999,11 @@ export type MutationAddWalletEntryArgs = {
 };
 
 
+export type MutationAskFinancialQuestionArgs = {
+  question: Scalars['String']['input'];
+};
+
+
 export type MutationCancelReceivableArgs = {
   entryId: Scalars['UUID']['input'];
 };
@@ -1094,6 +1115,7 @@ export type MutationCreateTagArgs = {
 export type MutationCreateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount: Scalars['String']['input'];
+  autoSettle?: InputMaybe<Scalars['Boolean']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
@@ -1316,6 +1338,7 @@ export type MutationUpdateTagArgs = {
 export type MutationUpdateTransactionArgs = {
   accountId?: InputMaybe<Scalars['UUID']['input']>;
   amount?: InputMaybe<Scalars['String']['input']>;
+  autoSettle?: InputMaybe<Scalars['Boolean']['input']>;
   category?: InputMaybe<Scalars['String']['input']>;
   creditCardId?: InputMaybe<Scalars['UUID']['input']>;
   currency?: InputMaybe<Scalars['String']['input']>;
@@ -1970,6 +1993,7 @@ export type TransactionTypeObject = {
   __typename?: 'TransactionTypeObject';
   accountId?: Maybe<Scalars['String']['output']>;
   amount: Scalars['String']['output'];
+  autoSettle?: Maybe<Scalars['Boolean']['output']>;
   bankName?: Maybe<Scalars['String']['output']>;
   category?: Maybe<Scalars['String']['output']>;
   createdAt?: Maybe<Scalars['String']['output']>;


### PR DESCRIPTION
Closes #634

## Resumo
- Redesenha o menu inferior privado para 5 tabs: Início, Transações, Insights, Cartões e Mais.
- Remove o botão central + da tab bar; Nova transação e Planejamento passam a morar no hub Mais.
- Adiciona indicador líquido com Reanimated, haptics e transição horizontal estilo carrossel entre tabs.
- Atualiza o tour de cartões para não depender mais da âncora do FAB.
- Documenta o fluxo em ARCHITECTURE.md/DATAFLOW.md e registra o plano em docs/superpowers.
- Sincroniza shared/types/generated/graphql.ts porque o codegen trouxe drift de schema já presente.

## Validação
- npm run quality-check: passou, 418 suites / 2710 testes.
- Pre-push hook: passou policy, contracts, typecheck, audit crítico e coverage.
- npm test -- core/navigation/routes.test.ts __tests__/app/private-layout.test.tsx core/navigation/app-tab-bar.test.tsx core/navigation/more-hub-screen.test.tsx features/credit-cards/cards-tour/cards-tour-steps.test.ts features/credit-cards/cards-tour/use-cards-tour.test.ts __tests__/e2e/dashboard.test.tsx --runInBand --forceExit: passou, 7 suites / 45 testes.
- npm test -- __tests__/e2e/transactions.test.tsx --runInBand --forceExit: passou, 6 testes.

## Screenshots / Smoke
- Draft até anexar screenshots e/ou smoke manual iOS/Android do menu inferior, Mais, Cartões, Insights e fluxo de Nova transação.

## Notas
- Sem mudança backend ou DB.
- O audit report mostra apenas vulnerabilidades moderadas já existentes; o gate crítico passou.
