### PR TITLE
docs(legal): substituir Asaas por AbacatePay nos documentos legais

### DIFF
--- a/features/legal/content/index.test.ts
+++ b/features/legal/content/index.test.ts
@@ -66,7 +66,7 @@ describe("PRIVACY_POLICY_DOCUMENT", () => {
       "BRAPI",
       "PostHog",
       "OpenAI",
-      "Asaas",
+      "AbacatePay",
       "Resend",
     ]) {
       expect(items).toContain(vendor);

--- a/features/legal/content/privacy-policy.ts
+++ b/features/legal/content/privacy-policy.ts
@@ -5,7 +5,7 @@ const SUPPORT_EMAIL = "suporte@auraxis.com.br";
 export const PRIVACY_POLICY_DOCUMENT: LegalDocument = {
   id: "privacy-policy",
   title: "Política de Privacidade",
-  version: "1.2.0",
+  version: "1.3.0",
   effectiveDate: "11/07/2026",
   contactEmail: SUPPORT_EMAIL,
   siblingId: "terms-of-service",
@@ -95,7 +95,7 @@ export const PRIVACY_POLICY_DOCUMENT: LegalDocument = {
             "Sentry, para observabilidade e monitoramento de erros no frontend;",
             "BRAPI, para consulta de cotações e dados de mercado;",
             "PostHog Cloud, para analytics de produto com eventos minimizados, somente após consentimento;",
-            "Asaas, para processamento de cobrança recorrente do plano Premium (nome, email, CPF/CNPJ, valor e plano);",
+            "AbacatePay (Abacatepay Tecnologia LTDA, CNPJ 58.271.413/0001-90), para processamento de cobrança recorrente do plano Premium (nome, email, CPF/CNPJ, valor e plano);",
             "Resend, para envio de emails transacionais, como verificação de conta, redefinição de senha e avisos de cobrança;",
             "OpenAI, para geração de insights financeiros via IA (apenas quando o recurso for utilizado, com dados minimizados e sem identificadores pessoais).",
           ],
@@ -107,7 +107,7 @@ export const PRIVACY_POLICY_DOCUMENT: LegalDocument = {
         },
         {
           kind: "paragraph",
-          text: "Detalhes específicos do processamento por Asaas, incluindo retenção e bases legais, podem ser consultados na política de privacidade do provedor em https://www.asaas.com/politica-de-privacidade.",
+          text: "O processamento pelo provedor de pagamento, incluindo retenção e bases legais, é regido pela política de privacidade da Abacatepay Tecnologia LTDA (CNPJ 58.271.413/0001-90).",
         },
       ],
     },

--- a/features/legal/content/terms-of-service.ts
+++ b/features/legal/content/terms-of-service.ts
@@ -5,7 +5,7 @@ const SUPPORT_EMAIL = "suporte@auraxis.com.br";
 export const TERMS_OF_SERVICE_DOCUMENT: LegalDocument = {
   id: "terms-of-service",
   title: "Termos de Uso",
-  version: "1.1.0",
+  version: "1.2.0",
   effectiveDate: "20/05/2026",
   contactEmail: SUPPORT_EMAIL,
   siblingId: "privacy-policy",
@@ -109,7 +109,7 @@ export const TERMS_OF_SERVICE_DOCUMENT: LegalDocument = {
         },
         {
           kind: "paragraph",
-          text: "O processamento de cobrança é realizado pela Asaas (provedor de pagamento brasileiro). O Auraxis não armazena dados de cartão de crédito. Tributos eventualmente aplicáveis seguem a legislação vigente.",
+          text: "O processamento de cobrança é realizado pela AbacatePay (Abacatepay Tecnologia LTDA, CNPJ 58.271.413/0001-90). O Auraxis não armazena dados de cartão de crédito. Tributos eventualmente aplicáveis seguem a legislação vigente.",
         },
         {
           kind: "paragraph",
@@ -140,7 +140,7 @@ export const TERMS_OF_SERVICE_DOCUMENT: LegalDocument = {
             "Em caso de falha na cobrança automática (por exemplo, cartão expirado ou saldo insuficiente), o provedor de pagamento pode tentar a cobrança novamente conforme regras próprias.",
             "Após a confirmação de falha definitiva, o usuário será notificado por email e poderá atualizar o método de pagamento ou cancelar o plano. Durante o período de carência (3 dias), o acesso Premium continua ativo.",
             "Após a carência sem regularização, o plano é rebaixado para Free e funcionalidades Premium ficam indisponíveis. Os dados do usuário permanecem preservados.",
-            "Para disputas envolvendo cobranças, o usuário deve entrar em contato pelo canal oficial de suporte. O Auraxis colabora com a Asaas para investigação e resolução conforme normas do setor.",
+            "Para disputas envolvendo cobranças, o usuário deve entrar em contato pelo canal oficial de suporte. O Auraxis colabora com a AbacatePay para investigação e resolução conforme normas do setor.",
           ],
         },
       ],


### PR DESCRIPTION
## Summary

Espelho do PR web#1140. Decisão do PO (2026-07-19): o gateway de pagamento passa a ser **AbacatePay**.

"Asaas" estava publicado como **subprocessador de dados** na política de privacidade do app e citado
nos termos de uso (§ processamento de pagamento e § disputas). Documento divergente do tratamento
real é risco de LGPD, não cosmético.

### Mudanças

- Subprocessador → **Abacatepay Tecnologia LTDA (CNPJ 58.271.413/0001-90)**
- Termos: processamento de cobrança e colaboração em disputas
- Política de privacidade `1.2.0` → **`1.3.0`**; Termos `1.1.0` → **`1.2.0`**

### Decisão registrada

O texto anterior linkava `https://www.asaas.com/politica-de-privacidade`. **Não consegui verificar
uma URL pública de política de privacidade da AbacatePay** (não há link visível no site deles), então
o controlador é identificado por razão social + CNPJ em vez de um link inventado. Vale preencher
quando confirmada — no web e no app juntos, para não divergirem.

## Validation

- `npm run quality-check` verde
- **421 suítes, 2748 testes passando**

**Screenshots:** não anexadas — a mudança é substituição de texto em documentos legais renderizados
pelas telas existentes, sem alteração de layout, componente ou estilo.

## Residual risk

Baixo. Vale sincronizar a publicação com o web (#1140) para que as duas superfícies não exibam
subprocessadores diferentes ao mesmo tempo.

## Refs

Closes #678