### PR TITLE
fix(auth): teclado não abre ao tocar nos inputs de login

### DIFF
--- a/features/auth/screens/login-screen.test.tsx
+++ b/features/auth/screens/login-screen.test.tsx
@@ -110,6 +110,16 @@ describe("LoginScreen", () => {
     );
   });
 
+  it("torna o shell do campo tocavel para focar o input (fix teclado #655)", () => {
+    const { getByTestId } = renderScreen();
+    // O Input aninhado no XStack tinha perdido o tap-to-focus; agora tocar em
+    // qualquer parte do shell foca o input (ref.focus). Exercita o handler.
+    expect(() => fireEvent.press(getByTestId("login-email-shell"))).not.toThrow();
+    expect(() =>
+      fireEvent.press(getByTestId("login-password-shell")),
+    ).not.toThrow();
+  });
+
   it("mantem as acoes do fluxo de auth conectadas ao controller", () => {
     const { getByText } = renderScreen();
 

--- a/features/auth/screens/login-screen.tsx
+++ b/features/auth/screens/login-screen.tsx
@@ -1,6 +1,8 @@
 import {
+  useRef,
   useState,
   type ComponentProps,
+  type ComponentRef,
   type ReactElement,
   type ReactNode,
 } from "react";
@@ -383,6 +385,7 @@ function PremiumInputField({
   ...rest
 }: PremiumInputFieldProps): ReactElement {
   const [focused, setFocused] = useState(false);
+  const inputRef = useRef<ComponentRef<typeof Input>>(null);
 
   return (
     <YStack gap="$2">
@@ -393,6 +396,7 @@ function PremiumInputField({
         fontSize="$2"
         fontWeight="$6"
         letterSpacing={1.1}
+        onPress={() => inputRef.current?.focus()}
       >
         {label}
       </Label>
@@ -405,8 +409,10 @@ function PremiumInputField({
         backgroundColor={AUTH_GLASS}
         paddingHorizontal="$3"
         style={focused ? styles.inputShellFocused : styles.inputShellResting}
+        onPress={() => inputRef.current?.focus()}
       >
         <Input
+          ref={inputRef}
           id={id}
           accessibilityLabel={accessibilityLabel ?? label}
           aria-invalid={Boolean(errorText)}


### PR DESCRIPTION
## Bug (Closes #655)
Na tela de login, tocar nos inputs (email/senha) **não abria o teclado** — Android e iOS.

## Causa raiz
Regressão do redesign premium (#629): o `PremiumInputField` passou a **aninhar o `Input` do Tamagui dentro de um `XStack` shell**, quebrando o tap-to-focus. Antes o login usava `AppInputField` (Input direto no YStack), que funciona. O `Label htmlFor` já existia antes → não é ele.

## Fix
Padrão RN robusto para container de input customizado: **`ref` no Input + `onPress` no shell (e no Label)** que chama `inputRef.current?.focus()`. Tocar em qualquer parte do campo foca o input e abre o teclado. Mantém o shell/halo premium e o teste de foco existente.

## Verificação
- `npm run quality-check` **verde**: 2748 testes, cobertura 94.76% / 84.92% branch; tsc + lint OK.
- +teste que exercita o `onPress` do shell (email e senha).
- **Validação final em device recomendada** (foco nativo não é 100% testável em jest).

Closes #655