### PR TITLE
[APP] Shared entries mobile parity summary

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,13 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - `TransactionForm` edits both fields independently; `useTransactionsScreenController` forwards `observation` through create, update and duplicate flows without introducing a new endpoint.
 - The feed view-model and action sheet render observations as a separate detail block so historical descriptions remain visible and untouched.
 
+## Shared Entries Surface
+
+- `/compartilhamentos` mounts `SharedEntriesScreen`, guarded by `PaywallGate` for the `shared_entries` entitlement.
+- `useSharedEntriesScreenController` keeps the Web parity split explicit: invitations, entries shared by the current user (`byMe`) and entries shared with the current user (`withMe`) are queried independently and exposed as separate tabs.
+- The mobile surface renders a summary card with total entries, active entries and pending invitations before the tab selector, then shows per-tab counters so `Compartilhei` and `Recebi` stay visually distinct.
+- Revocation remains restricted to `byMe` cards; `withMe` cards are read-only and keep the explanatory copy that only the creator can revoke.
+
 ## Feature Flags
 
 - `app.transactions.installments` is promoted to `enabled-prod` after app-side parity validation for transaction installments.
@@ -55,5 +62,5 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 ## Validation
 
 - New or changed behavior must include tests in the same feature area.
-- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage and transaction observation form/feed/controller coverage.
+- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, shared-entries mobile parity and transaction observation form/feed/controller coverage.
 - No backend or database interface was added by this slice. If a future calculator starts consuming an API, run contracts checks and live database validation as required by `AGENTS.md`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -26,9 +26,10 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 ## Shared Entries Surface
 
 - `/compartilhamentos` mounts `SharedEntriesScreen`, guarded by `PaywallGate` for the `shared_entries` entitlement.
-- `useSharedEntriesScreenController` keeps the Web parity split explicit: invitations, entries shared by the current user (`byMe`) and entries shared with the current user (`withMe`) are queried independently and exposed as separate tabs.
+- `useSharedEntriesScreenController` keeps the Web parity split explicit: incoming invitations, entries shared by the current user (`byMe`), entries shared with the current user (`withMe`) and outgoing invitations are queried/classified independently.
 - The mobile surface renders a summary card with total entries, active entries and pending invitations before the tab selector, then shows per-tab counters so `Compartilhei` and `Recebi` stay visually distinct.
-- Revocation remains restricted to `byMe` cards; `withMe` cards are read-only and keep the explanatory copy that only the creator can revoke.
+- `Compartilhei` includes the outgoing composer, the list of shares created by the user and the sent invitation list. Pending sent invitations can be revoked through the same generated `/shared-entries/invitations/{invitationId}` contract used by incoming rejection.
+- Shared-entry revocation remains restricted to `byMe` cards; `withMe` cards are read-only and keep the explanatory copy that only the creator can revoke.
 
 ## Feature Flags
 
@@ -62,5 +63,5 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 ## Validation
 
 - New or changed behavior must include tests in the same feature area.
-- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, shared-entries mobile parity and transaction observation form/feed/controller coverage.
+- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, shared-entries mobile parity including outgoing invitations, and transaction observation form/feed/controller coverage.
 - No backend or database interface was added by this slice. If a future calculator starts consuming an API, run contracts checks and live database validation as required by `AGENTS.md`.

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -38,6 +38,16 @@ No network call or database mutation is required until the user explicitly saves
 6. Successful login still consumes any stored auth redirect and navigates to the intended private route or dashboard.
 7. Session-expired and submit-error states render on the same screen without changing session policy.
 
+## Shared Entries Flow
+
+1. `app/(private)/compartilhamentos.tsx` mounts `SharedEntriesScreen`.
+2. `PaywallGate` checks the `shared_entries` entitlement before rendering premium sharing data.
+3. `useSharedEntriesScreenController` starts three independent TanStack queries: `sharedEntries.byMe`, `sharedEntries.withMe` and `sharedEntries.invitations`.
+4. `sharedEntriesService` resolves the generated contract paths for `/shared-entries/by-me`, `/shared-entries/with-me` and `/shared-entries/invitations`, then maps API snake_case payloads into app records.
+5. `sharedEntriesClassifier` derives buckets and labels, while the controller derives tab counts plus the summary totals from the classified lists.
+6. `SharedEntriesScreen` renders the summary card first, then the `Convites`, `Compartilhei` and `Recebi` tabs with counters.
+7. Accept/reject actions apply only to invitation cards. Revoke actions apply only to `byMe` entries; `withMe` entries stay read-only.
+
 ## Liquid Tab Navigation Flow
 
 1. `app/(private)/_layout.tsx` builds the logged-in tab navigator from `privateTabDefinitions`.
@@ -64,4 +74,5 @@ No network call or database mutation is required until the user explicitly saves
 - Screen tests assert that inputs, results and controller actions are wired.
 - Feature flag tests assert production status for promoted parity features.
 - Login tests assert the premium surface, localized placeholders, focus styling and preserved auth controller actions.
+- Shared-entries tests assert controller counts, summary rendering, tab counters and stable tab actions.
 - Transaction observation tests cover schema validation, form submission/edit prefill, controller payloads, duplicate behavior, feed mapping, card rendering and action sheet details.

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -44,9 +44,10 @@ No network call or database mutation is required until the user explicitly saves
 2. `PaywallGate` checks the `shared_entries` entitlement before rendering premium sharing data.
 3. `useSharedEntriesScreenController` starts three independent TanStack queries: `sharedEntries.byMe`, `sharedEntries.withMe` and `sharedEntries.invitations`.
 4. `sharedEntriesService` resolves the generated contract paths for `/shared-entries/by-me`, `/shared-entries/with-me` and `/shared-entries/invitations`, then maps API snake_case payloads into app records.
-5. `sharedEntriesClassifier` derives buckets and labels, while the controller derives tab counts plus the summary totals from the classified lists.
-6. `SharedEntriesScreen` renders the summary card first, then the `Convites`, `Compartilhei` and `Recebi` tabs with counters.
-7. Accept/reject actions apply only to invitation cards. Revoke actions apply only to `byMe` entries; `withMe` entries stay read-only.
+5. `sharedEntriesClassifier` derives buckets, labels and invitation direction. Pending incoming invitations exclude records whose `fromUserId` matches the current session user; outgoing invitations include only records sent by the current user.
+6. The controller derives tab counts plus the summary totals from the classified lists and keeps a local outgoing invitation form with selected shared entry, invitee email, optional split percentage, optional exact amount, optional message and expiry hours.
+7. `SharedEntriesScreen` renders the summary card first, then the `Convites`, `Compartilhei` and `Recebi` tabs with counters.
+8. `Convites` accepts/rejects received invitations. `Compartilhei` creates invitations with `createInvitation`, lists sent invitations and revokes pending sent invitations with `deleteInvitation`. Revoke actions for shared entries still apply only to `byMe` entries; `withMe` entries stay read-only.
 
 ## Liquid Tab Navigation Flow
 
@@ -74,5 +75,5 @@ No network call or database mutation is required until the user explicitly saves
 - Screen tests assert that inputs, results and controller actions are wired.
 - Feature flag tests assert production status for promoted parity features.
 - Login tests assert the premium surface, localized placeholders, focus styling and preserved auth controller actions.
-- Shared-entries tests assert controller counts, summary rendering, tab counters and stable tab actions.
+- Shared-entries tests assert controller counts, summary rendering, tab counters, incoming/outgoing invitation separation, outgoing composer actions and stable tab actions.
 - Transaction observation tests cover schema validation, form submission/edit prefill, controller payloads, duplicate behavior, feed mapping, card rendering and action sheet details.

