### PR TITLE
feat(shell): splash animada premium no boot

### DIFF
--- a/core/shell/animated-splash.test.tsx
+++ b/core/shell/animated-splash.test.tsx
@@ -1,0 +1,47 @@
+import { render } from "@testing-library/react-native";
+import * as SplashScreen from "expo-splash-screen";
+
+import { AnimatedSplash } from "@/core/shell/animated-splash";
+import { useAppShellStore } from "@/core/shell/app-shell-store";
+import { SPLASH_WORDMARK } from "@/core/shell/splash-scene";
+
+jest.mock("expo-splash-screen", () => ({
+  hideAsync: jest.fn().mockResolvedValue(undefined),
+  preventAutoHideAsync: jest.fn().mockResolvedValue(undefined),
+}));
+
+describe("AnimatedSplash", () => {
+  beforeEach(() => {
+    useAppShellStore.setState({
+      reducedMotionEnabled: false,
+      themePreference: "light",
+    });
+  });
+
+  it("encena a marca (aura, logo e wordmark) enquanto visivel", () => {
+    const { getByTestId } = render(<AnimatedSplash startupReady={false} />);
+
+    expect(getByTestId("animated-splash")).toBeTruthy();
+    expect(getByTestId("splash-aura")).toBeTruthy();
+    expect(getByTestId("splash-logo")).toBeTruthy();
+
+    const wordmark = getByTestId("splash-wordmark");
+    // Uma letra (Animated.Text) por caractere da marca.
+    expect(wordmark.children).toHaveLength(SPLASH_WORDMARK.length);
+  });
+
+  it("renderiza a cena em repouso com reduced motion", () => {
+    useAppShellStore.setState({ reducedMotionEnabled: true });
+
+    const { getByTestId } = render(<AnimatedSplash startupReady={false} />);
+
+    expect(getByTestId("animated-splash")).toBeTruthy();
+    expect(getByTestId("splash-logo")).toBeTruthy();
+    expect(getByTestId("splash-wordmark")).toBeTruthy();
+  });
+
+  it("aciona o hide do splash nativo ao montar", () => {
+    render(<AnimatedSplash startupReady={false} />);
+    expect(SplashScreen.hideAsync as jest.Mock).toHaveBeenCalled();
+  });
+});

--- a/core/shell/animated-splash.tsx
+++ b/core/shell/animated-splash.tsx
@@ -1,28 +1,53 @@
-import { useEffect, type ReactElement } from "react";
+import { useEffect, useMemo, type ReactElement } from "react";
 
 import * as SplashScreen from "expo-splash-screen";
