### PR TITLE
fix(ci): allowlistar DoS de tooling que travava todo PR do app

### DIFF
--- a/scripts/ci-audit-gate.js
+++ b/scripts/ci-audit-gate.js
@@ -6,11 +6,22 @@ const os = require("node:os");
 const path = require("node:path");
 const { execSync } = require("node:child_process");
 
+// Allowlisted high/critical advisories. Each entry must be a transitive
+// build/dev-tooling dependency processing trusted input (the project's own
+// config/paths at build time), NOT a runtime path reachable by attacker input.
+// The permanent fix — a coordinated dependency bump validated in a build — is
+// tracked in #691; these entries keep the gate honest for the rest of the tree
+// meanwhile instead of blocking every app PR.
 const allowedIds = new Set([
   "GHSA-3ppc-4f35-3m26",
   "GHSA-7r86-cg39-jmmj",
   "GHSA-23c5-xmqv-rm74",
   "1113371",
+  // Published after 2026-07-19 — all quadratic/exponential-complexity DoS in
+  // parsers pulled in transitively by Metro / RN CLI / expo tooling (#691).
+  "GHSA-3jxr-9vmj-r5cp", // brace-expansion — DoS via exponential {} expansion
+  "GHSA-52cp-r559-cp3m", // js-yaml — quadratic CPU via YAML merge-key chains
+  "GHSA-395f-4hp3-45gv", // shell-quote — quadratic DoS in parse()
 ]);
 
 const runAudit = () => {


### PR DESCRIPTION
## Summary

O check **required `Dependency Audit (npm)`** passou a falhar em **todo PR do app** — inclusive os que
não tocam dependências (#689, #690). A `main` estava verde em 19/07, então **não é regressão de branch**:
são advisories **publicadas depois** dessa data que o gate ainda não conhecia.

## Diagnóstico

`scripts/ci-audit-gate.js` falha em qualquer high/critical fora da sua allowlist. Três advisories high
novas caíram:

| GHSA | Pacote | Natureza |
|------|--------|----------|
| GHSA-3jxr-9vmj-r5cp | brace-expansion | DoS via expansão exponencial de `{}` |
| GHSA-52cp-r559-cp3m | js-yaml | CPU quadrático via merge-key chains |
| GHSA-395f-4hp3-45gv | shell-quote | DoS quadrático em `parse()` |

As três são **transitivas de tooling de build** (Metro / RN CLI / expo), DoS de parser processando o
**input confiável** do próprio projeto em build — nenhuma é caminho de runtime alcançável por input de
atacante.

## Correção

Adicionadas à allowlist do gate, cada uma com justificativa por ID — mesmo padrão das advisories já
allowlistadas. O gate passa localmente (`node scripts/ci-audit-gate.js` → exit 0).

O **fix definitivo** (bump coordenado validado em build) fica na **#691** — allowlist é a mitigação
temporária para não travar o pipeline até lá.

## Validation

- `node scripts/ci-audit-gate.js` → `Audit gate passed`, exit 0

## Refs

Closes #693. Ref #691 (fix definitivo). Destrava #689 e #690.