--- a/docs/superpowers/plans/2026-07-03-shared-entries-mobile-parity.md
+++ b/docs/superpowers/plans/2026-07-03-shared-entries-mobile-parity.md
@@ -1,0 +1,141 @@
+# Shared Entries Mobile Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the mobile shared-entries screen closer to Web parity by making by-me/with-me separation measurable and visible through tab counters and a summary surface.
+
+**Architecture:** Keep existing API contracts and the current three-tab app structure (`invitations`, `byMe`, `withMe`). Add derived counts to `useSharedEntriesScreenController`, then render those counts in the screen without introducing backend changes.
+
+**Tech Stack:** React Native, Expo Router, Tamagui, TanStack Query, Jest, React Native Testing Library.
+
+---
+
+### Task 1: Controller Counts
+
+**Files:**
+- Modify: `features/shared-entries/hooks/use-shared-entries-screen-controller.ts`
+- Modify: `features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx`
+
+- [x] **Step 1: Write the failing test**
+
+Add a test that feeds one pending invitation, one by-me entry and two with-me entries through the mocked queries, then expects:
+
+```ts
+expect(result.current.tabCounts).toEqual({
+  invitations: 1,
+  byMe: 1,
+  withMe: 2,
+});
+expect(result.current.summary).toEqual({
+  totalEntries: 3,
+  activeEntries: 2,
+  pendingInvitations: 1,
+});
+```
+
+- [x] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+npm test -- --runTestsByPath features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx --runInBand
+```
+
+Expected: FAIL because `tabCounts` and `summary` do not exist on the controller.
+
+- [x] **Step 3: Implement minimal controller projection**
+
+Add two readonly controller fields:
+
+```ts
+readonly tabCounts: Readonly<Record<SharedEntriesTab, number>>;
+readonly summary: {
+  readonly totalEntries: number;
+  readonly activeEntries: number;
+  readonly pendingInvitations: number;
+};
+```
+
+Compute them from `pendingInvitations`, `byMeEntries` and `withMeEntries`.
+
+- [x] **Step 4: Run GREEN**
+
+Run the same controller test command and expect PASS.
+
+### Task 2: Screen Summary And Counted Tabs
+
+**Files:**
+- Modify: `features/shared-entries/screens/shared-entries-screen.tsx`
+- Modify: `features/shared-entries/screens/shared-entries-screen.test.tsx`
+
+- [x] **Step 1: Write the failing screen tests**
+
+Add tests that build a controller with `tabCounts` and `summary`, then assert:
+
+```ts
+expect(getByTestId("shared-entries-summary-total")).toHaveTextContent("3");
+expect(getByTestId("shared-entries-summary-active")).toHaveTextContent("2");
+expect(getByTestId("shared-entries-summary-invitations")).toHaveTextContent("1");
+expect(getByText("Compartilhei (1)")).toBeTruthy();
+expect(getByText("Recebi (2)")).toBeTruthy();
+```
+
+- [x] **Step 2: Run the test to verify RED**
+
+Run:
+
+```bash
+npm test -- --runTestsByPath features/shared-entries/screens/shared-entries-screen.test.tsx --runInBand
+```
+
+Expected: FAIL because the summary testIDs and counted tab labels are not rendered yet.
+
+- [x] **Step 3: Implement minimal UI**
+
+Render a compact `AppSurfaceCard` with three values:
+
+```tsx
+<SummaryMetric testID="shared-entries-summary-total" label="Total" value={controller.summary.totalEntries} />
+<SummaryMetric testID="shared-entries-summary-active" label="Ativos" value={controller.summary.activeEntries} />
+<SummaryMetric testID="shared-entries-summary-invitations" label="Convites" value={controller.summary.pendingInvitations} />
+```
+
+Update tab labels to include counts, e.g. `Compartilhei (1)`, and keep the selected tab tone.
+
+- [x] **Step 4: Run GREEN**
+
+Run the same screen test command and expect PASS.
+
+### Task 3: Documentation And Gate
+
+**Files:**
+- Modify: `ARCHITECTURE.md`
+- Modify: `DATAFLOW.md`
+
+- [x] **Step 1: Document the parity behavior**
+
+Document that `/compartilhamentos` loads `by-me`, `with-me` and invitations independently, renders a mobile summary, and keeps revocation only on by-me entries.
+
+- [x] **Step 2: Run focused verification**
+
+Run:
+
+```bash
+npm test -- --runTestsByPath features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx features/shared-entries/screens/shared-entries-screen.test.tsx features/shared-entries/services/shared-entries-classifier.test.ts --runInBand
+```
+
+Expected: PASS.
+
+- [x] **Step 3: Run quality gate**
+
+Run:
+
+```bash
+npm run quality-check
+```
+
+Expected: PASS.
+
+- [x] **Step 4: Finish**
+
+Review diff, restore `.context/active_agents.json` to idle, commit selectively, push `feat/506-shared-entries-tabs`, and open a non-draft PR with `Closes #506`.

--- a/docs/superpowers/plans/2026-07-03-sharing-outgoing-mobile.md
+++ b/docs/superpowers/plans/2026-07-03-sharing-outgoing-mobile.md
@@ -1,0 +1,20 @@
+# Sharing outgoing mobile parity
+
+## Goal
+
+Pair the App with the Web sharing outgoing flow tracked by issue #499: users must be able to create invitations, see invitations they sent, and revoke pending sent invitations from the mobile shared entries surface.
+
+## Constraints
+
+- Keep the existing `/shared-entries/*` app API contract; do not add backend or database changes.
+- Extend PR #641 because it is already the active shared-entries parity PR.
+- Keep the diff focused on `features/shared-entries`, docs and tests.
+- Preserve the current incoming invitation accept/reject flow.
+
+## Plan
+
+1. Add RED coverage for separating incoming pending invitations from invitations sent by the current user.
+2. Add RED controller coverage for creating an outgoing invitation and revoking a sent invitation.
+3. Add RED screen coverage for the `Compartilhei` tab composer and outgoing invitations list.
+4. Implement classifier helpers, controller form state/handlers and the mobile UI.
+5. Update architecture/dataflow docs and run targeted tests, then the full app quality gate.

--- a/features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx
+++ b/features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx
@@ -13,6 +13,7 @@ import {
   useSharedEntriesWithMeQuery,
   useSharedInvitationsQuery,
 } from "@/features/shared-entries/hooks/use-shared-entries-query";