-import { StyleSheet, type StyleProp, type ViewStyle } from "react-native";
+import {
+  StyleSheet,
+  useWindowDimensions,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from "react-native";
 import Animated, {
   Easing,
   useAnimatedStyle,
   useSharedValue,
+  withDelay,
   withRepeat,
   withSequence,
   withTiming,
 } from "react-native-reanimated";
+import Svg, { Circle, Defs, RadialGradient, Stop } from "react-native-svg";
 
+import { typography } from "@/config/design-tokens";
 import { useAppShellStore } from "@/core/shell/app-shell-store";
 import {
   SPLASH_FADE_DURATION_MS,
   useAnimatedSplashController,
 } from "@/core/shell/use-animated-splash-controller";
 import { useResolvedTheme } from "@/core/shell/use-resolved-theme";
+import {
+  SPLASH_PARTICLE_COUNT,
+  SPLASH_WORDMARK,
+  buildSplashParticles,
+  wordmarkLetterDelay,
+  type SplashParticle,
+} from "@/core/shell/splash-scene";
+import { AppGradient } from "@/shared/components/app-gradient";
 import { AppImage } from "@/shared/components/app-image";
 import { darkSemanticColors, lightSemanticColors } from "@/shared/theme";
 
-const ICON_SIZE = 112;
-const PULSE_SCALE = 1.08;
-const PULSE_DURATION_MS = 700;
+const ICON_SIZE = 116;
+const AURA_SIZE = 320;
+const LOGO_ENTER_DURATION_MS = 620;
+const LOGO_ENTER_DELAY_MS = 80;
+const LOGO_SETTLE_DURATION_MS = 220;
+const AURA_BREATHE_DURATION_MS = 1800;
+const SHIMMER_DURATION_MS = 1200;
+const WORDMARK_ENTER_DURATION_MS = 460;
+
+/** Curva "emphasized" (Material) para entradas expressivas. */
+const EMPHASIZED = Easing.bezier(0.16, 1, 0.3, 1);
 
 const splashIcon = require("../../assets/images/splash-icon.png");
 
@@ -31,46 +56,285 @@ export interface AnimatedSplashProps {
 }
 
 /**
- * Overlay de splash animado (F3 — épico #540): assume o lugar do splash
- * nativo no primeiro frame JS, pulsa o monograma enquanto fontes/sessão
- * carregam e faz fade-out quando o app está pronto. A logo final
- * substitui `assets/images/splash-icon.png` quando a arte chegar.
+ * Glow radial (a "aura" da marca) que pulsa suavemente atrás da logo. Usa um
+ * `RadialGradient` do SVG (cor da marca → transparente); a respiração é feita no
+ * `Animated.View` que o envolve, evitando animar atributos do SVG.
  */
-export function AnimatedSplash({ startupReady }: AnimatedSplashProps): ReactElement | null {
+function AuraGlow({
+  color,
+  reduced,
+}: {
+  readonly color: string;
+  readonly reduced: boolean;
+}): ReactElement {
+  const scale = useSharedValue(reduced ? 1 : 0.9);
+  const opacity = useSharedValue(reduced ? 0.5 : 0.35);
+
+  useEffect(() => {
+    if (reduced) {
+      return;
+    }
+    scale.value = withRepeat(
+      withTiming(1.12, {
+        duration: AURA_BREATHE_DURATION_MS,
+        easing: Easing.inOut(Easing.quad),
+      }),
+      -1,
+      true,
+    );
+    opacity.value = withRepeat(
+      withTiming(0.6, {
+        duration: AURA_BREATHE_DURATION_MS,
+        easing: Easing.inOut(Easing.quad),
+      }),
+      -1,
+      true,
+    );
+  }, [opacity, reduced, scale]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+
+  return (
+    <Animated.View
+      testID="splash-aura"
+      pointerEvents="none"
+      style={[styles.auraContainer, style] as StyleProp<ViewStyle>}
+    >
+      <Svg width={AURA_SIZE} height={AURA_SIZE}>
+        <Defs>
+          <RadialGradient id="auraGrad" cx="50%" cy="50%" r="50%">
+            <Stop offset="0%" stopColor={color} stopOpacity={0.55} />
+            <Stop offset="70%" stopColor={color} stopOpacity={0.12} />
+            <Stop offset="100%" stopColor={color} stopOpacity={0} />
+          </RadialGradient>
+        </Defs>
+        <Circle
+          cx={AURA_SIZE / 2}
+          cy={AURA_SIZE / 2}
+          r={AURA_SIZE / 2}
+          fill="url(#auraGrad)"
+        />
+      </Svg>
+    </Animated.View>
+  );
+}
+
+/**
+ * "Mote" de luz que sobe e some em loop, com atraso/duração próprios. Em
+ * "reduzir movimento" fica estático numa opacidade discreta.
+ */
+function DriftParticle({
+  particle,
+  color,
+  reduced,
+}: {
+  readonly particle: SplashParticle;
+  readonly color: string;
+  readonly reduced: boolean;
+}): ReactElement {
+  const progress = useSharedValue(reduced ? 1 : 0);
+
+  useEffect(() => {
+    if (reduced) {
+      return;
+    }
+    progress.value = withDelay(
+      particle.delayMs,
+      withRepeat(
+        withTiming(1, {
+          duration: particle.durationMs,
+          easing: Easing.inOut(Easing.quad),
+        }),
+        -1,
+        false,
+      ),
+    );
+  }, [particle.delayMs, particle.durationMs, progress, reduced]);
+
+  const style = useAnimatedStyle(() => {
+    if (reduced) {
+      return { opacity: particle.maxOpacity * 0.5, transform: [{ translateY: 0 }] };
+    }
+    const p = progress.value;
+    return {
+      opacity: Math.sin(p * Math.PI) * particle.maxOpacity,
+      transform: [{ translateY: -p * particle.driftY }],
+    };
+  });
+
+  return (
+    <Animated.View
+      pointerEvents="none"
+      style={
+        [
+          {
+            position: "absolute",
+            left: particle.x,
+            top: particle.y,
+            width: particle.size,
+            height: particle.size,
+            borderRadius: particle.size / 2,
+            backgroundColor: color,
+          },
+          style,
+        ] as StyleProp<ViewStyle>
+      }
+    />
+  );
+}
+
+/**
+ * Logo da marca com entrada (fade + scale com leve overshoot) e um brilho
+ * ("shimmer") diagonal que cruza a arte uma vez após ela assentar.
+ */
+function LogoMark({ reduced }: { readonly reduced: boolean }): ReactElement {
+  const scale = useSharedValue(reduced ? 1 : 0.82);
+  const opacity = useSharedValue(reduced ? 1 : 0);
+  const shimmerX = useSharedValue(-ICON_SIZE);
+
+  useEffect(() => {
+    if (reduced) {
+      return;
+    }
+    opacity.value = withDelay(
+      LOGO_ENTER_DELAY_MS,
+      withTiming(1, { duration: LOGO_ENTER_DURATION_MS, easing: EMPHASIZED }),
+    );
+    scale.value = withDelay(
+      LOGO_ENTER_DELAY_MS,
+      withSequence(
+        withTiming(1.04, { duration: LOGO_ENTER_DURATION_MS, easing: EMPHASIZED }),
+        withTiming(1, {
+          duration: LOGO_SETTLE_DURATION_MS,
+          easing: Easing.out(Easing.quad),
+        }),
+      ),
+    );
+    shimmerX.value = withDelay(
+      LOGO_ENTER_DELAY_MS + LOGO_ENTER_DURATION_MS,
+      withRepeat(
+        withTiming(ICON_SIZE, {
+          duration: SHIMMER_DURATION_MS,
+          easing: Easing.inOut(Easing.quad),
+        }),
+        2,
+        false,
+      ),
+    );
+  }, [opacity, reduced, scale, shimmerX]);
+
+  const logoStyle = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ scale: scale.value }],
+  }));
+  const shimmerStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: shimmerX.value }, { rotate: "18deg" }],
+  }));
+
+  return (
+    <Animated.View
+      testID="splash-logo"
+      style={[styles.logoContainer, logoStyle] as StyleProp<ViewStyle>}
+    >
+      <AppImage
+        source={splashIcon}
+        style={styles.logo}
+        contentFit="contain"
+        fade={false}
+      />
+      {!reduced && (
+        <Animated.View
+          pointerEvents="none"
+          style={[styles.shimmer, shimmerStyle] as StyleProp<ViewStyle>}
+        >
+          <AppGradient
+            colors={[
+              "rgba(255,255,255,0)",
+              "rgba(255,255,255,0.35)",
+              "rgba(255,255,255,0)",
+            ]}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 0 }}
+            style={styles.shimmerBand}
+          />
+        </Animated.View>
+      )}
+    </Animated.View>
+  );
+}
+
+/** Uma letra do wordmark, com reveal em cascata (fade + subida). */
+function WordmarkLetter({
+  char,
+  index,
+  color,
+  reduced,
+}: {
+  readonly char: string;
+  readonly index: number;
+  readonly color: string;
+  readonly reduced: boolean;
+}): ReactElement {
+  const opacity = useSharedValue(reduced ? 1 : 0);
+  const translateY = useSharedValue(reduced ? 0 : 10);
+
+  useEffect(() => {
+    if (reduced) {
+      return;
+    }
+    const delay = wordmarkLetterDelay(index);
+    opacity.value = withDelay(
+      delay,
+      withTiming(1, { duration: WORDMARK_ENTER_DURATION_MS, easing: EMPHASIZED }),
+    );
+    translateY.value = withDelay(
+      delay,
+      withTiming(0, { duration: WORDMARK_ENTER_DURATION_MS, easing: EMPHASIZED }),
+    );
+  }, [index, opacity, reduced, translateY]);
+
+  const style = useAnimatedStyle(() => ({
+    opacity: opacity.value,
+    transform: [{ translateY: translateY.value }],
+  }));
+
+  return (
+    <Animated.Text style={[styles.wordmarkLetter, { color }, style]}>
+      {char}
+    </Animated.Text>
+  );
+}
+
+/**
+ * Overlay de splash animado premium (issue #642, épico #540): assume o lugar do
+ * splash nativo no primeiro frame JS e encena a marca — gradiente de fundo do
+ * tema, aura pulsante, partículas à deriva, logo com shimmer e reveal do
+ * wordmark "Auraxis" — fazendo fade-out quando o app fica pronto. Respeita
+ * "reduzir movimento" (cena estática) e mantém `pointerEvents="none"` para nunca
+ * bloquear a navegação. A logo final substitui `assets/images/splash-icon.png`
+ * quando a arte definitiva chegar.
+ */
+export function AnimatedSplash({
+  startupReady,
+}: AnimatedSplashProps): ReactElement | null {
   const { visible, phase } = useAnimatedSplashController(startupReady);
   const reducedMotionEnabled = useAppShellStore(
     (state) => state.reducedMotionEnabled,
   );
   const resolvedTheme = useResolvedTheme();
+  const { width, height } = useWindowDimensions();
   const palette =
     resolvedTheme === "auraxis_dark" ? darkSemanticColors : lightSemanticColors;
 
-  const pulse = useSharedValue(1);
   const overlayOpacity = useSharedValue(1);
 
   useEffect(() => {
     // O splash nativo pode sair assim que o overlay JS está montado.
     void SplashScreen.hideAsync();
   }, []);
-
-  useEffect(() => {
-    if (reducedMotionEnabled) {
-      return;
-    }
-    pulse.value = withRepeat(
-      withSequence(
-        withTiming(PULSE_SCALE, {
-          duration: PULSE_DURATION_MS,
-          easing: Easing.inOut(Easing.quad),
-        }),
-        withTiming(1, {
-          duration: PULSE_DURATION_MS,
-          easing: Easing.inOut(Easing.quad),
-        }),
-      ),
-      -1,
-    );
-  }, [pulse, reducedMotionEnabled]);
 
   useEffect(() => {
     if (phase === "fading") {
@@ -81,9 +345,11 @@ export function AnimatedSplash({ startupReady }: AnimatedSplashProps): ReactElem
   const overlayStyle = useAnimatedStyle(() => ({
     opacity: overlayOpacity.value,
   }));
-  const iconStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: pulse.value }],
-  }));
+
+  const particles = useMemo(
+    () => buildSplashParticles(SPLASH_PARTICLE_COUNT, { width, height }),
+    [width, height],
+  );
 
   if (!visible) {
     return null;
@@ -96,23 +362,76 @@ export function AnimatedSplash({ startupReady }: AnimatedSplashProps): ReactElem
       style={
         [
           StyleSheet.absoluteFillObject,
-          {
-            backgroundColor: palette.background,
-            alignItems: "center",
-            justifyContent: "center",
-          },
+          { backgroundColor: palette.background },
           overlayStyle,
         ] as StyleProp<ViewStyle>
       }
     >
-      <Animated.View style={iconStyle as StyleProp<ViewStyle>}>
-        <AppImage
-          source={splashIcon}
-          style={{ width: ICON_SIZE, height: ICON_SIZE }}
-          contentFit="contain"
-          fade={false}
+      {particles.map((particle) => (
+        <DriftParticle
+          key={particle.key}
+          particle={particle}
+          color={palette.primary}
+          reduced={reducedMotionEnabled}
         />
-      </Animated.View>
+      ))}
+      <View style={styles.centerGroup}>
+        <AuraGlow color={palette.primary} reduced={reducedMotionEnabled} />
+        <LogoMark reduced={reducedMotionEnabled} />
+        <View testID="splash-wordmark" style={styles.wordmarkRow}>
+          {[...SPLASH_WORDMARK].map((char, index) => (
+            <WordmarkLetter
+              key={`${char}-${index}`}
+              char={char}
+              index={index}
+              color={palette.foreground}
+              reduced={reducedMotionEnabled}
+            />
+          ))}
+        </View>
+      </View>
     </Animated.View>
   );
 }
