### PR TITLE
ci(app): hardening de entrega — OTA guard, release auto-merge, docs de release/fingerprint

### DIFF
--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -55,12 +55,32 @@ jobs:
           eas-version: 16.13.0
           token: ${{ secrets.EXPO_TOKEN }}
 
+      - name: Guard — require channel/environment
+        env:
+          CHANNEL: ${{ inputs.channel }}
+        run: |
+          set -euo pipefail
+          # Guard duro: aborta ANTES do `eas update` se o canal (usado tanto em
+          # `--channel` quanto em `--environment`) vier ausente/vazio. Sem
+          # `--environment` o Expo não inlina os `EXPO_PUBLIC_*` no bundle OTA,
+          # deixando `EXPO_PUBLIC_API_URL` undefined (fallback localhost) e
+          # quebrando todas as chamadas de API no device. Ver issues #564/#646.
+          if [ -z "${CHANNEL:-}" ]; then
+            echo "::error::CHANNEL/--environment ausente ou vazio — abortando OTA para não publicar bundle com EXPO_PUBLIC_* undefined." >&2
+            exit 1
+          fi
+          echo "OK — canal/environment resolvido: ${CHANNEL}"
+
       - name: Publish update
         env:
           CHANNEL: ${{ inputs.channel }}
           MESSAGE: ${{ inputs.message }}
         run: |
           set -euo pipefail
+          if [ -z "${CHANNEL:-}" ]; then
+            echo "::error::CHANNEL/--environment vazio no passo de publish — abortando." >&2
+            exit 1
+          fi
           if [ -z "${MESSAGE:-}" ]; then
             MESSAGE="$(git log -1 --pretty=%s)"
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -25,8 +25,38 @@ jobs:
           fi
 
       - name: Run Release Please
+        id: release
         uses: googleapis/release-please-action@c3fc4de07084f75a2b61a5b933069bda6edf3d5c # v4
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      # Habilita auto-merge no PR "chore(main): release ..." para que ele entre
+      # sozinho assim que os checks obrigatórios ficarem verdes. Sem isso, um fix
+      # P0 pode ficar semanas parado esperando merge manual do PR de release
+      # (aconteceu com o crash de transações). Épico: platform #854 / app #648.
+      # O merge cria a tag `v*`, que dispara o store-release.yml (build + submit
+      # interno draft — promoção interno→prod segue manual, ver #645).
+      - name: Enable auto-merge on the release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.pr }}
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+          RELEASE_PR_JSON: ${{ steps.release.outputs.pr }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Caminho primário: número do PR vem do output `pr` (JSON do release-please).
+          pr_number="$(printf '%s' "${RELEASE_PR_JSON:-}" | jq -r '.number // empty' 2>/dev/null || true)"
+          # Fallback robusto: localiza o PR de release aberto pela label padrão
+          # do release-please, caso o output não traga o número.
+          if [ -z "${pr_number}" ]; then
+            pr_number="$(gh pr list --repo "${REPO}" --state open \
+              --label 'autorelease: pending' --json number --jq '.[0].number // empty' 2>/dev/null || true)"
+          fi
+          if [ -z "${pr_number}" ] || [ "${pr_number}" = "null" ]; then
+            echo "Nenhum PR de release aberto — nada a habilitar."
+            exit 0
+          fi
+          echo "Habilitando auto-merge (squash) no PR de release #${pr_number}"
+          gh pr merge "${pr_number}" --repo "${REPO}" --auto --squash

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -81,7 +81,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ "${{ github.event_name }}" = "push" ]; then
-            # Tag push (v*) -> full production release on both platforms with auto-submit
+            # Tag push (v*) — criada quando o PR do release-please é mergeado
+            # (auto-merge habilitado em release-please.yml). Dispara build nas
+            # duas plataformas com --auto-submit.
+            #
+            # IMPORTANTE — sem auto-promoção para produção (issue #645):
+            #   - Android: eas.json submit.production.android = track:internal +
+            #     releaseStatus:draft → o AAB entra como DRAFT no internal track,
+            #     nunca em produção. Promover interno→produção é MANUAL no Play
+            #     Console (gate one-click, ver docs/release-process.md).
+            #   - iOS: o submit sobe para o TestFlight; publicar na App Store
+            #     (produção) é MANUAL no App Store Connect.
             platform="all"
             profile="production"
             auto_submit="true"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,6 +20,44 @@ Gatilhos do `store-release.yml`:
   build `production` nas duas plataformas com `--auto-submit`.
 - **Manual (`workflow_dispatch`)**: escolhe plataforma, profile e auto-submit.
 