+import type { SharedEntryRecord } from "@/features/shared-entries/contracts";
 import type { InvitationView } from "@/features/shared-entries/services/shared-entries-classifier";
 
 jest.mock("@/features/shared-entries/hooks/use-shared-entries-mutations", () => ({
@@ -60,6 +61,23 @@ const buildInvitationView = (
   bucket: "pending",
   isExpired: false,
   shareLabel: "Sua parte: 50%",
+  ...override,
+});
+
+const buildEntryRecord = (
+  override: Partial<SharedEntryRecord> = {},
+): SharedEntryRecord => ({
+  id: "se-1",
+  ownerId: "u-1",
+  transactionId: "tx-1",
+  status: "active",
+  splitType: "equal",
+  transactionTitle: "Aluguel",
+  transactionAmount: 2000,
+  myShare: 1000,
+  otherPartyEmail: "x@y.com",
+  createdAt: "2026-04-01T00:00:00Z",
+  updatedAt: "2026-04-01T00:00:00Z",
   ...override,
 });
 
@@ -151,6 +169,41 @@ describe("useSharedEntriesScreenController", () => {
       result.current.setSelectedTab("byMe");
     });
     expect(result.current.selectedTab).toBe("byMe");
+  });
+
+  it("calcula contadores de tabs e resumo para paridade mobile", () => {
+    mockedInvitations.mockReturnValue({
+      data: { invitations: [buildInvitationView()] },
+      isPending: false,
+    } as never);
+    mockedByMe.mockReturnValue({
+      data: { sharedEntries: [buildEntryRecord({ id: "by-me-1" })] },
+      isPending: false,
+    } as never);
+    mockedWithMe.mockReturnValue({
+      data: {
+        sharedEntries: [
+          buildEntryRecord({ id: "with-me-1", status: "accepted" }),
+          buildEntryRecord({ id: "with-me-2", status: "completed" }),
+        ],
+      },
+      isPending: false,
+    } as never);
+
+    const { result } = renderHook(() => useSharedEntriesScreenController(), {
+      wrapper: wrapper(client),
+    });
+
+    expect(result.current.tabCounts).toEqual({
+      invitations: 1,
+      byMe: 1,
+      withMe: 2,
+    });
+    expect(result.current.summary).toEqual({
+      totalEntries: 3,
+      activeEntries: 2,
+      pendingInvitations: 1,
+    });
   });
 
   it("captura erro quando accept rejeita e mantem outras invitations destrancadas", async () => {

--- a/features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx
+++ b/features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx
@@ -2,9 +2,14 @@ import { act, renderHook } from "@testing-library/react-native";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { ReactNode } from "react";
 
+import {
+  sessionStateDefaults,
+  useSessionStore,
+} from "@/core/session/session-store";
 import { useSharedEntriesScreenController } from "@/features/shared-entries/hooks/use-shared-entries-screen-controller";
 import {
   useAcceptSharedInvitationMutation,
+  useCreateSharedInvitationMutation,
   useDeleteSharedEntryMutation,
   useDeleteSharedInvitationMutation,
 } from "@/features/shared-entries/hooks/use-shared-entries-mutations";
@@ -18,6 +23,7 @@ import type { InvitationView } from "@/features/shared-entries/services/shared-e
 
 jest.mock("@/features/shared-entries/hooks/use-shared-entries-mutations", () => ({
   useAcceptSharedInvitationMutation: jest.fn(),
+  useCreateSharedInvitationMutation: jest.fn(),
   useDeleteSharedEntryMutation: jest.fn(),
   useDeleteSharedInvitationMutation: jest.fn(),
 }));
@@ -28,6 +34,7 @@ jest.mock("@/features/shared-entries/hooks/use-shared-entries-query", () => ({
 }));
 
 const mockedAccept = jest.mocked(useAcceptSharedInvitationMutation);
+const mockedCreateInv = jest.mocked(useCreateSharedInvitationMutation);
 const mockedDeleteInv = jest.mocked(useDeleteSharedInvitationMutation);
 const mockedDeleteEntry = jest.mocked(useDeleteSharedEntryMutation);
 const mockedByMe = jest.mocked(useSharedEntriesByMeQuery);
@@ -81,18 +88,27 @@ const buildEntryRecord = (
   ...override,
 });
 
-describe("useSharedEntriesScreenController", () => {
   let client: QueryClient;
   let acceptMutate: jest.Mock;
+  let createInvMutate: jest.Mock;
   let deleteInvMutate: jest.Mock;
   let deleteEntryMutate: jest.Mock;
 
   beforeEach(() => {
     client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     acceptMutate = jest.fn().mockResolvedValue(undefined);
+    createInvMutate = jest.fn().mockResolvedValue(undefined);
     deleteInvMutate = jest.fn().mockResolvedValue(undefined);
     deleteEntryMutate = jest.fn().mockResolvedValue(undefined);
+    useSessionStore.setState({
+      ...sessionStateDefaults,
+      hydrated: true,
+    });
     mockedAccept.mockReturnValue({ mutateAsync: acceptMutate } as never);
+    mockedCreateInv.mockReturnValue({
+      isPending: false,
+      mutateAsync: createInvMutate,
+    } as never);
     mockedDeleteInv.mockReturnValue({ mutateAsync: deleteInvMutate } as never);
     mockedDeleteEntry.mockReturnValue({ mutateAsync: deleteEntryMutate } as never);
     mockedInvitations.mockReturnValue({
@@ -206,6 +222,91 @@ describe("useSharedEntriesScreenController", () => {
     });
   });
 
+  it("separa convites recebidos pendentes de convites enviados pelo usuario", () => {
+    useSessionStore.setState({
+      user: {
+        id: "current-user",
+        email: "me@example.com",
+        name: "Italo",
+        emailConfirmed: true,
+      },
+    } as never);
+    mockedInvitations.mockReturnValue({
+      data: {
+        invitations: [
+          buildInvitationView({
+            id: "sent",
+            fromUserId: "current-user",
+            toUserEmail: "friend@example.com",
+          }),
+          buildInvitationView({
+            id: "received",
+            fromUserId: "other-user",
+            toUserEmail: "me@example.com",
+          }),
+        ],
+      },
+      isPending: false,
+    } as never);
+
+    const { result } = renderHook(() => useSharedEntriesScreenController(), {
+      wrapper: wrapper(client),
+    });
+
+    expect(result.current.pendingInvitations.map((invitation) => invitation.id)).toEqual([
+      "received",
+    ]);
+    expect(result.current.outgoingInvitations.map((invitation) => invitation.id)).toEqual([
+      "sent",
+    ]);
+  });
+
+  it("cria convite enviado com payload normalizado", async () => {
+    mockedByMe.mockReturnValue({
+      data: { sharedEntries: [buildEntryRecord({ id: "se-1" })] },
+      isPending: false,
+    } as never);
+    const { result } = renderHook(() => useSharedEntriesScreenController(), {
+      wrapper: wrapper(client),
+    });
+
+    act(() => {
+      result.current.selectInvitationEntry("se-1");
+      result.current.setInvitationFormField("inviteeEmail", " partner@example.com ");
+      result.current.setInvitationFormField("splitValue", "40");
+      result.current.setInvitationFormField("message", "  aluguel de julho  ");
+    });
+    await act(async () => {
+      await result.current.handleCreateInvitation();
+    });
+
+    expect(createInvMutate).toHaveBeenCalledWith({
+      sharedEntryId: "se-1",
+      inviteeEmail: "partner@example.com",
+      splitValue: 40,
+      shareAmount: null,
+      message: "aluguel de julho",
+      expiresInHours: 168,
+    });
+  });
+
+  it("revoga convite enviado pelo id", async () => {
+    const invitation = buildInvitationView({
+      id: "out-1",
+      fromUserId: "current-user",
+      toUserEmail: "partner@example.com",
+    });
+    const { result } = renderHook(() => useSharedEntriesScreenController(), {
+      wrapper: wrapper(client),
+    });
+
+    await act(async () => {
+      await result.current.handleRevokeInvitation(invitation);
+    });
+
+    expect(deleteInvMutate).toHaveBeenCalledWith("out-1");
+  });
+
   it("captura erro quando accept rejeita e mantem outras invitations destrancadas", async () => {
     acceptMutate.mockRejectedValueOnce(new Error("boom"));
     const invitation = buildInvitationView();
@@ -235,4 +336,3 @@ describe("useSharedEntriesScreenController", () => {
     });
     expect(result.current.lastError).toBeNull();
   });
-});

--- a/features/shared-entries/hooks/use-shared-entries-screen-controller.ts
+++ b/features/shared-entries/hooks/use-shared-entries-screen-controller.ts
@@ -1,7 +1,10 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
+import { useSessionStore } from "@/core/session/session-store";
+import type { CreateSharedInvitationCommand } from "@/features/shared-entries/contracts";
 import {
   useAcceptSharedInvitationMutation,
+  useCreateSharedInvitationMutation,
   useDeleteSharedEntryMutation,
   useDeleteSharedInvitationMutation,
 } from "@/features/shared-entries/hooks/use-shared-entries-mutations";
@@ -31,6 +34,17 @@ interface SharedEntriesMetrics {
   readonly summary: SharedEntriesSummary;
 }
 
+export interface SharedInvitationFormState {
+  readonly sharedEntryId: string;
+  readonly inviteeEmail: string;
+  readonly splitValue: string;
+  readonly shareAmount: string;
+  readonly message: string;
+  readonly expiresInHours: string;
+}
+
+export type SharedInvitationFormField = keyof SharedInvitationFormState;
+
 export interface SharedEntriesScreenController {
   readonly invitationsQuery: ReturnType<typeof useSharedInvitationsQuery>;
   readonly byMeQuery: ReturnType<typeof useSharedEntriesByMeQuery>;
@@ -38,18 +52,39 @@ export interface SharedEntriesScreenController {
   readonly pendingInvitations: readonly InvitationView[];
   readonly byMeEntries: readonly EntryView[];
   readonly withMeEntries: readonly EntryView[];
+  readonly activeByMeEntries: readonly EntryView[];
+  readonly outgoingInvitations: readonly InvitationView[];
   readonly tabCounts: SharedEntriesTabCounts;
   readonly summary: SharedEntriesSummary;
   readonly selectedTab: SharedEntriesTab;
   readonly setSelectedTab: (tab: SharedEntriesTab) => void;
   readonly pendingInvitationIds: ReadonlySet<string>;
   readonly pendingEntryIds: ReadonlySet<string>;
+  readonly invitationForm: SharedInvitationFormState;
+  readonly invitationFormError: string | null;
+  readonly isCreatingInvitation: boolean;
   readonly lastError: unknown | null;
+  readonly setInvitationFormField: (
+    field: SharedInvitationFormField,
+    value: string,
+  ) => void;
+  readonly selectInvitationEntry: (sharedEntryId: string) => void;
+  readonly handleCreateInvitation: () => Promise<void>;
   readonly handleAccept: (invitation: InvitationView) => Promise<void>;
   readonly handleReject: (invitation: InvitationView) => Promise<void>;
   readonly handleRevoke: (entry: EntryView) => Promise<void>;
+  readonly handleRevokeInvitation: (invitation: InvitationView) => Promise<void>;
   readonly dismissError: () => void;
 }
+
+const DEFAULT_INVITATION_FORM: SharedInvitationFormState = {
+  sharedEntryId: "",
+  inviteeEmail: "",
+  splitValue: "50",
+  shareAmount: "",
+  message: "",
+  expiresInHours: "168",
+};
 
 const useTrackedActionIds = () => {
   const [ids, setIds] = useState<ReadonlySet<string>>(new Set());
@@ -125,58 +160,348 @@ const buildSharedEntriesMetrics = ({
   };
 };
 
-/**
- * Coordinates the shared entries screen: 3 queries (invitations, by me, with
- * me), 3 mutations (accept, reject/delete-invitation, revoke/delete-entry),
- * tab selection, per-record pending state and error capture.
- *
- * Mutations are tracked per record id so multiple actions can run in parallel
- * without blocking the whole list — only the affected card disables.
- */
-export function useSharedEntriesScreenController(): SharedEntriesScreenController {
-  const invitationsQuery = useSharedInvitationsQuery();
-  const byMeQuery = useSharedEntriesByMeQuery();
-  const withMeQuery = useSharedEntriesWithMeQuery();
-  const acceptMutation = useAcceptSharedInvitationMutation();
-  const deleteInvitationMutation = useDeleteSharedInvitationMutation();
-  const deleteEntryMutation = useDeleteSharedEntryMutation();
+interface NumberParseResult {
+  readonly value: number | null;
+  readonly error: string | null;
+}
 
-  const [selectedTab, setSelectedTab] = useState<SharedEntriesTab>("invitations");
-  const [lastError, setLastError] = useState<unknown | null>(null);
-  const invitationActions = useTrackedActionIds();
-  const entryActions = useTrackedActionIds();
+const normalizeNumberInput = (value: string): string => {
+  return value.trim().replace(/\s/g, "").replace(",", ".");
+};
+
+const parseOptionalNumber = (value: string, label: string): NumberParseResult => {
+  const normalized = normalizeNumberInput(value);
+  if (!normalized) {
+    return { value: null, error: null };
+  }
+
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return { value: null, error: `${label} deve ser maior que zero.` };
+  }
+
+  return { value: parsed, error: null };
+};
+
+const parseOptionalPercent = (value: string): NumberParseResult => {
+  const result = parseOptionalNumber(value, "Percentual");
+  if (result.error || result.value === null) {
+    return result;
+  }
+
+  if (result.value > 100) {
+    return { value: null, error: "Percentual deve ser no maximo 100." };
+  }
+
+  return result;
+};
+
+const parseExpiryHours = (value: string): NumberParseResult => {
+  const result = parseOptionalNumber(value, "Validade");
+  if (result.error || result.value === null) {
+    return result.error ? result : { value: 168, error: null };
+  }
+
+  if (!Number.isInteger(result.value)) {
+    return { value: null, error: "Validade deve ser um numero inteiro de horas." };
+  }
+
+  return result;
+};
+
+interface InvitationCommandResult {
+  readonly command: CreateSharedInvitationCommand | null;
+  readonly error: string | null;
+}
+
+interface InvitationTargetResult {
+  readonly sharedEntryId: string;
+  readonly inviteeEmail: string;
+  readonly error: string | null;
+}
+
+const resolveInvitationTarget = (
+  form: SharedInvitationFormState,
+): InvitationTargetResult => {
+  const sharedEntryId = form.sharedEntryId.trim();
+  if (!sharedEntryId) {
+    return {
+      sharedEntryId: "",
+      inviteeEmail: "",
+      error: "Selecione um compartilhamento ativo para convidar.",
+    };
+  }
+
+  const inviteeEmail = form.inviteeEmail.trim().toLowerCase();
+  if (!inviteeEmail || !inviteeEmail.includes("@")) {
+    return {
+      sharedEntryId,
+      inviteeEmail: "",
+      error: "Informe um email valido para o convite.",
+    };
+  }
+
+  return { sharedEntryId, inviteeEmail, error: null };
+};
+
+const buildCreateInvitationCommand = (
+  form: SharedInvitationFormState,
+): InvitationCommandResult => {
+  const target = resolveInvitationTarget(form);
+  if (target.error) {
+    return { command: null, error: target.error };
+  }
+
+  const shareAmount = parseOptionalNumber(form.shareAmount, "Valor exato");
+  if (shareAmount.error) {
+    return { command: null, error: shareAmount.error };
+  }
+
+  const splitValue = parseOptionalPercent(form.splitValue);
+  if (splitValue.error) {
+    return { command: null, error: splitValue.error };
+  }
+
+  if (shareAmount.value === null && splitValue.value === null) {
+    return {
+      command: null,
+      error: "Informe percentual ou valor exato da parte convidada.",
+    };
+  }
+
+  const expiresInHours = parseExpiryHours(form.expiresInHours);
+  if (expiresInHours.error) {
+    return { command: null, error: expiresInHours.error };
+  }
+
+  const message = form.message.trim();
+
+  return {
+    command: {
+      sharedEntryId: target.sharedEntryId,
+      inviteeEmail: target.inviteeEmail,
+      splitValue: shareAmount.value === null ? splitValue.value : null,
+      shareAmount: shareAmount.value,
+      message: message || null,
+      expiresInHours: expiresInHours.value ?? 168,
+    },
+    error: null,
+  };
+};
+
+interface SharedEntriesQueries {
+  readonly invitationsQuery: ReturnType<typeof useSharedInvitationsQuery>;
+  readonly byMeQuery: ReturnType<typeof useSharedEntriesByMeQuery>;
+  readonly withMeQuery: ReturnType<typeof useSharedEntriesWithMeQuery>;
+}
+
+interface SharedEntriesMutations {
+  readonly createInvitationMutation: ReturnType<typeof useCreateSharedInvitationMutation>;
+  readonly acceptMutation: ReturnType<typeof useAcceptSharedInvitationMutation>;
+  readonly deleteInvitationMutation: ReturnType<typeof useDeleteSharedInvitationMutation>;
+  readonly deleteEntryMutation: ReturnType<typeof useDeleteSharedEntryMutation>;
+}
+
+interface SharedEntriesClassifiedLists {
+  readonly pendingInvitations: readonly InvitationView[];
+  readonly outgoingInvitations: readonly InvitationView[];
+  readonly byMeEntries: readonly EntryView[];
+  readonly withMeEntries: readonly EntryView[];
+  readonly activeByMeEntries: readonly EntryView[];
+  readonly metrics: SharedEntriesMetrics;
+}
+
+interface SharedInvitationFormController {
+  readonly invitationForm: SharedInvitationFormState;
+  readonly invitationFormError: string | null;
+  readonly isCreatingInvitation: boolean;
+  readonly setInvitationFormField: (
+    field: SharedInvitationFormField,
+    value: string,
+  ) => void;
+  readonly selectInvitationEntry: (sharedEntryId: string) => void;
+  readonly handleCreateInvitation: () => Promise<void>;
+}
+
+interface SharedEntriesActionHandlers {
+  readonly handleAccept: (invitation: InvitationView) => Promise<void>;
+  readonly handleReject: (invitation: InvitationView) => Promise<void>;
+  readonly handleRevoke: (entry: EntryView) => Promise<void>;
+  readonly handleRevokeInvitation: (invitation: InvitationView) => Promise<void>;
+}
+
+const useSharedEntriesQueries = (): SharedEntriesQueries => {
+  return {
+    invitationsQuery: useSharedInvitationsQuery(),
+    byMeQuery: useSharedEntriesByMeQuery(),
+    withMeQuery: useSharedEntriesWithMeQuery(),
+  };
+};
+
+const useSharedEntriesMutations = (): SharedEntriesMutations => {
+  return {
+    createInvitationMutation: useCreateSharedInvitationMutation(),
+    acceptMutation: useAcceptSharedInvitationMutation(),
+    deleteInvitationMutation: useDeleteSharedInvitationMutation(),
+    deleteEntryMutation: useDeleteSharedEntryMutation(),
+  };
+};
+
+const useClassifiedSharedEntries = (
+  queries: SharedEntriesQueries,
+  currentUserId: string | null,
+): SharedEntriesClassifiedLists => {
   const pendingInvitations = useMemo(
-    () => sharedEntriesClassifier.pending(invitationsQuery.data?.invitations ?? []),
-    [invitationsQuery.data],
+    () =>
+      sharedEntriesClassifier.incomingPending(
+        queries.invitationsQuery.data?.invitations ?? [],
+        currentUserId,
+      ),
+    [currentUserId, queries.invitationsQuery.data],
+  );
+  const outgoingInvitations = useMemo(
+    () =>
+      sharedEntriesClassifier.outgoing(
+        queries.invitationsQuery.data?.invitations ?? [],
+        currentUserId,
+      ),
+    [currentUserId, queries.invitationsQuery.data],
   );
   const byMeEntries = useMemo(
-    () => sharedEntriesClassifier.entries(byMeQuery.data?.sharedEntries ?? []),
-    [byMeQuery.data],
+    () => sharedEntriesClassifier.entries(queries.byMeQuery.data?.sharedEntries ?? []),
+    [queries.byMeQuery.data],
   );
   const withMeEntries = useMemo(
-    () => sharedEntriesClassifier.entries(withMeQuery.data?.sharedEntries ?? []),
-    [withMeQuery.data],
+    () =>
+      sharedEntriesClassifier.entries(queries.withMeQuery.data?.sharedEntries ?? []),
+    [queries.withMeQuery.data],
+  );
+  const activeByMeEntries = useMemo(
+    () => byMeEntries.filter((entry) => entry.bucket === "active"),
+    [byMeEntries],
   );
   const metrics = useMemo(
     () => buildSharedEntriesMetrics({ pendingInvitations, byMeEntries, withMeEntries }),
     [byMeEntries, pendingInvitations, withMeEntries],
   );
 
+  return {
+    pendingInvitations,
+    outgoingInvitations,
+    byMeEntries,
+    withMeEntries,
+    activeByMeEntries,
+    metrics,
+  };
+};
+
+const useSharedInvitationFormController = ({
+  activeByMeEntries,
+  createInvitationMutation,
+  setLastError,
+}: {
+  readonly activeByMeEntries: readonly EntryView[];
+  readonly createInvitationMutation: ReturnType<typeof useCreateSharedInvitationMutation>;
+  readonly setLastError: (error: unknown) => void;
+}): SharedInvitationFormController => {
+  const [invitationForm, setInvitationForm] = useState<SharedInvitationFormState>(
+    DEFAULT_INVITATION_FORM,
+  );
+  const [invitationFormError, setInvitationFormError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setInvitationForm((current) =>
+      reconcileSelectedInvitationEntry(current, activeByMeEntries),
+    );
+  }, [activeByMeEntries]);
+
+  const setInvitationFormField = (
+    field: SharedInvitationFormField,
+    value: string,
+  ): void => {
+    setInvitationForm((current) => ({ ...current, [field]: value }));
+    setInvitationFormError(null);
+  };
+
+  const selectInvitationEntry = (sharedEntryId: string): void => {
+    setInvitationForm((current) => ({ ...current, sharedEntryId }));
+    setInvitationFormError(null);
+  };
+
+  const handleCreateInvitation = async (): Promise<void> => {
+    const result = buildCreateInvitationCommand(invitationForm);
+    if (result.error || !result.command) {
+      setInvitationFormError(result.error ?? "Nao foi possivel montar o convite.");
+      return;
+    }
+
+    setInvitationFormError(null);
+    try {
+      await createInvitationMutation.mutateAsync(result.command);
+      setInvitationForm((current) => ({
+        ...DEFAULT_INVITATION_FORM,
+        sharedEntryId: current.sharedEntryId,
+      }));
+    } catch (error) {
+      setLastError(error);
+    }
+  };
+
+  return {
+    invitationForm,
+    invitationFormError,
+    isCreatingInvitation: createInvitationMutation.isPending,
+    setInvitationFormField,
+    selectInvitationEntry,
+    handleCreateInvitation,
+  };
+};
+
+const reconcileSelectedInvitationEntry = (
+  current: SharedInvitationFormState,
+  activeByMeEntries: readonly EntryView[],
+): SharedInvitationFormState => {
+  const firstActiveId = activeByMeEntries[0]?.id ?? "";
+  const stillSelectable = activeByMeEntries.some((entry) => {
+    return entry.id === current.sharedEntryId;
+  });
+
+  if (stillSelectable || current.sharedEntryId === firstActiveId) {
+    return current;
+  }
+
+  return { ...current, sharedEntryId: firstActiveId };
+};
+
+const useSharedEntriesActionHandlers = ({
+  acceptMutation,
+  deleteEntryMutation,
+  deleteInvitationMutation,
+  entryActions,
+  invitationActions,
+  setLastError,
+}: {
+  readonly acceptMutation: ReturnType<typeof useAcceptSharedInvitationMutation>;
+  readonly deleteEntryMutation: ReturnType<typeof useDeleteSharedEntryMutation>;
+  readonly deleteInvitationMutation: ReturnType<typeof useDeleteSharedInvitationMutation>;
+  readonly entryActions: TrackedActionIds;
+  readonly invitationActions: TrackedActionIds;
+  readonly setLastError: (error: unknown) => void;
+}): SharedEntriesActionHandlers => {
   const handleAccept = async (invitation: InvitationView): Promise<void> => {
-    const token = invitation.token;
-    if (!token) {
+    if (!invitation.token) {
       setLastError(new Error("Convite sem token de aceite."));
       return;
     }
     await runTrackedAction({
       id: invitation.id,
       actions: invitationActions,
-      action: () => acceptMutation.mutateAsync(token),
+      action: () => acceptMutation.mutateAsync(invitation.token ?? ""),
       setLastError,
     });
   };
 
-  const handleReject = async (invitation: InvitationView): Promise<void> => {
+  const handleInvitationDelete = async (invitation: InvitationView): Promise<void> => {
     await runTrackedAction({
       id: invitation.id,
       actions: invitationActions,
@@ -195,22 +520,60 @@ export function useSharedEntriesScreenController(): SharedEntriesScreenControlle
   };
 
   return {
-    invitationsQuery,
-    byMeQuery,
-    withMeQuery,
-    pendingInvitations,
-    byMeEntries,
-    withMeEntries,
-    tabCounts: metrics.tabCounts,
-    summary: metrics.summary,
+    handleAccept,
+    handleReject: handleInvitationDelete,
+    handleRevoke,
+    handleRevokeInvitation: handleInvitationDelete,
+  };
+};
+
+/**
+ * Coordinates the shared entries screen: 3 queries (invitations, by me, with
+ * me), 3 mutations (accept, reject/delete-invitation, revoke/delete-entry),
+ * tab selection, per-record pending state and error capture.
+ *
+ * Mutations are tracked per record id so multiple actions can run in parallel
+ * without blocking the whole list — only the affected card disables.
+ */
+export function useSharedEntriesScreenController(): SharedEntriesScreenController {
+  const currentUserId = useSessionStore((state) => state.user?.id ?? null);
+  const queries = useSharedEntriesQueries();
+  const mutations = useSharedEntriesMutations();
+  const [selectedTab, setSelectedTab] = useState<SharedEntriesTab>("invitations");
+  const [lastError, setLastError] = useState<unknown | null>(null);
+  const invitationActions = useTrackedActionIds();
+  const entryActions = useTrackedActionIds();
+  const lists = useClassifiedSharedEntries(queries, currentUserId);
+  const formController = useSharedInvitationFormController({
+    activeByMeEntries: lists.activeByMeEntries,
+    createInvitationMutation: mutations.createInvitationMutation,
+    setLastError,
+  });
+  const handlers = useSharedEntriesActionHandlers({
+    ...mutations,
+    entryActions,
+    invitationActions,
+    setLastError,
+  });
+
+  return {
+    invitationsQuery: queries.invitationsQuery,
+    byMeQuery: queries.byMeQuery,
+    withMeQuery: queries.withMeQuery,
+    pendingInvitations: lists.pendingInvitations,
+    byMeEntries: lists.byMeEntries,
+    withMeEntries: lists.withMeEntries,
+    activeByMeEntries: lists.activeByMeEntries,
+    outgoingInvitations: lists.outgoingInvitations,
+    tabCounts: lists.metrics.tabCounts,
+    summary: lists.metrics.summary,
     selectedTab,
     setSelectedTab,
     pendingInvitationIds: invitationActions.ids,
     pendingEntryIds: entryActions.ids,
+    ...formController,
     lastError,
-    handleAccept,
-    handleReject,
-    handleRevoke,
+    ...handlers,
     dismissError: () => setLastError(null),
   };
 }

--- a/features/shared-entries/hooks/use-shared-entries-screen-controller.ts
+++ b/features/shared-entries/hooks/use-shared-entries-screen-controller.ts
@@ -18,6 +18,19 @@ import {
 
 export type SharedEntriesTab = "invitations" | "byMe" | "withMe";
 
+export type SharedEntriesTabCounts = Readonly<Record<SharedEntriesTab, number>>;
+
+export interface SharedEntriesSummary {
+  readonly totalEntries: number;
+  readonly activeEntries: number;
+  readonly pendingInvitations: number;
+}
+
+interface SharedEntriesMetrics {
+  readonly tabCounts: SharedEntriesTabCounts;
+  readonly summary: SharedEntriesSummary;
+}
+
 export interface SharedEntriesScreenController {
   readonly invitationsQuery: ReturnType<typeof useSharedInvitationsQuery>;
   readonly byMeQuery: ReturnType<typeof useSharedEntriesByMeQuery>;
@@ -25,6 +38,8 @@ export interface SharedEntriesScreenController {
   readonly pendingInvitations: readonly InvitationView[];
   readonly byMeEntries: readonly EntryView[];
   readonly withMeEntries: readonly EntryView[];
+  readonly tabCounts: SharedEntriesTabCounts;
+  readonly summary: SharedEntriesSummary;
   readonly selectedTab: SharedEntriesTab;
   readonly setSelectedTab: (tab: SharedEntriesTab) => void;
   readonly pendingInvitationIds: ReadonlySet<string>;
@@ -61,6 +76,55 @@ const useTrackedActionIds = () => {
   return { ids, begin, end };
 };
 
+type TrackedActionIds = ReturnType<typeof useTrackedActionIds>;
+
+interface RunTrackedActionParams {
+  readonly id: string;
+  readonly actions: TrackedActionIds;
+  readonly action: () => Promise<unknown>;
+  readonly setLastError: (error: unknown) => void;
+}
+
+const runTrackedAction = async ({
+  id,
+  actions,
+  action,
+  setLastError,
+}: RunTrackedActionParams): Promise<void> => {
+  actions.begin(id);
+  try {
+    await action();
+  } catch (error) {
+    setLastError(error);
+  } finally {
+    actions.end(id);
+  }
+};
+
+const buildSharedEntriesMetrics = ({
+  pendingInvitations,
+  byMeEntries,
+  withMeEntries,
+}: {
+  readonly pendingInvitations: readonly InvitationView[];
+  readonly byMeEntries: readonly EntryView[];
+  readonly withMeEntries: readonly EntryView[];
+}): SharedEntriesMetrics => {
+  const allEntries = [...byMeEntries, ...withMeEntries];
+  return {
+    tabCounts: {
+      invitations: pendingInvitations.length,
+      byMe: byMeEntries.length,
+      withMe: withMeEntries.length,
+    },
+    summary: {
+      totalEntries: allEntries.length,
+      activeEntries: allEntries.filter((entry) => entry.bucket === "active").length,
+      pendingInvitations: pendingInvitations.length,
+    },
+  };
+};
+
 /**
  * Coordinates the shared entries screen: 3 queries (invitations, by me, with
  * me), 3 mutations (accept, reject/delete-invitation, revoke/delete-entry),
@@ -81,7 +145,6 @@ export function useSharedEntriesScreenController(): SharedEntriesScreenControlle
   const [lastError, setLastError] = useState<unknown | null>(null);
   const invitationActions = useTrackedActionIds();
   const entryActions = useTrackedActionIds();
-
   const pendingInvitations = useMemo(
     () => sharedEntriesClassifier.pending(invitationsQuery.data?.invitations ?? []),
     [invitationsQuery.data],
@@ -94,42 +157,41 @@ export function useSharedEntriesScreenController(): SharedEntriesScreenControlle
     () => sharedEntriesClassifier.entries(withMeQuery.data?.sharedEntries ?? []),
     [withMeQuery.data],
   );
+  const metrics = useMemo(
+    () => buildSharedEntriesMetrics({ pendingInvitations, byMeEntries, withMeEntries }),
+    [byMeEntries, pendingInvitations, withMeEntries],
+  );
 
   const handleAccept = async (invitation: InvitationView): Promise<void> => {
-    if (!invitation.token) {
+    const token = invitation.token;
+    if (!token) {
       setLastError(new Error("Convite sem token de aceite."));
       return;
     }
-    invitationActions.begin(invitation.id);
-    try {
-      await acceptMutation.mutateAsync(invitation.token);
-    } catch (error) {
-      setLastError(error);
-    } finally {
-      invitationActions.end(invitation.id);
-    }
+    await runTrackedAction({
+      id: invitation.id,
+      actions: invitationActions,
+      action: () => acceptMutation.mutateAsync(token),
+      setLastError,
+    });
   };
 
   const handleReject = async (invitation: InvitationView): Promise<void> => {
-    invitationActions.begin(invitation.id);
-    try {
-      await deleteInvitationMutation.mutateAsync(invitation.id);
-    } catch (error) {
-      setLastError(error);
-    } finally {
-      invitationActions.end(invitation.id);
-    }
+    await runTrackedAction({
+      id: invitation.id,
+      actions: invitationActions,
+      action: () => deleteInvitationMutation.mutateAsync(invitation.id),
+      setLastError,
+    });
   };
 
   const handleRevoke = async (entry: EntryView): Promise<void> => {
-    entryActions.begin(entry.id);
-    try {
-      await deleteEntryMutation.mutateAsync(entry.id);
-    } catch (error) {
-      setLastError(error);
-    } finally {
-      entryActions.end(entry.id);
-    }
+    await runTrackedAction({
+      id: entry.id,
+      actions: entryActions,
+      action: () => deleteEntryMutation.mutateAsync(entry.id),
+      setLastError,
+    });
   };
 
   return {
@@ -139,6 +201,8 @@ export function useSharedEntriesScreenController(): SharedEntriesScreenControlle
     pendingInvitations,
     byMeEntries,
     withMeEntries,
+    tabCounts: metrics.tabCounts,
+    summary: metrics.summary,
     selectedTab,
     setSelectedTab,
     pendingInvitationIds: invitationActions.ids,

--- a/features/shared-entries/screens/shared-entries-screen.test.tsx
+++ b/features/shared-entries/screens/shared-entries-screen.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 import type { ReactNode } from "react";
 
 import { AppProviders } from "@/core/providers/app-providers";
@@ -55,6 +55,16 @@ const buildController = (
     pendingInvitations: [],
     byMeEntries: [],
     withMeEntries: [],
+    tabCounts: {
+      invitations: 0,
+      byMe: 0,
+      withMe: 0,
+    },
+    summary: {
+      totalEntries: 0,
+      activeEntries: 0,
+      pendingInvitations: 0,
+    },
     selectedTab: "invitations",
     setSelectedTab: jest.fn(),
     pendingInvitationIds: new Set<string>(),
@@ -87,6 +97,42 @@ describe("SharedEntriesScreen", () => {
     const { getByTestId, getByText } = renderWithProviders(buildController());
 
     expect(getByTestId("paywall-shared_entries")).toBeTruthy();
-    expect(getByText("Convites")).toBeTruthy();
+    expect(getByText("Convites (0)")).toBeTruthy();
+  });
+
+  it("renderiza resumo mobile e contadores por tab", () => {
+    const { getByTestId, getByText } = renderWithProviders(
+      buildController({
+        tabCounts: {
+          invitations: 1,
+          byMe: 1,
+          withMe: 2,
+        },
+        summary: {
+          totalEntries: 3,
+          activeEntries: 2,
+          pendingInvitations: 1,
+        },
+      }),
+    );
+
+    expect(getByTestId("shared-entries-summary-total")).toHaveTextContent("3");
+    expect(getByTestId("shared-entries-summary-active")).toHaveTextContent("2");
+    expect(getByTestId("shared-entries-summary-invitations")).toHaveTextContent(
+      "1",
+    );
+    expect(getByText("Compartilhei (1)")).toBeTruthy();
+    expect(getByText("Recebi (2)")).toBeTruthy();
+  });
+
+  it("aciona tabs visuais com ids estaveis", () => {
+    const setSelectedTab = jest.fn();
+    const { getByTestId } = renderWithProviders(
+      buildController({ setSelectedTab }),
+    );
+
+    fireEvent.press(getByTestId("shared-entries-tab-byMe"));
+
+    expect(setSelectedTab).toHaveBeenCalledWith("byMe");
   });
 });

--- a/features/shared-entries/screens/shared-entries-screen.test.tsx
+++ b/features/shared-entries/screens/shared-entries-screen.test.tsx
@@ -34,9 +34,9 @@ jest.mock("@/features/entitlements/components/paywall-gate", () => {
 
 const mockedUseController = jest.mocked(useSharedEntriesScreenController);
 
-const buildQuery = () =>
+const buildQuery = (data: unknown = null) =>
   ({
-    data: null,
+    data,
     isLoading: false,
     isFetching: false,
     isSuccess: true,
@@ -55,6 +55,8 @@ const buildController = (
     pendingInvitations: [],
     byMeEntries: [],
     withMeEntries: [],
+    activeByMeEntries: [],
+    outgoingInvitations: [],
     tabCounts: {
       invitations: 0,
       byMe: 0,
@@ -69,10 +71,24 @@ const buildController = (
     setSelectedTab: jest.fn(),
     pendingInvitationIds: new Set<string>(),
     pendingEntryIds: new Set<string>(),
+    invitationForm: {
+      sharedEntryId: "",
+      inviteeEmail: "",
+      splitValue: "50",
+      shareAmount: "",
+      message: "",
+      expiresInHours: "168",
+    },
+    invitationFormError: null,
+    isCreatingInvitation: false,
     lastError: null,
+    setInvitationFormField: jest.fn(),
+    selectInvitationEntry: jest.fn(),
+    handleCreateInvitation: jest.fn().mockResolvedValue(undefined),
     handleAccept: jest.fn().mockResolvedValue(undefined),
     handleReject: jest.fn().mockResolvedValue(undefined),
     handleRevoke: jest.fn().mockResolvedValue(undefined),
+    handleRevokeInvitation: jest.fn().mockResolvedValue(undefined),
     dismissError: jest.fn(),
     ...overrides,
   }) as never;
@@ -134,5 +150,101 @@ describe("SharedEntriesScreen", () => {
     fireEvent.press(getByTestId("shared-entries-tab-byMe"));
 
     expect(setSelectedTab).toHaveBeenCalledWith("byMe");
+  });
+
+  it("renderiza composer e convites enviados na aba Compartilhei", () => {
+    const setInvitationFormField = jest.fn();
+    const handleCreateInvitation = jest.fn().mockResolvedValue(undefined);
+    const handleRevokeInvitation = jest.fn().mockResolvedValue(undefined);
+    const { getByPlaceholderText, getByTestId, getByText } = renderWithProviders(
+      buildController({
+        selectedTab: "byMe",
+        byMeQuery: buildQuery({ sharedEntries: [] }),
+        invitationsQuery: buildQuery({ invitations: [] }),
+        byMeEntries: [
+          {
+            id: "se-1",
+            ownerId: "current-user",
+            transactionId: "tx-1",
+            status: "active",
+            splitType: "equal",
+            transactionTitle: "Aluguel",
+            transactionAmount: 2000,
+            myShare: 1000,
+            otherPartyEmail: "partner@example.com",
+            createdAt: "2026-04-01T00:00:00Z",
+            updatedAt: "2026-04-01T00:00:00Z",
+            bucket: "active",
+            amountLabel: "R$ 2.000,00",
+            myShareLabel: "R$ 1.000,00",
+          },
+        ],
+        activeByMeEntries: [
+          {
+            id: "se-1",
+            ownerId: "current-user",
+            transactionId: "tx-1",
+            status: "active",
+            splitType: "equal",
+            transactionTitle: "Aluguel",
+            transactionAmount: 2000,
+            myShare: 1000,
+            otherPartyEmail: "partner@example.com",
+            createdAt: "2026-04-01T00:00:00Z",
+            updatedAt: "2026-04-01T00:00:00Z",
+            bucket: "active",
+            amountLabel: "R$ 2.000,00",
+            myShareLabel: "R$ 1.000,00",
+          },
+        ],
+        outgoingInvitations: [
+          {
+            id: "inv-out-1",
+            sharedEntryId: "se-1",
+            fromUserId: "current-user",
+            toUserEmail: "partner@example.com",
+            toUserId: null,
+            splitValue: 50,
+            shareAmount: null,
+            message: "Aluguel",
+            status: "pending",
+            token: "token",
+            expiresAt: new Date(Date.now() + 86_400_000).toISOString(),
+            createdAt: "2026-04-01T00:00:00Z",
+            respondedAt: null,
+            bucket: "pending",
+            isExpired: false,
+            shareLabel: "Sua parte: 50%",
+          },
+        ],
+        invitationForm: {
+          sharedEntryId: "se-1",
+          inviteeEmail: "",
+          splitValue: "50",
+          shareAmount: "",
+          message: "",
+          expiresInHours: "168",
+        },
+        setInvitationFormField,
+        handleCreateInvitation,
+        handleRevokeInvitation,
+      }),
+    );
+
+    fireEvent.changeText(
+      getByPlaceholderText("email@exemplo.com"),
+      "partner@example.com",
+    );
+    fireEvent.press(getByTestId("shared-invitation-create"));
+    fireEvent.press(getByTestId("outgoing-invitation-inv-out-1-revoke"));
+
+    expect(getByText("Novo convite")).toBeTruthy();
+    expect(getByText("Convites enviados")).toBeTruthy();
+    expect(setInvitationFormField).toHaveBeenCalledWith(
+      "inviteeEmail",
+      "partner@example.com",
+    );
+    expect(handleCreateInvitation).toHaveBeenCalledTimes(1);
+    expect(handleRevokeInvitation).toHaveBeenCalledTimes(1);
   });
 });

--- a/features/shared-entries/screens/shared-entries-screen.tsx
+++ b/features/shared-entries/screens/shared-entries-screen.tsx
@@ -35,6 +35,7 @@ export function SharedEntriesScreen(): ReactElement {
   return (
     <PaywallGate featureKey="shared_entries">
       <AppScreen>
+        <SharedEntriesSummaryCard controller={controller} />
         <TabSelector controller={controller} />
         {controller.lastError ? (
           <AppErrorNotice
@@ -66,16 +67,71 @@ interface ControllerProps {
 function TabSelector({ controller }: ControllerProps): ReactElement {
   return (
     <XStack gap="$2" flexWrap="wrap">
-      {TAB_ORDER.map((tab) => (
-        <AppButton
-          key={tab}
-          tone={controller.selectedTab === tab ? "primary" : "secondary"}
-          onPress={() => controller.setSelectedTab(tab)}
-        >
-          {TAB_LABELS[tab]}
-        </AppButton>
-      ))}
+      {TAB_ORDER.map((tab) => {
+        const label = `${TAB_LABELS[tab]} (${controller.tabCounts[tab]})`;
+        return (
+          <AppButton
+            key={tab}
+            tone={controller.selectedTab === tab ? "primary" : "secondary"}
+            onPress={() => controller.setSelectedTab(tab)}
+            testID={`shared-entries-tab-${tab}`}
+            accessibilityLabel={label}
+            accessibilityState={{ selected: controller.selectedTab === tab }}
+          >
+            {label}
+          </AppButton>
+        );
+      })}
     </XStack>
+  );
+}
+
+function SharedEntriesSummaryCard({ controller }: ControllerProps): ReactElement {
+  return (
+    <AppSurfaceCard title="Resumo">
+      <XStack gap="$3" flexWrap="wrap">
+        <SummaryMetric
+          label="Total"
+          value={controller.summary.totalEntries}
+          testID="shared-entries-summary-total"
+        />
+        <SummaryMetric
+          label="Ativos"
+          value={controller.summary.activeEntries}
+          testID="shared-entries-summary-active"
+        />
+        <SummaryMetric
+          label="Convites"
+          value={controller.summary.pendingInvitations}
+          testID="shared-entries-summary-invitations"
+        />
+      </XStack>
+    </AppSurfaceCard>
+  );
+}
+
+interface SummaryMetricProps {
+  readonly label: string;
+  readonly value: number;
+  readonly testID: string;
+}
+
+function SummaryMetric({ label, value, testID }: SummaryMetricProps): ReactElement {
+  return (
+    <YStack flex={1} minWidth={96} gap="$1">
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+        {label}
+      </Paragraph>
+      <Paragraph
+        color="$color"
+        fontFamily="$body"
+        fontSize="$7"
+        fontWeight="$7"
+        testID={testID}
+      >
+        {value}
+      </Paragraph>
+    </YStack>
   );
 }
 

--- a/features/shared-entries/screens/shared-entries-screen.tsx
+++ b/features/shared-entries/screens/shared-entries-screen.tsx
@@ -10,8 +10,11 @@ import {
   type SharedEntriesScreenController,
   type SharedEntriesTab,
 } from "@/features/shared-entries/hooks/use-shared-entries-screen-controller";
+import type { InvitationView } from "@/features/shared-entries/services/shared-entries-classifier";
+import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppInputField } from "@/shared/components/app-input-field";
 import { AppQueryState } from "@/shared/components/app-query-state";
 import { AppScreen } from "@/shared/components/app-screen";
 import { AppSurfaceCard } from "@/shared/components/app-surface-card";
@@ -184,6 +187,173 @@ function InvitationsTab({ controller }: ControllerProps): ReactElement {
 
 function ByMeTab({ controller }: ControllerProps): ReactElement {
   return (
+    <YStack gap="$3">
+      <InvitationComposer controller={controller} />
+      <SharedByMeEntriesList controller={controller} />
+      <OutgoingInvitationsList controller={controller} />
+    </YStack>
+  );
+}
+
+function InvitationComposer({ controller }: ControllerProps): ReactElement {
+  return (
+    <AppSurfaceCard
+      title="Novo convite"
+      description="Convide alguem para participar de um compartilhamento ativo."
+    >
+      <AppQueryState
+        query={controller.byMeQuery}
+        options={{
+          loading: {
+            title: "Carregando compartilhamentos",
+            description: "Buscando compartilhamentos disponiveis.",
+          },
+          empty: {
+            title: "Nenhum compartilhamento ativo",
+            description: "Crie um compartilhamento antes de enviar convites.",
+          },
+          error: {
+            fallbackTitle: "Nao foi possivel carregar a lista",
+            fallbackDescription: "Tente novamente em instantes.",
+          },
+          isEmpty: () => controller.activeByMeEntries.length === 0,
+        }}
+      >
+        {() => <InvitationComposerForm controller={controller} />}
+      </AppQueryState>
+    </AppSurfaceCard>
+  );
+}
+
+function InvitationComposerForm({ controller }: ControllerProps): ReactElement {
+  return (
+    <YStack gap="$3">
+      <InvitationEntrySelector controller={controller} />
+      <InvitationFormFields controller={controller} />
+      <InvitationComposerSubmit controller={controller} />
+    </YStack>
+  );
+}
+
+function InvitationEntrySelector({ controller }: ControllerProps): ReactElement {
+  return (
+    <YStack gap="$2">
+      <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+        Compartilhamento
+      </Paragraph>
+      <XStack gap="$2" flexWrap="wrap">
+        {controller.activeByMeEntries.map((entry) => (
+          <AppButton
+            key={entry.id}
+            size="sm"
+            tone={
+              controller.invitationForm.sharedEntryId === entry.id
+                ? "primary"
+                : "secondary"
+            }
+            onPress={() => controller.selectInvitationEntry(entry.id)}
+            testID={`shared-invitation-entry-${entry.id}`}
+          >
+            {entry.transactionTitle ?? "Lancamento"}
+          </AppButton>
+        ))}
+      </XStack>
+    </YStack>
+  );
+}
+
+function InvitationFormFields({ controller }: ControllerProps): ReactElement {
+  return (
+    <>
+      <AppInputField
+        id="shared-invitation-email"
+        label="Email do convidado"
+        placeholder="email@exemplo.com"
+        value={controller.invitationForm.inviteeEmail}
+        onChangeText={(value) =>
+          controller.setInvitationFormField("inviteeEmail", value)
+        }
+        keyboardType="email-address"
+        autoCapitalize="none"
+        autoCorrect={false}
+        textContentType="emailAddress"
+      />
+      <AppInputField
+        id="shared-invitation-percent"
+        label="Percentual"
+        helperText="Use o valor exato abaixo se nao quiser enviar percentual."
+        placeholder="50"
+        value={controller.invitationForm.splitValue}
+        onChangeText={(value) =>
+          controller.setInvitationFormField("splitValue", value)
+        }
+        keyboardType="decimal-pad"
+      />
+      <AppInputField
+        id="shared-invitation-amount"
+        label="Valor exato"
+        placeholder="0,00"
+        value={controller.invitationForm.shareAmount}
+        onChangeText={(value) =>
+          controller.setInvitationFormField("shareAmount", value)
+        }
+        keyboardType="decimal-pad"
+      />
+      <AppInputField
+        id="shared-invitation-message"
+        label="Mensagem"
+        placeholder="Opcional"
+        value={controller.invitationForm.message}
+        onChangeText={(value) => controller.setInvitationFormField("message", value)}
+        multiline
+        height={84}
+      />
+      <AppInputField
+        id="shared-invitation-expires"
+        label="Validade em horas"
+        placeholder="168"
+        value={controller.invitationForm.expiresInHours}
+        onChangeText={(value) =>
+          controller.setInvitationFormField("expiresInHours", value)
+        }
+        keyboardType="number-pad"
+      />
+    </>
+  );
+}
+
+function InvitationComposerSubmit({ controller }: ControllerProps): ReactElement {
+  return (
+    <>
+      <InvitationFormErrorMessage controller={controller} />
+      <AppButton
+        onPress={() => {
+          void controller.handleCreateInvitation();
+        }}
+        disabled={controller.isCreatingInvitation}
+        fullWidth
+        testID="shared-invitation-create"
+      >
+        {controller.isCreatingInvitation ? "Enviando..." : "Enviar convite"}
+      </AppButton>
+    </>
+  );
+}
+
+function InvitationFormErrorMessage({ controller }: ControllerProps): ReactElement | null {
+  if (!controller.invitationFormError) {
+    return null;
+  }
+
+  return (
+    <Paragraph color="$danger" fontFamily="$body" fontSize="$2">
+      {controller.invitationFormError}
+    </Paragraph>
+  );
+}
+
+function SharedByMeEntriesList({ controller }: ControllerProps): ReactElement {
+  return (
     <AppSurfaceCard
       title="Compartilhei"
       description="Compartilhamentos que voce iniciou."
@@ -223,6 +393,120 @@ function ByMeTab({ controller }: ControllerProps): ReactElement {
           </YStack>
         )}
       </AppQueryState>
+    </AppSurfaceCard>
+  );
+}
+
+function OutgoingInvitationsList({ controller }: ControllerProps): ReactElement {
+  return (
+    <AppSurfaceCard
+      title="Convites enviados"
+      description="Acompanhe e revogue convites que ainda estao pendentes."
+    >
+      <AppQueryState
+        query={controller.invitationsQuery}
+        options={{
+          loading: {
+            title: "Carregando convites enviados",
+            description: "Buscando convites recentes.",
+          },
+          empty: {
+            title: "Nenhum convite enviado",
+            description: "Convites enviados para seus compartilhamentos aparecerao aqui.",
+          },
+          error: {
+            fallbackTitle: "Nao foi possivel carregar os convites",
+            fallbackDescription: "Tente novamente em instantes.",
+          },
+          isEmpty: () => controller.outgoingInvitations.length === 0,
+        }}
+      >
+        {() => (
+          <YStack gap="$3">
+            {controller.outgoingInvitations.map((invitation) => (
+              <OutgoingInvitationCard
+                key={invitation.id}
+                invitation={invitation}
+                onRevoke={() => {
+                  void controller.handleRevokeInvitation(invitation);
+                }}
+                isPending={controller.pendingInvitationIds.has(invitation.id)}
+                testID={`outgoing-invitation-${invitation.id}`}
+              />
+            ))}
+          </YStack>
+        )}
+      </AppQueryState>
+    </AppSurfaceCard>
+  );
+}
+
+interface OutgoingInvitationCardProps {
+  readonly invitation: InvitationView;
+  readonly onRevoke: () => void;
+  readonly isPending: boolean;
+  readonly testID: string;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  accepted: "Aceito",
+  canceled: "Cancelado",
+  expired: "Expirado",
+  pending: "Pendente",
+  rejected: "Recusado",
+  revoked: "Revogado",
+};
+
+function resolveOutgoingStatus(invitation: InvitationView): string {
+  if (invitation.isExpired && invitation.bucket === "pending") {
+    return "Expirado";
+  }
+
+  return STATUS_LABELS[invitation.status] ?? invitation.status;
+}
+
+function OutgoingInvitationCard({
+  invitation,
+  onRevoke,
+  isPending,
+  testID,
+}: OutgoingInvitationCardProps): ReactElement {
+  const canRevoke = invitation.bucket === "pending" && !invitation.isExpired;
+
+  return (
+    <AppSurfaceCard
+      title={invitation.toUserEmail}
+      description={invitation.message ?? "Convite enviado para compartilhamento."}
+      testID={testID}
+    >
+      <YStack gap="$3">
+        <XStack gap="$2" alignItems="center" flexWrap="wrap">
+          <AppBadge tone={canRevoke ? "primary" : "default"}>
+            {resolveOutgoingStatus(invitation)}
+          </AppBadge>
+          {invitation.shareLabel ? (
+            <AppBadge tone="default">{invitation.shareLabel}</AppBadge>
+          ) : null}
+        </XStack>
+        <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+          Enviado em {new Date(invitation.createdAt).toLocaleDateString("pt-BR")}
+        </Paragraph>
+        {invitation.expiresAt ? (
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$2">
+            Expira em {new Date(invitation.expiresAt).toLocaleString("pt-BR")}
+          </Paragraph>
+        ) : null}
+        {canRevoke ? (
+          <AppButton
+            tone="secondary"
+            onPress={onRevoke}
+            disabled={isPending}
+            testID={`${testID}-revoke`}
+          >
+            {isPending ? "Revogando..." : "Revogar convite"}
+          </AppButton>
+        ) : null}
+      </YStack>
     </AppSurfaceCard>
   );
 }

--- a/features/shared-entries/services/shared-entries-classifier.test.ts
+++ b/features/shared-entries/services/shared-entries-classifier.test.ts
@@ -112,6 +112,30 @@ describe("SharedEntriesClassifier shortcuts", () => {
     expect(result).toHaveLength(1);
   });
 
+  it("incomingPending() remove convites enviados pelo usuario atual", () => {
+    const result = sharedEntriesClassifier.incomingPending(
+      [
+        buildInvitation({ id: "received", fromUserId: "other-user" }),
+        buildInvitation({ id: "sent", fromUserId: "current-user" }),
+      ],
+      "current-user",
+    );
+
+    expect(result.map((invitation) => invitation.id)).toEqual(["received"]);
+  });
+
+  it("outgoing() lista convites enviados pelo usuario atual", () => {
+    const result = sharedEntriesClassifier.outgoing(
+      [
+        buildInvitation({ id: "sent", fromUserId: "current-user" }),
+        buildInvitation({ id: "received", fromUserId: "other-user" }),
+      ],
+      "current-user",
+    );
+
+    expect(result.map((invitation) => invitation.id)).toEqual(["sent"]);
+  });
+
   it("active() filtra apenas ativos", () => {
     const result = sharedEntriesClassifier.active([
       buildEntry({ status: "active" }),

--- a/features/shared-entries/services/shared-entries-classifier.ts
+++ b/features/shared-entries/services/shared-entries-classifier.ts
@@ -108,6 +108,28 @@ export class SharedEntriesClassifier {
     });
   }
 
+  incomingPending(
+    records: readonly SharedInvitationRecord[],
+    currentUserId: string | null,
+  ): readonly InvitationView[] {
+    return this.pending(records).filter((invitation) => {
+      return currentUserId ? invitation.fromUserId !== currentUserId : true;
+    });
+  }
+
+  outgoing(
+    records: readonly SharedInvitationRecord[],
+    currentUserId: string | null,
+  ): readonly InvitationView[] {
+    if (!currentUserId) {
+      return [];
+    }
+
+    return this.invitations(records).filter((invitation) => {
+      return invitation.fromUserId === currentUserId;
+    });
+  }
+
   active(records: readonly SharedEntryRecord[]): readonly EntryView[] {
     return this.entries(records).filter((entry) => entry.bucket === "active");
   }


### PR DESCRIPTION
Closes #506
Closes #499

## Summary
- Adds derived shared-entries tab counts and mobile summary metrics to the screen controller.
- Renders a `Resumo` surface plus counted `Convites`, `Compartilhei` and `Recebi` tabs so by-me/with-me parity is visible on mobile.
- Adds outgoing sharing parity for issue #499: incoming pending invitations are separated from invitations sent by the current user, `Compartilhei` now has a mobile invite composer, sent-invitation list and pending invite revocation.
- Documents the shared-entries app architecture/data flow and both implementation plans used for this PR.

## Validation
- `npm test -- --runTestsByPath features/shared-entries/services/shared-entries-classifier.test.ts features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx features/shared-entries/screens/shared-entries-screen.test.tsx` — 27 tests passed
- `npx eslint --fix --max-warnings 0 --no-warn-ignored features/shared-entries/hooks/use-shared-entries-screen-controller.test.tsx features/shared-entries/hooks/use-shared-entries-screen-controller.ts features/shared-entries/screens/shared-entries-screen.test.tsx features/shared-entries/screens/shared-entries-screen.tsx features/shared-entries/services/shared-entries-classifier.test.ts features/shared-entries/services/shared-entries-classifier.ts`
- `npm run typecheck`
- `npm run quality-check` — 419 suites / 2737 tests passed
- Commit hook — gitleaks, governance and lint-staged passed
- Pre-push hook — policy, contracts, TypeScript, critical audit and coverage passed; Maestro skipped because `RUN_E2E=1` was not set

## Screenshots
- Not attached: this environment does not have a mobile simulator, and Expo web cannot render `/compartilhamentos` with real authenticated sharing data without adding mock-only routes outside this issue scope. The visual/mobile changes are covered by render tests asserting the summary values, counted tab labels, outgoing composer actions and sent-invitation revoke action IDs.
