### PR TITLE
docs(release): cadeia auto release->store (interno draft) + gate manual de prod

### DIFF
--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -81,7 +81,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            # Tag push (v*) -> full production release on both platforms with auto-submit
+            # Tag push (v*) — criada quando o PR do release-please é mergeado
+            # (auto-merge habilitado em release-please.yml). Dispara build nas
+            # duas plataformas com --auto-submit.
+            #
+            # IMPORTANTE — sem auto-promoção para produção (issue #645):
+            #   - Android: eas.json submit.production.android = track:internal +
+            #     releaseStatus:draft → o AAB entra como DRAFT no internal track,
+            #     nunca em produção. Promover interno→produção é MANUAL no Play
+            #     Console (gate one-click, ver docs/release-process.md).
+            #   - iOS: o submit sobe para o TestFlight; publicar na App Store
+            #     (produção) é MANUAL no App Store Connect.
             platform="all"
             profile="production"
             auto_submit="true"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,6 +20,44 @@ Gatilhos do `store-release.yml`:
   build `production` nas duas plataformas com `--auto-submit`.
 - **Manual (`workflow_dispatch`)**: escolhe plataforma, profile e auto-submit.
 
+### Cadeia automática de release (issues #648 / #645)
+
+O ciclo é encadeado ponta a ponta, sem passo manual até a promoção:
+
+```
+commits na main ─► release-please abre "chore(main): release X.Y.Z"
+                   │  (auto-merge squash habilitado — release-please.yml)
+                   ▼
+                   PR entra sozinho quando os checks ficam verdes
+                   │
+                   ▼
+                   release-please cria a tag v* + GitHub Release
+                   │
+                   ▼
+                   store-release.yml (push da tag) ─► eas build --auto-submit
+                   ├─ Android → internal track como DRAFT
+                   └─ iOS → TestFlight
+```
+
+> **Sem auto-promoção para produção.** A cadeia para no track interno
+> (Android draft) e no TestFlight (iOS). Promover para produção pública é
+> sempre **manual** — ver o gate abaixo. Motivação: um fix P0 não deve ficar
+> preso esperando merge do release (#648), mas também não deve ir sozinho para
+> produção sem um humano no loop (#645).
+
+### Gate de promoção interno → produção (one-click, manual)
+
+Depois que o build entra no internal/TestFlight, a promoção é um passo humano:
+
+- **Android** — Play Console → Testing → Internal testing → selecionar o build →
+  **Promote release** → Production → revisar rollout % → **Rollout to Production**.
+- **iOS** — App Store Connect → o build do TestFlight → adicionar à versão da
+  App Store → **Submit for Review** → após aprovação, liberar (manual ou
+  phased release).
+
+Nenhum secret ou automação promove para produção; o gate é intencionalmente
+manual.
+
 Gatilho do `ota-update.yml`: somente manual (`workflow_dispatch`), escolhendo
 canal `preview` ou `production` — publica o estado JS do commit checked-out.
 


### PR DESCRIPTION
## O quê
Documenta e torna explícita a cadeia automática de release **até o track interno**, mantendo a promoção para produção **manual** (conservador, sem auto-promoção).

## Contexto
O `store-release.yml` **já dispara automaticamente** no push da tag `v*` (criada quando o PR do release-please é mergeado) e resolve `auto_submit=true`, profile `production`. E o `eas.json` já garante o destino seguro:
- `submit.production.android` = `track: internal` + `releaseStatus: draft` → AAB entra como **draft** no internal track.
- iOS → **TestFlight**.

Ou seja, o requisito de #645 (auto-disparar store-release/submit no merge do release) já está satisfeito de forma conservadora. Este PR **não** introduz auto-promoção para produção — apenas documenta a cadeia e o gate manual.

## Como
- Comentário explícito no passo `Resolve build parameters` do `store-release.yml` deixando claro o destino interno-draft/TestFlight e que promoção→prod é manual.
- `docs/release-process.md`: diagrama da cadeia `release-please (auto-merge) → tag → store-release → internal draft/TestFlight` + seção do **gate one-click** de promoção interno→produção (Play Console / App Store Connect).

## Guard-rails
- Nenhuma alteração em `app.json`/`eas.json` (binário/OTA intactos).
- `store-release.yml` só ganhou comentários; governança `check-runtime-release-governance` continua verde.

Closes #645