+### Cadeia automática de release (issues #648 / #645)
+
+O ciclo é encadeado ponta a ponta, sem passo manual até a promoção:
+
+```
+commits na main ─► release-please abre "chore(main): release X.Y.Z"
+                   │  (auto-merge squash habilitado — release-please.yml)
+                   ▼
+                   PR entra sozinho quando os checks ficam verdes
+                   │
+                   ▼
+                   release-please cria a tag v* + GitHub Release
+                   │
+                   ▼
+                   store-release.yml (push da tag) ─► eas build --auto-submit
+                   ├─ Android → internal track como DRAFT
+                   └─ iOS → TestFlight
+```
+
+> **Sem auto-promoção para produção.** A cadeia para no track interno
+> (Android draft) e no TestFlight (iOS). Promover para produção pública é
+> sempre **manual** — ver o gate abaixo. Motivação: um fix P0 não deve ficar
+> preso esperando merge do release (#648), mas também não deve ir sozinho para
+> produção sem um humano no loop (#645).
+
+### Gate de promoção interno → produção (one-click, manual)
+
+Depois que o build entra no internal/TestFlight, a promoção é um passo humano:
+
+- **Android** — Play Console → Testing → Internal testing → selecionar o build →
+  **Promote release** → Production → revisar rollout % → **Rollout to Production**.
+- **iOS** — App Store Connect → o build do TestFlight → adicionar à versão da
+  App Store → **Submit for Review** → após aprovação, liberar (manual ou
+  phased release).
+
+Nenhum secret ou automação promove para produção; o gate é intencionalmente
+manual.
+
 Gatilho do `ota-update.yml`: somente manual (`workflow_dispatch`), escolhendo
 canal `preview` ou `production` — publica o estado JS do commit checked-out.
 

--- a/docs/runbooks/runtimeversion-fingerprint-migration.md
+++ b/docs/runbooks/runtimeversion-fingerprint-migration.md
@@ -1,0 +1,125 @@
+# Runbook — migração de `runtimeVersion` para policy `fingerprint`
+
+> **Status: RECOMENDADO, DEFERIDO.** Este runbook documenta a mudança e o seu
+> risco. **NÃO** aplique a mudança em `app.json` sem antes executar a validação
+> com build real descrita aqui. Issue de rastreamento: [#647](https://github.com/italofelipe/auraxis-app/issues/647).
+
+## Estado atual
+
+`app.json`:
+
+```jsonc
+{
+  "expo": {
+    "version": "1.0.0",
+    "runtimeVersion": { "policy": "appVersion" }
+  }
+}
+```
+
+Com `policy: appVersion`, o **runtimeVersion** de todo build e de todo OTA é
+igual a `expo.version` (hoje `1.0.0`). O EAS Update só entrega um update a um
+build instalado cujo runtimeVersion **casa exatamente** com o do update.
+
+## O problema
+
+`appVersion` acopla a compatibilidade de OTA à *string de marketing*, não ao
+que realmente importa para um OTA seguro: a **camada nativa** (dependências com
+código nativo, config plugins, permissões, versão do SDK do Expo).
+
+Consequências no estado atual:
+
+- **Falso positivo (perigoso).** Se uma dep nativa mudar mas a `version`
+  continuar `1.0.0`, um OTA JS-only é entregue a um build cujo binário nativo é
+  incompatível → crash em runtime (JS chama API nativa que não existe naquele
+  binário). Este é exatamente o risco que motiva #647.
+- **Falso negativo (atrito).** Todo bump de `version` (mesmo puramente de
+  marketing, sem mudança nativa) muda o runtimeVersion e **corta OTA** para os
+  builds antigos, forçando atualização pela loja mesmo quando um OTA bastaria.
+
+## A mudança recomendada
+
+Trocar a policy para `fingerprint`:
+
+```jsonc
+{
+  "expo": {
+    "version": "1.0.0",
+    "runtimeVersion": { "policy": "fingerprint" }
+  }
+}
+```
+
+Com `fingerprint`, o Expo calcula o runtimeVersion a partir de um **hash das
+entradas nativas** do projeto (deps nativas, config plugins, `app.json` nativo,
+versão do Expo, etc.). O runtime só muda quando a camada nativa muda — que é
+precisamente quando um OTA deixaria de ser seguro. É a policy recomendada pela
+Expo para projetos CNG (Continuous Native Generation) no SDK 52+.
+
+Requer o pacote `expo-updates` (já é dependência de OTA) e o cálculo de
+fingerprint do `@expo/fingerprint` (transitivo do `expo`).
+
+## Risco / impacto — por que não flipar às cegas
+
+**A mudança altera a chave de compatibilidade de entrega de OTA.** Isso tem
+duas implicações que só se validam com build real:
+
+1. **Descontinuidade nos builds já instalados.** Os builds hoje em campo têm
+   runtimeVersion `1.0.0` (appVersion). O primeiro build feito com
+   `policy: fingerprint` terá um runtimeVersion **diferente** (o hash). A partir
+   daí, **OTAs publicados sob o novo runtime NÃO alcançam os builds `1.0.0`
+   antigos** — eles só voltam a receber OTA depois de instalarem, pela loja, um
+   build já com fingerprint. Planeje a migração junto de um release de loja.
+2. **Canais/branches do EAS Update.** É preciso confirmar que o canal
+   (`preview`/`production`) publica o update sob o runtime esperado e que um
+   device com o build de fingerprint efetivamente recebe o update. Um erro aqui
+   silencia OTA em produção sem crash aparente — o app só "para de atualizar".
+
+Por isso **não** basta editar `app.json` e mergear: a corretude depende de um
+build nativo real e de um teste de entrega ponta a ponta.
+
+## Passo de validação obrigatório (antes de aplicar)
+
+1. **Branch de validação** (não `main`): editar `app.json` para
+   `runtimeVersion.policy: fingerprint`.
+2. **Build de preview real** (não OTA):
+   ```bash
+   eas build --profile preview --platform android
+   # opcional: --platform ios
+   ```
+   Instalar o APK de preview num device.
+3. **Conferir o runtimeVersion calculado**:
+   ```bash
+   npx expo-updates runtimeversion:resolve --platform android
+   # ou: npx @expo/fingerprint fingerprint:generate
+   ```
+   Anotar o hash — é o novo runtimeVersion.
+4. **Publicar um OTA JS-only** no mesmo canal do build de preview e confirmar a
+   compatibilidade de runtime:
+   ```bash
+   eas update --branch preview --environment preview --message "fingerprint smoke"
+   eas update:list --branch preview --limit 3
+   ```
+   O update precisa aparecer com o **mesmo runtimeVersion** do build de preview.
+5. **Confirmar no device** que o build de preview recebe o OTA no segundo
+   relaunch (mesma checagem do smoke de OTA em `docs/release-process.md`).
+6. **Teste de incompatibilidade (opcional, mas ideal):** bumpar uma dep nativa
+   na branch, rebuildar o fingerprint e confirmar que o runtime **muda** — ou
+   seja, que um OTA sob o runtime antigo NÃO é entregue ao novo binário. É esta
+   propriedade que corrige #647.
+
+Só depois de 1–6 verdes, aplicar a mudança em `app.json` em `main`, alinhada a
+um release de loja (para os builds antigos migrarem via loja).
+
+## Rollback
+
+Reverter `runtimeVersion.policy` para `appVersion` no `app.json` e refazer o
+build de loja. OTAs publicados sob o runtime de fingerprint deixam de casar; o
+comportamento volta ao acoplamento por `version`.
+
+## Referências
+
+- Expo — *Runtime versions and updates* (policy `fingerprint` vs `appVersion`).
+- `@expo/fingerprint` — cálculo do hash de entradas nativas.
+- `docs/release-process.md` — ciclo OTA vs build, gate de promoção.
+- Issue [#647](https://github.com/italofelipe/auraxis-app/issues/647).


### PR DESCRIPTION
## Onda 2/3 da faxina (app)
Consolida 4 mudanças aditivas/seguras:
- **W2.4 (Closes #646):** guard hard-fail no `ota-update.yml` se `channel/--environment` ausente (evita OTA com `EXPO_PUBLIC_*` undefined).
- **W2.1 (Refs #854):** auto-merge do PR de release-please (não fica parado; fix P0 do crash ficou ~1 mês sem lançar). Cortar a tag NÃO auto-promove p/ produção.
- **W2.3 (Closes #645):** documenta a cadeia release→store-release mantendo submit em track **interno/draft** (promoção interno→prod segue MANUAL, por controle de custo EAS). Mudança em store-release.yml é só comentário.
- **W3.5 (Closes #647):** runbook de migração `runtimeVersion`→fingerprint **documentado/deferido** (muda entrega de OTA dos builds instalados; exige validação com build real). NÃO altera app.json.

Tudo aditivo (workflows + docs), sem tocar código de app. YAML validado. CI (auto-merge) é o gate.

Closes #646
Closes #645
Closes #647