### PR TITLE
ci(release): auto-merge do PR de release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,8 +25,38 @@ jobs:
           fi
 
       - name: Run Release Please
+        id: release
         uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Habilita auto-merge no PR "chore(main): release ..." para que ele entre
+      # sozinho assim que os checks obrigatórios ficarem verdes. Sem isso, um fix
+      # P0 pode ficar semanas parado esperando merge manual do PR de release
+      # (aconteceu com o crash de transações). Épico: platform #854 / app #648.
+      # O merge cria a tag `v*`, que dispara o store-release.yml (build + submit
+      # interno draft — promoção interno→prod segue manual, ver #645).
+      - name: Enable auto-merge on the release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Caminho primário: número do PR vem do output `pr` (JSON do release-please).
+          pr_number="$(printf '%s' "${RELEASE_PR_JSON:-}" | jq -r '.number // empty' 2>/dev/null || true)"
+          # Fallback robusto: localiza o PR de release aberto pela label padrão
+          # do release-please, caso o output não traga o número.
+          if [ -z "${pr_number}" ]; then
+            pr_number="$(gh pr list --repo "${REPO}" --state open \
+              --label 'autorelease: pending' --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          fi
+          if [ -z "${pr_number}" ] || [ "${pr_number}" = "null" ]; then
+            echo "Nenhum PR de release aberto — nada a habilitar."
+            exit 0
+          fi
+          echo "Habilitando auto-merge (squash) no PR de release #${pr_number}"
+          gh pr merge "${pr_number}" --repo "${REPO}" --auto --squash


### PR DESCRIPTION
## O quê
Habilita **auto-merge (squash)** no PR `chore(main): release ...` gerado pelo release-please, para que ele entre sozinho quando os checks obrigatórios ficarem verdes.

## Por quê
Um fix P0 (crash Android de transações) ficou ~1 mês na `main` sem ser lançado porque o PR de release ficou parado esperando merge manual. Prod ficava atrás da main. Parte do épico de plataforma italofelipe/auraxis-platform#854.

## Como
- `id: release` no passo do release-please para expor os outputs.
- Novo passo `Enable auto-merge on the release PR`:
  - lê o número do PR do output `pr` (JSON) via `jq .number`;
  - fallback robusto: `gh pr list` pela label padrão `autorelease: pending`;
  - `gh pr merge --auto --squash` com o `RELEASE_PLEASE_TOKEN`.
- `Allow auto-merge` já está habilitado no repo (usado pelo `auto-merge.yml` do Dependabot).

## Encadeamento
O merge cria a tag `v*`, que dispara o `store-release.yml` (build + submit **interno draft**). Promoção interno→produção continua **manual** (#645). Sem auto-promoção para produção.

Closes #648