### PR TITLE
[APP] Bloquear API insegura em runtime de produção

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -29,6 +29,12 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - `app.credit-cards.expense-actions` is promoted to `enabled-prod` after app-side parity validation for edit, duplicate and delete actions in credit card invoices.
 - Local flag status is tested through `shared/feature-flags/service.test.ts`; runtime providers can still override decisions where configured.
 
+## Runtime Security
+
+- `shared/config/runtime.ts` is the canonical resolver for public Expo runtime configuration used by HTTP, telemetry and product services.
+- Production runtime (`EXPO_PUBLIC_APP_ENV=production`) must resolve `EXPO_PUBLIC_API_URL` to a valid HTTPS URL and must never fall back to localhost. The guard runs while `appRuntimeConfig` is created, before the app can build an HTTP client against an unsafe base URL.
+- Development and preview builds can still use localhost for Expo Go/dev-client workflows.
+
 ## Auth Surface
 
 - The login route keeps the same `useLoginScreenController` contract for mutation, captcha, error handling, legal links and navigation.

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -20,6 +20,14 @@ No network call or database mutation is required until the user explicitly saves
 4. `enabled-prod` means the app fallback treats the feature as enabled in production-ready builds.
 5. Remote provider decisions can still override the local fallback when Unleash mode is configured.
 
+## Production Runtime Config Flow
+
+1. `shared/config/runtime.ts` reads `EXPO_PUBLIC_APP_ENV` from Expo public env and falls back to `expo.extra.appEnv` or `development`.
+2. The same module resolves `apiBaseUrl` from `EXPO_PUBLIC_API_URL`, then `expo.extra.apiUrl`, then the local development fallback `http://localhost:5000`.
+3. `normalizeBaseUrl` removes trailing slashes so downstream clients receive a stable base URL.
+4. If the resolved app environment is `production`, `assertProductionApiBaseUrl` rejects invalid URLs, non-HTTPS URLs and localhost-style hosts before exporting `appRuntimeConfig`.
+5. `core/http/http-client.ts` imports the guarded `appRuntimeConfig.apiBaseUrl`; a production bundle without a safe API URL fails fast instead of dispatching requests to localhost.
+
 ## Premium Login Flow
 
 1. `LoginScreen` obtains all auth actions and state from `useLoginScreenController`.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -56,6 +56,34 @@ vai injetar o secret no bundle. **Nunca** comitar a DSN em `app.json`,
 `extra.appEnv` → fallback `"development"`. Usar `production` /
 `preview` / `development` conforme o profile EAS.
 
