### PR TITLE
ci(ota): forçar --environment no ota-update (guard hard-fail)

### DIFF
--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -55,12 +55,32 @@ jobs:
           eas-version: 16.13.0
           token: ${{ secrets.EXPO_TOKEN }}
 
+      - name: Guard — require channel/environment
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          # Guard duro: aborta ANTES do `eas update` se o canal (usado tanto em
+          # `--channel` quanto em `--environment`) vier ausente/vazio. Sem
+          # `--environment` o Expo não inlina os `EXPO_PUBLIC_*` no bundle OTA,
+          # deixando `EXPO_PUBLIC_API_URL` undefined (fallback localhost) e
+          # quebrando todas as chamadas de API no device. Ver issues #564/#646.
+          if [ -z "${CHANNEL:-}" ]; then
+            echo "::error::CHANNEL/--environment ausente ou vazio — abortando OTA para não publicar bundle com EXPO_PUBLIC_* undefined." >&2
+            exit 1
+          fi
+          echo "OK — canal/environment resolvido: ${CHANNEL}"
+
       - name: Publish update
         env:
           CHANNEL: ${{ inputs.channel }}
           MESSAGE: ${{ inputs.message }}
         run: |
           set -euo pipefail
+          if [ -z "${CHANNEL:-}" ]; then
+            echo "::error::CHANNEL/--environment vazio no passo de publish — abortando." >&2
+            exit 1
+          fi
           if [ -z "${MESSAGE:-}" ]; then
             MESSAGE="$(git log -1 --pretty=%s)"
           fi


### PR DESCRIPTION
## O quê
Adiciona um guard que **falha o job antes do `eas update`** se o canal (usado em `--channel` e `--environment`) vier ausente/vazio.

## Por quê
Sem `--environment`, o Expo não inlina os `EXPO_PUBLIC_*` em build-time no bundle OTA — `EXPO_PUBLIC_API_URL` sai `undefined` (fallback localhost) e quebra todas as chamadas de API no device (issues #564/#646). O workflow já passava `--environment "$CHANNEL"`, mas não havia guarda contra um canal vazio.

## Como
- Novo passo `Guard — require channel/environment` entre `Setup Expo` e `Publish update`.
- Checagem defensiva adicional no início do passo de publish.
- Aditivo/seguro: não altera binário nem o comportamento do OTA quando o canal está presente.

Closes #646