### PR TITLE
fix(auth): restaurar tap-to-focus nos inputs de login (teclado não abria)

### DIFF
--- a/features/auth/screens/login-screen.test.tsx
+++ b/features/auth/screens/login-screen.test.tsx
@@ -90,23 +90,37 @@ describe("LoginScreen", () => {
     expect(getByPlaceholderText("Your password")).toBeTruthy();
   });
 
-  it("aplica halo premium enquanto o campo esta focado", () => {
-    const { getByPlaceholderText, getByTestId } = renderScreen();
+  it("aplica halo premium no proprio input enquanto focado", () => {
+    // #655: the focus halo lives on the Input itself, not on a wrapping shell.
+    // Nesting the Input inside a styled shell swallowed tap-to-focus on device;
+    // asserting the style on the input guards against reintroducing the wrapper.
+    const { getByPlaceholderText } = renderScreen();
     const emailInput = getByPlaceholderText("seu@email.com");
-    const emailShell = getByTestId("login-email-shell");
 
     fireEvent(emailInput, "focus");
-    expect(StyleSheet.flatten(emailShell.props.style)).toEqual(
+    expect(StyleSheet.flatten(emailInput.props.style)).toEqual(
       expect.objectContaining({
         borderColor: "rgba(155,233,255,0.6)",
       }),
     );
 
     fireEvent(emailInput, "blur");
-    expect(StyleSheet.flatten(emailShell.props.style)).toEqual(
+    expect(StyleSheet.flatten(emailInput.props.style)).toEqual(
       expect.objectContaining({
         borderColor: "rgba(255,255,255,0.16)",
       }),
+    );
+  });
+
+  it("estiliza a borda glass no proprio input (regressao #655)", () => {
+    // The glass border/background must live on the Input itself. If a styled
+    // shell wraps a transparent Input again — the layout that swallowed
+    // tap-to-focus — the border would move off the input and this fails.
+    const { getByPlaceholderText } = renderScreen();
+    const emailInput = getByPlaceholderText("seu@email.com");
+
+    expect(StyleSheet.flatten(emailInput.props.style)).toEqual(
+      expect.objectContaining({ borderColor: "rgba(255,255,255,0.16)" }),
     );
   });
 

--- a/features/auth/screens/login-screen.tsx
+++ b/features/auth/screens/login-screen.tsx
@@ -396,29 +396,24 @@ function PremiumInputField({
       >
         {label}
       </Label>
-      <XStack
-        testID={`${id}-shell`}
-        minHeight={54}
-        alignItems="center"
-        borderRadius={radii.md}
-        borderWidth={borderWidths.hairline}
-        backgroundColor={AUTH_GLASS}
-        paddingHorizontal="$3"
-        style={focused ? styles.inputShellFocused : styles.inputShellResting}
-      >
+      <YStack testID={`${id}-shell`} position="relative" justifyContent="center">
         <Input
           id={id}
           accessibilityLabel={accessibilityLabel ?? label}
           aria-invalid={Boolean(errorText)}
-          flex={1}
+          minHeight={54}
           height={54}
-          borderWidth={0}
-          backgroundColor="transparent"
+          borderRadius={radii.md}
+          borderWidth={borderWidths.hairline}
+          backgroundColor={AUTH_GLASS}
           color="#FFFFFF"
           fontFamily="$body"
           fontSize="$4"
           placeholderTextColor="$muted"
-          paddingHorizontal={0}
+          paddingHorizontal="$3"
+          // Reserve room so text never renders under the absolute trailing icon.
+          paddingRight={trailingIcon ? 52 : "$3"}
+          style={focused ? styles.inputShellFocused : styles.inputShellResting}
           {...rest}
           onBlur={(event) => {
             setFocused(false);
@@ -429,8 +424,23 @@ function PremiumInputField({
             onFocus?.(event);
           }}
         />
-        {trailingIcon}
-      </XStack>
+        {trailingIcon ? (
+          // Absolutely positioned over the input's right edge: the icon still
+          // receives its own taps, while the rest of the input stays tappable
+          // for focus. Nesting the Input inside a styled shell (the previous
+          // approach) swallowed tap-to-focus on Android and iOS (#655).
+          <YStack
+            position="absolute"
+            right={6}
+            top={0}
+            bottom={0}
+            alignItems="center"
+            justifyContent="center"
+          >
+            {trailingIcon}
+          </YStack>
+        ) : null}
+      </YStack>
       {errorText ? (
         <Paragraph color={colorPalette.red400} fontFamily="$body" fontSize="$2">
           {errorText}


### PR DESCRIPTION
## Summary

Regressão do redesign premium (#629): tocar nos inputs de email/senha do login **não abria o teclado**
em Android e iOS. O `PremiumInputField` aninhava o `Input` do Tamagui dentro de um `XStack` shell
estilizado, e o toque no shell nunca focava o `Input` aninhado.

## Correção

O `Input` volta a ser o elemento **diretamente estilizado** (borda/fundo glass no próprio Input) — o
padrão provado do `AppInputField`. O toggle de mostrar/ocultar senha fica **posicionado absolutamente**
sobre a borda direita do Input (recebe seus próprios toques; o resto do Input segue tocável para focar).
Visual premium preservado.

## Validation

- `npm run quality-check` verde: lint, typecheck, policy, contracts, **421 suites / 2749 testes**
- O teste do halo de foco passou a asserir no **próprio Input** (não num shell), guardando a regressão:
  se alguém reintroduzir o shell aninhado, o borderColor sai do input e o teste falha
- Teste novo: `estiliza a borda glass no proprio input (regressao #655)`

## Screenshots

Não anexadas: o Expo Web do app está quebrado (`createTamagui() missing tokens.size` — pré-existente)
e não há device/simulador nesta sessão. A correção é validada por unit test (foco no input) e o visual
premium é inalterado — só a estrutura do container mudou. Validação visual final no device do build.

## Refs

Closes #655