+## API base URL — production guard
+
+`shared/config/runtime.ts` resolve `apiBaseUrl` em build/runtime a partir de
+`EXPO_PUBLIC_API_URL` → `expo.extra.apiUrl` → fallback local
+`http://localhost:5000`.
+
+Esse fallback só é permitido fora de produção. Quando
+`EXPO_PUBLIC_APP_ENV=production`, o runtime falha durante a criação de
+`appRuntimeConfig` se a URL resolvida:
+
+- não for uma URL válida;
+- não usar `https://`;
+- apontar para host local (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`).
+
+Isso impede que um binário de loja seja publicado silenciosamente apontando
+para a API local de desenvolvimento. Builds `preview` e `development`
+continuam aceitando `localhost` para fluxo local/dev client.
+
+Configuração obrigatória para builds de produção:
+
+```bash
+EXPO_PUBLIC_APP_ENV=production
+EXPO_PUBLIC_API_URL=https://api.auraxis.com.br
+```
+
+Preferir EAS environment/secrets para esses valores. Não gravar URL de produção
+em `.env*` versionado.
+
 ### Sanitização (LGPD)
 
 `sanitizeSentryEvent` em `app/services/sentry.ts` remove `user.email` e

--- a/docs/superpowers/plans/2026-07-02-production-api-guard.md
+++ b/docs/superpowers/plans/2026-07-02-production-api-guard.md
@@ -1,0 +1,209 @@
+# Production API Guard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent production app bundles from resolving the API base URL to localhost or any non-HTTPS endpoint.
+
+**Architecture:** Keep the guard inside `shared/config/runtime.ts`, where the runtime singleton already resolves public Expo env and `expo.extra` values. Add pure validation helpers so unit tests can cover the policy without booting the app, and make `appRuntimeConfig` call the validator at module initialization.
+
+**Tech Stack:** Expo SDK 54, React Native, TypeScript strict, Jest.
+
+---
+
+### Task 1: Runtime Guard Tests
+
+**Files:**
+- Create: `shared/config/runtime.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```ts
+import {
+  assertProductionApiBaseUrl,
+  normalizeBaseUrl,
+  resolveAppEnvironment,
+} from "@/shared/config/runtime";
+
+describe("runtime production API guard", () => {
+  it("bloqueia localhost quando o app roda como production", () => {
+    expect(() =>
+      assertProductionApiBaseUrl({
+        apiBaseUrl: "http://localhost:5000",
+        appEnvironment: "production",
+      }),
+    ).toThrow(
+      "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL",
+    );
+  });
+
+  it("bloqueia endpoints nao-HTTPS quando o app roda como production", () => {
+    expect(() =>
+      assertProductionApiBaseUrl({
+        apiBaseUrl: "http://api.auraxis.com.br",
+        appEnvironment: "production",
+      }),
+    ).toThrow(
+      "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL",
+    );
+  });
+
+  it("aceita API HTTPS normalizada em production", () => {
+    expect(
+      assertProductionApiBaseUrl({
+        apiBaseUrl: normalizeBaseUrl("https://api.auraxis.com.br/"),
+        appEnvironment: "production",
+      }),
+    ).toBe("https://api.auraxis.com.br");
+  });
+
+  it("mantem localhost permitido fora de production", () => {
+    expect(
+      assertProductionApiBaseUrl({
+        apiBaseUrl: "http://localhost:5000",
+        appEnvironment: "development",
+      }),
+    ).toBe("http://localhost:5000");
+  });
+
+  it("normaliza ambientes Expo conhecidos e cai para development quando ausente", () => {
+    expect(resolveAppEnvironment("production")).toBe("production");
+    expect(resolveAppEnvironment("preview")).toBe("preview");
+    expect(resolveAppEnvironment("development")).toBe("development");
+    expect(resolveAppEnvironment("")).toBe("development");
+  });
+});
+```
+
+- [ ] **Step 2: Verify RED**
+
+Run:
+
+```bash
+npm test -- shared/config/runtime.test.ts --runInBand
+```
+
+Expected: fail because `assertProductionApiBaseUrl` and `resolveAppEnvironment` are not exported yet.
+
+### Task 2: Runtime Guard Implementation
+
+**Files:**
+- Modify: `shared/config/runtime.ts`
+
+- [ ] **Step 1: Add environment resolution**
+
+Add `EXPO_PUBLIC_APP_ENV` to `RuntimeEnvKey`, add its reader, and introduce:
+
+```ts
+type AppEnvironment = "development" | "preview" | "production";
+
+export const resolveAppEnvironment = (rawValue: string | null | undefined): AppEnvironment => {
+  const normalized = String(rawValue ?? "").trim().toLowerCase();
+  return normalized === "production" || normalized === "preview" ? normalized : "development";
+};
+```
+
+- [ ] **Step 2: Add production URL assertion**
+
+Add:
+
+```ts
+const PRODUCTION_API_URL_ERROR =
+  "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL. Configure EXPO_PUBLIC_API_URL=https://api.auraxis.com.br in the EAS environment before building.";
+
+const isLocalhostHostname = (hostname: string): boolean =>
+  hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+
+export const assertProductionApiBaseUrl = ({
+  apiBaseUrl,
+  appEnvironment,
+}: {
+  readonly apiBaseUrl: string;
+  readonly appEnvironment: AppEnvironment;
+}): string => {
+  if (appEnvironment !== "production") {
+    return apiBaseUrl;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(apiBaseUrl);
+  } catch {
+    throw new Error(PRODUCTION_API_URL_ERROR);
+  }
+
+  if (parsedUrl.protocol !== "https:" || isLocalhostHostname(parsedUrl.hostname)) {
+    throw new Error(PRODUCTION_API_URL_ERROR);
+  }
+
+  return apiBaseUrl;
+};
+```
+
+- [ ] **Step 3: Wire singleton config**
+
+Resolve app env before `appRuntimeConfig`, compute the normalized API URL once, and pass it through the assertion:
+
+```ts
+const appEnvironment = resolveAppEnvironment(
+  readString("EXPO_PUBLIC_APP_ENV", "appEnv", "development"),
+);
+
+const resolvedApiBaseUrl = assertProductionApiBaseUrl({
+  apiBaseUrl: normalizeBaseUrl(
+    readString("EXPO_PUBLIC_API_URL", "apiUrl", DEFAULT_API_BASE_URL),
+  ),
+  appEnvironment,
+});
+```
+
+Then set `apiBaseUrl: resolvedApiBaseUrl`.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+npm test -- shared/config/runtime.test.ts --runInBand
+```
+
+Expected: all tests pass.
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `docs/runtime.md`
+- Modify: `ARCHITECTURE.md`
+- Modify: `DATAFLOW.md`
+
+- [ ] **Step 1: Document runtime policy**
+
+In `docs/runtime.md`, add a section near the Sentry environment/runtime docs explaining that `EXPO_PUBLIC_APP_ENV=production` requires `EXPO_PUBLIC_API_URL` to be HTTPS and cannot use localhost.
+
+- [ ] **Step 2: Document architecture/dataflow impact**
+
+Add a short runtime security bullet to `ARCHITECTURE.md` and a `Production Runtime Config Flow` section to `DATAFLOW.md`.
+
+### Task 4: Validation And Shipping
+
+- [ ] **Step 1: Focused checks**
+
+Run:
+
+```bash
+npm test -- shared/config/runtime.test.ts --runInBand
+npx eslint --max-warnings 0 --no-warn-ignored shared/config/runtime.ts shared/config/runtime.test.ts
+npm run typecheck
+git diff --check
+```
+
+- [ ] **Step 2: Full gate**
+
+Run:
+
+```bash
+npm run quality-check
+```
+
+- [ ] **Step 3: Restore coordination and ship**
+
+Restore `.context/active_agents.json` to idle, stage only intended files, commit, push and open a non-draft PR with `Closes #521`. No screenshots are required because this is a non-visual runtime/security change.

--- a/shared/config/runtime.test.ts
+++ b/shared/config/runtime.test.ts
@@ -1,0 +1,93 @@
+import type * as RuntimeConfigModule from "@/shared/config/runtime";
+
+describe("runtime production API guard", () => {
+  const originalEnv = process.env;
+  const loadRuntime = (): typeof RuntimeConfigModule =>
+    jest.requireActual("@/shared/config/runtime") as typeof RuntimeConfigModule;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+    delete process.env.EXPO_PUBLIC_API_URL;
+    delete process.env.EXPO_PUBLIC_APP_ENV;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("bloqueia localhost quando o app roda como production", () => {
+    const { assertProductionApiBaseUrl } = loadRuntime();
+
+    expect(() =>
+      assertProductionApiBaseUrl({
+        apiBaseUrl: "http://localhost:5000",
+        appEnvironment: "production",
+      }),
+    ).toThrow(
+      "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL",
+    );
+  });
+
+  it("bloqueia endpoints nao-HTTPS quando o app roda como production", () => {
+    const { assertProductionApiBaseUrl } = loadRuntime();
+
+    expect(() =>
+      assertProductionApiBaseUrl({
+        apiBaseUrl: "http://api.auraxis.com.br",
+        appEnvironment: "production",
+      }),
+    ).toThrow(
+      "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL",
+    );
+  });
+
+  it("aceita API HTTPS normalizada em production", () => {
+    const { assertProductionApiBaseUrl, normalizeBaseUrl } = loadRuntime();
+
+    expect(
+      assertProductionApiBaseUrl({
+        apiBaseUrl: normalizeBaseUrl("https://api.auraxis.com.br/"),
+        appEnvironment: "production",
+      }),
+    ).toBe("https://api.auraxis.com.br");
+  });
+
+  it("mantem localhost permitido fora de production", () => {
+    const { assertProductionApiBaseUrl } = loadRuntime();
+
+    expect(
+      assertProductionApiBaseUrl({
+        apiBaseUrl: "http://localhost:5000",
+        appEnvironment: "development",
+      }),
+    ).toBe("http://localhost:5000");
+  });
+
+  it("normaliza ambientes Expo conhecidos e cai para development quando ausente", () => {
+    const { resolveAppEnvironment } = loadRuntime();
+
+    expect(resolveAppEnvironment("production")).toBe("production");
+    expect(resolveAppEnvironment("preview")).toBe("preview");
+    expect(resolveAppEnvironment("development")).toBe("development");
+    expect(resolveAppEnvironment("")).toBe("development");
+    expect(resolveAppEnvironment(undefined)).toBe("development");
+  });
+
+  it("falha ao montar o singleton quando production nao define API HTTPS", () => {
+    process.env.EXPO_PUBLIC_APP_ENV = "production";
+
+    expect(() => loadRuntime()).toThrow(
+      "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL",
+    );
+  });
+
+  it("monta o singleton em production quando a API publica e HTTPS", () => {
+    process.env.EXPO_PUBLIC_APP_ENV = "production";
+    process.env.EXPO_PUBLIC_API_URL = "https://api.auraxis.com.br/";
+
+    const { appRuntimeConfig } = loadRuntime();
+
+    expect(appRuntimeConfig.apiBaseUrl).toBe("https://api.auraxis.com.br");
+  });
+});

--- a/shared/config/runtime.ts
+++ b/shared/config/runtime.ts
@@ -6,6 +6,7 @@ import {
 } from "@/shared/config/checkout-provider-channel";
 
 export type ApiMode = "live" | "mock";
+export type AppEnvironment = "development" | "preview" | "production";
 
 export interface AppRuntimeConfig {
   readonly apiBaseUrl: string;
@@ -39,6 +40,7 @@ const DEFAULT_BRAPI_BASE_URL = "https://brapi.dev/api";
 const expoExtra = (Constants.expoConfig?.extra ?? {}) as Record<string, unknown>;
 
 type RuntimeEnvKey =
+  | "EXPO_PUBLIC_APP_ENV"
   | "EXPO_PUBLIC_API_URL"
   | "EXPO_PUBLIC_API_MODE"
   | "EXPO_PUBLIC_API_CONTRACT_VERSION"
@@ -56,6 +58,7 @@ type RuntimeEnvKey =
   | "EXPO_PUBLIC_BRAPI_BASE_URL";
 
 const RUNTIME_ENV_READERS: Readonly<Record<RuntimeEnvKey, () => string | undefined>> = {
+  EXPO_PUBLIC_APP_ENV: () => process.env.EXPO_PUBLIC_APP_ENV,
   EXPO_PUBLIC_API_URL: () => process.env.EXPO_PUBLIC_API_URL,
   EXPO_PUBLIC_API_MODE: () => process.env.EXPO_PUBLIC_API_MODE,
   EXPO_PUBLIC_API_CONTRACT_VERSION: () => process.env.EXPO_PUBLIC_API_CONTRACT_VERSION,
@@ -153,15 +156,70 @@ export const normalizeBaseUrl = (rawUrl: string): string => {
   return rawUrl.slice(0, end);
 };
 
+export const resolveAppEnvironment = (
+  rawValue: string | null | undefined,
+): AppEnvironment => {
+  const normalized = String(rawValue ?? "").trim().toLowerCase();
+
+  if (normalized === "production" || normalized === "preview") {
+    return normalized;
+  }
+
+  return "development";
+};
+
+const PRODUCTION_API_URL_ERROR =
+  "Production app runtime requires EXPO_PUBLIC_API_URL to be an HTTPS URL. Configure EXPO_PUBLIC_API_URL=https://api.auraxis.com.br in the EAS environment before building.";
+
+const isLocalhostHostname = (hostname: string): boolean =>
+  ["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"].includes(hostname);
+
+export const assertProductionApiBaseUrl = ({
+  apiBaseUrl,
+  appEnvironment,
+}: {
+  readonly apiBaseUrl: string;
+  readonly appEnvironment: AppEnvironment;
+}): string => {
+  if (appEnvironment !== "production") {
+    return apiBaseUrl;
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(apiBaseUrl);
+  } catch {
+    throw new Error(PRODUCTION_API_URL_ERROR);
+  }
+
+  if (
+    parsedUrl.protocol !== "https:"
+    || isLocalhostHostname(parsedUrl.hostname)
+  ) {
+    throw new Error(PRODUCTION_API_URL_ERROR);
+  }
+
+  return apiBaseUrl;
+};
+
 const readApiMode = (): ApiMode => {
   const rawValue = readString("EXPO_PUBLIC_API_MODE", "apiMode", "live").toLowerCase();
   return rawValue === "mock" ? "mock" : "live";
 };
 
-export const appRuntimeConfig: AppRuntimeConfig = Object.freeze({
+const appEnvironment = resolveAppEnvironment(
+  readString("EXPO_PUBLIC_APP_ENV", "appEnv", "development"),
+);
+
+const resolvedApiBaseUrl = assertProductionApiBaseUrl({
   apiBaseUrl: normalizeBaseUrl(
     readString("EXPO_PUBLIC_API_URL", "apiUrl", DEFAULT_API_BASE_URL),
   ),
+  appEnvironment,
+});
+
+export const appRuntimeConfig: AppRuntimeConfig = Object.freeze({
+  apiBaseUrl: resolvedApiBaseUrl,
   apiMode: readApiMode(),
   apiContractVersion: readString(
     "EXPO_PUBLIC_API_CONTRACT_VERSION",


### PR DESCRIPTION
## Resumo

- Adiciona guard em `shared/config/runtime.ts` para impedir que `EXPO_PUBLIC_APP_ENV=production` resolva a API para localhost, URL inválida ou endpoint não-HTTPS.
- Mantém `localhost` permitido em `development` e `preview` para Expo Go/dev-client.
- Cobre o comportamento com testes unitários de RED/GREEN para helper puro e criação do singleton `appRuntimeConfig`.
- Documenta a política em `docs/runtime.md`, `ARCHITECTURE.md` e `DATAFLOW.md`.

## Validação

- RED: `npm test -- shared/config/runtime.test.ts --runInBand` falhou antes da implementação por falta do guard e por produção ainda aceitar fallback local.
- `npm test -- shared/config/runtime.test.ts --runInBand`
- `npx eslint --max-warnings 0 --no-warn-ignored shared/config/runtime.ts shared/config/runtime.test.ts`
- `npm run typecheck`
- `git diff --check`
- `npm run quality-check`
- Pre-commit hooks: gitleaks, governance, lint-staged.
- Pre-push hooks: policy, contracts, TypeScript, audit crítico e coverage. Warnings restantes são os já existentes de `act(...)`/localstorage e audit moderado.

## Evidências visuais

Não aplicável: mudança de runtime/segurança sem alteração visual web/mobile.

## Notas

- Sem mudança backend, banco, OpenAPI, `app.json`, `eas.json` ou `.env*`.
- `npm audit --audit-level=critical` não encontrou vulnerabilidades críticas; o relatório ainda mostra vulnerabilidades moderadas existentes em dependências transitivas.

Closes #521