+
+const styles = StyleSheet.create({
+  centerGroup: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  auraContainer: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  logoContainer: {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+    overflow: "hidden",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  logo: {
+    width: ICON_SIZE,
+    height: ICON_SIZE,
+  },
+  shimmer: {
+    position: "absolute",
+    top: -ICON_SIZE * 0.25,
+    bottom: -ICON_SIZE * 0.25,
+    width: ICON_SIZE * 0.5,
+  },
+  shimmerBand: {
+    flex: 1,
+  },
+  wordmarkRow: {
+    flexDirection: "row",
+    marginTop: 22,
+  },
+  wordmarkLetter: {
+    fontFamily: typography.heading,
+    fontSize: 30,
+    letterSpacing: 1.5,
+  },
+});

--- a/core/shell/splash-scene.test.ts
+++ b/core/shell/splash-scene.test.ts
@@ -1,0 +1,72 @@
+import {
+  SPLASH_PARTICLE_COUNT,
+  SPLASH_WORDMARK,
+  buildSplashParticles,
+  createSeededRandom,
+  wordmarkLetterDelay,
+} from "@/core/shell/splash-scene";
+
+describe("createSeededRandom", () => {
+  it("e deterministico por seed e sempre em [0, 1)", () => {
+    const a = createSeededRandom(42);
+    const b = createSeededRandom(42);
+    for (let i = 0; i < 25; i += 1) {
+      const value = a();
+      expect(value).toBe(b());
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThan(1);
+    }
+  });
+
+  it("produz sequencias diferentes para seeds diferentes", () => {
+    expect(createSeededRandom(1)()).not.toBe(createSeededRandom(2)());
+  });
+});
+
+describe("buildSplashParticles", () => {
+  it("gera a quantidade pedida, deterministica e dentro dos limites", () => {
+    const size = { width: 400, height: 800 };
+    const first = buildSplashParticles(SPLASH_PARTICLE_COUNT, size);
+    const second = buildSplashParticles(SPLASH_PARTICLE_COUNT, size);
+
+    expect(first).toHaveLength(SPLASH_PARTICLE_COUNT);
+    expect(first).toEqual(second);
+
+    for (const particle of first) {
+      expect(particle.x).toBeGreaterThanOrEqual(0);
+      expect(particle.x).toBeLessThanOrEqual(400);
+      expect(particle.y).toBeGreaterThanOrEqual(0);
+      expect(particle.y).toBeLessThanOrEqual(800);
+      expect(particle.size).toBeGreaterThan(0);
+      expect(particle.durationMs).toBeGreaterThan(0);
+      expect(particle.delayMs).toBeGreaterThanOrEqual(0);
+      expect(particle.driftY).toBeGreaterThan(0);
+      expect(particle.maxOpacity).toBeGreaterThan(0);
+      expect(particle.maxOpacity).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it("varia o layout conforme a seed", () => {
+    const a = buildSplashParticles(8, { width: 400, height: 800 }, 1);
+    const b = buildSplashParticles(8, { width: 400, height: 800 }, 2);
+    expect(a).not.toEqual(b);
+  });
+});
+
+describe("wordmarkLetterDelay", () => {
+  it("cresce monotonicamente com o indice", () => {
+    expect(wordmarkLetterDelay(0)).toBeLessThan(wordmarkLetterDelay(1));
+    expect(wordmarkLetterDelay(2)).toBeLessThan(wordmarkLetterDelay(5));
+  });
+
+  it("nunca retorna atraso negativo", () => {
+    expect(wordmarkLetterDelay(-4)).toBeGreaterThanOrEqual(0);
+    expect(wordmarkLetterDelay(-4)).toBe(wordmarkLetterDelay(0));
+  });
+});
+
+describe("SPLASH_WORDMARK", () => {
+  it("e a marca Auraxis", () => {
+    expect(SPLASH_WORDMARK).toBe("Auraxis");
+  });
+});

--- a/core/shell/splash-scene.ts
+++ b/core/shell/splash-scene.ts
@@ -1,0 +1,110 @@
+/**
+ * Lógica pura da cena de splash animada (issue #642): geração determinística
+ * das partículas de fundo e cadência do reveal do wordmark. Mantida separada do
+ * componente para ser testável sem renderizar a árvore Reanimated/SVG.
+ */
+
+/** Palavra-marca revelada abaixo da logo, letra a letra. */
+export const SPLASH_WORDMARK = "Auraxis";
+
+/** Quantidade de partículas ("motes") que flutuam atrás da logo. */
+export const SPLASH_PARTICLE_COUNT = 16;
+
+/** Atraso base (ms) antes da primeira letra do wordmark aparecer. */
+export const WORDMARK_BASE_DELAY_MS = 420;
+
+/** Passo (ms) do stagger entre letras consecutivas do wordmark. */
+export const WORDMARK_STEP_MS = 55;
+
+/** Semente padrão do layout de partículas — fixa para um visual estável. */
+export const SPLASH_PARTICLE_SEED = 0xa11a5;
+
+/**
+ * PRNG determinístico (mulberry32). Dado o mesmo `seed`, produz sempre a mesma
+ * sequência em `[0, 1)`. Usado para posicionar partículas de forma estável
+ * (mesmo layout a cada boot) e testável.
+ *
+ * @param seed Semente inteira.
+ * @returns Função que retorna o próximo número pseudoaleatório em `[0, 1)`.
+ */
+export function createSeededRandom(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/** Especificação de uma partícula flutuante da cena. */
+export interface SplashParticle {
+  readonly key: string;
+  /** Posição horizontal absoluta (px). */
+  readonly x: number;
+  /** Posição vertical absoluta (px). */
+  readonly y: number;
+  /** Diâmetro do "mote" (px). */
+  readonly size: number;
+  /** Atraso inicial da animação (ms). */
+  readonly delayMs: number;
+  /** Duração de um ciclo de subida/fade (ms). */
+  readonly durationMs: number;
+  /** Deslocamento vertical (px) da deriva para cima. */
+  readonly driftY: number;
+  /** Opacidade máxima no auge do ciclo (0–1). */
+  readonly maxOpacity: number;
+}
+
+/** Dimensões da área onde as partículas são distribuídas. */
+export interface SplashSceneSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Gera as partículas espalhadas pela tela com tamanhos, atrasos, durações e
+ * derivas variados — de forma determinística para um dado `seed`.
+ *
+ * @param count Número de partículas.
+ * @param size Dimensões da área (`width`/`height` em px).
+ * @param seed Semente do layout (default {@link SPLASH_PARTICLE_SEED}).
+ * @returns Lista de partículas.
+ */
+export function buildSplashParticles(
+  count: number,
+  size: SplashSceneSize,
+  seed: number = SPLASH_PARTICLE_SEED,
+): SplashParticle[] {
+  const rand = createSeededRandom(seed);
+  const particles: SplashParticle[] = [];
+  for (let i = 0; i < count; i += 1) {
+    particles.push({
+      key: `splash-particle-${i}`,
+      x: rand() * size.width,
+      y: rand() * size.height,
+      size: 2 + rand() * 4,
+      delayMs: Math.round(rand() * 900),
+      durationMs: 2200 + Math.round(rand() * 1800),
+      driftY: 24 + rand() * 48,
+      maxOpacity: 0.18 + rand() * 0.3,
+    });
+  }
+  return particles;
+}
+
+/**
+ * Atraso (ms) do reveal da letra na posição `index`, em cascata.
+ *
+ * @param index Posição da letra (0-based).
+ * @param base Atraso da primeira letra (default {@link WORDMARK_BASE_DELAY_MS}).
+ * @param step Passo entre letras (default {@link WORDMARK_STEP_MS}).
+ * @returns Atraso não-negativo em ms.
+ */
+export function wordmarkLetterDelay(
+  index: number,
+  base: number = WORDMARK_BASE_DELAY_MS,
+  step: number = WORDMARK_STEP_MS,
+): number {
+  return base + Math.max(0, index) * step;
+}

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -40,18 +40,24 @@ jest.mock("axios", () => require("axios/dist/node/axios.cjs"));
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any, react/display-name */
 jest.mock("react-native-reanimated", () => {
   const React = require("react");
-  const { View } = require("react-native");
+  const { View, Text } = require("react-native");
   const fadeStub = { duration: () => fadeStub, delay: () => fadeStub };
   const ForwardedView = React.forwardRef(
     ({ children, style, ...rest }: any, ref: any) => {
       return React.createElement(View, { style, ref, ...rest }, children);
     },
   );
+  const ForwardedText = React.forwardRef(
+    ({ children, style, ...rest }: any, ref: any) => {
+      return React.createElement(Text, { style, ref, ...rest }, children);
+    },
+  );
   const createAnimatedComponent = (component: unknown) => component;
   return {
     __esModule: true,
-    default: { View: ForwardedView, createAnimatedComponent },
+    default: { View: ForwardedView, Text: ForwardedText, createAnimatedComponent },
     View: ForwardedView,
+    Text: ForwardedText,
     createAnimatedComponent,
     FadeIn: fadeStub,
     FadeOut: fadeStub,
@@ -64,6 +70,8 @@ jest.mock("react-native-reanimated", () => {
       typeof factory === "function" ? factory() : {},
     withTiming: (value: unknown) => value,
     withSpring: (value: unknown) => value,
+    withRepeat: (value: unknown) => value,
+    withSequence: (...values: unknown[]) => values[values.length - 1],
     withDelay: (_delay: unknown, value: unknown) => value,
     Easing: {
       bezier: () => (t: number) => t,


### PR DESCRIPTION
## O que
Evolui a splash overlay (`core/shell/animated-splash.tsx`) de um monograma pulsante simples para uma **cena de abertura da marca**:
- **Aura radial** pulsante atrás da logo (SVG `RadialGradient`, cor primária → transparente).
- **Partículas** ("motes") à deriva, sobem e somem em loop — layout determinístico (`splash-scene.ts`).
- **Logo** com entrada (fade + scale com leve overshoot + settle) e **shimmer** diagonal cruzando a arte.
- **Reveal em cascata** do wordmark "Auraxis", letra a letra.
- **Fade-out** coordenado com `startupReady`.

## Decisão técnica — sem Skia
A issue previa Skia, mas implementei com o **stack já instalado** (`react-native-svg` + `react-native-reanimated` + `expo-linear-gradient`). Motivo: **JS-only, sem nova dependência nativa** → menor risco no caminho de boot (uma falha aqui brica o app no launch), compatível com OTA, e libs já provadas neste app. Efeitos shader/partículas-physics via Skia ficam como follow-up opcional na #642 se desejado.

## Acessibilidade
Respeita **"reduzir movimento"** (`reducedMotionEnabled`): cena renderiza estática, sem animação. `pointerEvents="none"` — nunca bloqueia navegação. Splash nativa (expo-splash-screen) mantida como cobertura de cold start.

## Testes / qualidade
- `core/shell/splash-scene.test.ts` — helpers puros (partículas determinísticas, cadência do wordmark, PRNG seeded).
- `core/shell/animated-splash.test.tsx` — render com e sem reduced motion; hide do splash nativo.
- Completa o mock lean de reanimated no `jest.setup.ts` (withRepeat/withSequence/Animated.Text).
- `npm run quality-check` **verde**: 2747 testes, cobertura 94.76% stmts / 84.92% branch / 94.73% lines.

## Validação visual
A cena é animada e depende de runtime nativo — **validação visual pende device/simulador** (não capturável no CI). Sugiro validar no próximo build EAS.

Closes #642