### PR TITLE
fix(app): evitar crash no handoff pós-login em iOS e Android

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -49,6 +49,7 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - The visual layer is now a dedicated premium auth shell using the brand gradient, glass fields, white primary CTA and light status bar requested by the mobile handoff.
 - Login copy is read from `shared/i18n/locales/*.json`; the screen should not introduce new hardcoded product strings.
 - Premium login handoff hardening is tracked in `docs/handoffs/mobile-design-handoff-status-2026-07-01.md`; placeholder copy and glass focus styling must stay covered by login screen tests.
+- A successful login persists the canonical session before navigating to the private shell. Mounting that shell must not eagerly initialize every private route; the incident analysis and device smoke checklist live in `docs/wiki/mobile-login-crash-2026-07-23.md`.
 
 ## Private Navigation
 
@@ -56,12 +57,13 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - The bottom navigation follows the mobile liquid menu handoff with five visible tabs: `Início`, `Transações`, `Insights`, `Cartões` and `Mais`.
 - `Planejamento` is no longer a first-level tab; it is exposed through `MoreHubScreen` together with other secondary destinations.
 - The former center `+` action is removed from the tab bar. Quick transaction creation remains available from the `Mais` hub through the shared expense sheet store.
-- Tab content transitions use `core/navigation/tab-carousel-transition.ts`, which provides a fixed 480 ms full-width horizontal scene interpolation while keeping tab screens mounted.
+- Tab content transitions use `core/navigation/tab-carousel-transition.ts`, which provides a fixed 480 ms full-width horizontal scene interpolation.
+- The private navigator must keep `lazy: true` so only the focused route mounts during the post-login handoff. It must also keep `detachInactiveScreens` enabled so previously visited inactive screens leave the native view hierarchy while React Navigation preserves navigation state.
 - The active tab affordance lives in `core/navigation/app-tab-bar.tsx` as a Reanimated liquid blob with fixed spring parameters, a gradient surface and the active icon rendered in white.
 - The credit-cards guided tour no longer targets a `fab` anchor; its quick-transaction step is centered copy that points users to `Mais`.
 
 ## Validation
 
 - New or changed behavior must include tests in the same feature area.
-- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, shared-entries mobile parity including outgoing invitations, and transaction observation form/feed/controller coverage.
+- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, private navigator lazy/detach guarantees, shared-entries mobile parity including outgoing invitations, and transaction observation form/feed/controller coverage.
 - No backend or database interface was added by this slice. If a future calculator starts consuming an API, run contracts checks and live database validation as required by `AGENTS.md`.

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -35,8 +35,9 @@ No network call or database mutation is required until the user explicitly saves
 3. Premium labels and placeholders come from `shared/i18n/locales/*.json`; focus state only changes the local glass input shell styling.
 4. Email and password fields still write into the same React Hook Form controller.
 5. Submit calls `controller.handleSubmit`, preserving captcha enforcement and login mutation behavior.
-6. Successful login still consumes any stored auth redirect and navigates to the intended private route or dashboard.
-7. Session-expired and submit-error states render on the same screen without changing session policy.
+6. Successful login waits for the canonical session to be persisted, then consumes any stored auth redirect and navigates to the intended private route or dashboard.
+7. The private navigator mounts only the focused route (`lazy: true`) and detaches inactive screens from the native hierarchy, preventing the login handoff from initializing the complete private route tree.
+8. Session-expired and submit-error states render on the same screen without changing session policy.
 
 ## Shared Entries Flow
 
@@ -57,8 +58,9 @@ No network call or database mutation is required until the user explicitly saves
 4. When the active route changes, the Reanimated shared values move the liquid blob to the measured tab center with fixed spring parameters and squish timing.
 5. The active icon is rendered inside the blob while the active tab column reserves icon space and keeps the label visible.
 6. The tab navigator uses `createTabCarouselSceneStyleInterpolator(width)` plus `tabCarouselTransitionSpec` so route content slides horizontally with a fixed 480 ms timing curve.
-7. `MoreHubScreen` handles displaced actions: route cards call `router.push(href)`, while `Nova transação` opens the shared expense sheet store directly.
-8. The credit-cards tour quick-transaction step is centered instructional copy, so it does not depend on a removed `fab` anchor.
+7. `lazy: true` defers each route until its first focus; `detachInactiveScreens` removes inactive native views without changing route definitions or the custom tab transition.
+8. `MoreHubScreen` handles displaced actions: route cards call `router.push(href)`, while `Nova transação` opens the shared expense sheet store directly.
+9. The credit-cards tour quick-transaction step is centered instructional copy, so it does not depend on a removed `fab` anchor.
 
 ## Transaction Observation Flow
 
@@ -74,6 +76,6 @@ No network call or database mutation is required until the user explicitly saves
 - Pure calculator behavior is verified before screen tests.
 - Screen tests assert that inputs, results and controller actions are wired.
 - Feature flag tests assert production status for promoted parity features.
-- Login tests assert the premium surface, localized placeholders, focus styling and preserved auth controller actions.
+- Login tests assert the premium surface, localized placeholders, focus styling, preserved auth controller actions and safe lazy/detached initialization of the private navigator.
 - Shared-entries tests assert controller counts, summary rendering, tab counters, incoming/outgoing invitation separation, outgoing composer actions and stable tab actions.
 - Transaction observation tests cover schema validation, form submission/edit prefill, controller payloads, duplicate behavior, feed mapping, card rendering and action sheet details.

--- a/__tests__/app/private-layout.test.tsx
+++ b/__tests__/app/private-layout.test.tsx
@@ -171,7 +171,7 @@ describe("PrivateLayout", () => {
     expect(hiddenTabs).not.toContain("cartoes");
   });
 
-  it("configura transição horizontal de tabs com timing fixo", () => {
+  it("configura transição horizontal sem montar todas as rotas no login", () => {
     renderPrivateLayout();
 
     expect(mockTabsScreenOptions?.transitionSpec).toMatchObject({
@@ -180,8 +180,8 @@ describe("PrivateLayout", () => {
     });
     expect(mockTabsScreenOptions?.sceneStyleInterpolator).toEqual(expect.any(Function));
     expect(mockTabsScreenOptions).toMatchObject({
-      lazy: false,
+      lazy: true,
     });
-    expect(mockTabsProps).toMatchObject({ detachInactiveScreens: false });
+    expect(mockTabsProps).toMatchObject({ detachInactiveScreens: true });
   });
 });

--- a/app/(private)/_layout.tsx
+++ b/app/(private)/_layout.tsx
@@ -75,11 +75,11 @@ function PrivateLayoutContent(): ReactElement | null {
   return (
     <TourAnchorProvider>
       <Tabs
-        detachInactiveScreens={false}
+        detachInactiveScreens
         tabBar={(props) => <AppTabBar {...props} />}
         screenOptions={{
           headerShown: false,
-          lazy: false,
+          lazy: true,
           transitionSpec: tabCarouselTransitionSpec,
           sceneStyleInterpolator,
           tabBarActiveTintColor: tabTheme.primary,

--- a/docs/wiki/mobile-login-crash-2026-07-23.md
+++ b/docs/wiki/mobile-login-crash-2026-07-23.md
@@ -1,0 +1,170 @@
+# Incidente mobile: crash no handoff pós-login
+
+**Data da análise:** 2026-07-23
+
+**Issue:** [auraxis-app#704](https://github.com/italofelipe/auraxis-app/issues/704)
+
+**Plataformas afetadas:** iOS e Android
+
+**Área:** autenticação, sessão e navegação privada
+
+## Resumo
+
+Depois de um login válido, a sessão era persistida e o app navegava para o
+layout privado. Nesse primeiro mount, o navigator de tabs estava configurado
+para renderizar antecipadamente todas as rotas e manter telas inativas
+anexadas à hierarquia nativa.
+
+O diretório `app/(private)` contém 55 arquivos de tela. Inicializar esse grafo
+inteiro no handoff de autenticação aumenta abruptamente o uso de memória,
+executa efeitos de telas que o usuário ainda não abriu e amplia a superfície
+para falhas nativas. Como a configuração é compartilhada pelo React Navigation,
+o comportamento explica a reprodução tanto no iOS quanto no Android.
+
+## Evidências
+
+1. `useLoginMutation` aguarda `signIn`, que persiste a sessão canônica.
+2. `useLoginScreenController` navega para o redirect pretendido ou `/dashboard`.
+3. A navegação monta `app/(private)/_layout.tsx`.
+4. O commit `e587b70` (`feat(app): redesenhar menu inferior liquido (#635)`)
+   introduziu simultaneamente:
+   - `screenOptions.lazy: false`;
+   - `detachInactiveScreens: false`.
+5. A documentação do Bottom Tabs Navigator define `lazy: true` e
+   `detachInactiveScreens: true` como os padrões voltados a inicialização sob
+   demanda e economia de memória.
+6. O teste de regressão novo falhou antes da correção recebendo `lazy: false`
+   e passou depois da mudança.
+
+Referência:
+[React Navigation — Bottom Tabs Navigator](https://reactnavigation.org/docs/bottom-tab-navigator/).
+
+## Causa raiz
+
+O handoff pós-login estava acoplado a uma política de montagem agressiva do
+navigator privado. `lazy: false` mandava renderizar as rotas no primeiro render
+do navigator, enquanto `detachInactiveScreens: false` desabilitava a proteção
+que remove telas inativas da hierarquia nativa.
+
+Não houve mudança no contrato da API, no formato dos tokens, no SecureStore ou
+nas credenciais. A falha acontecia depois da autenticação, durante a entrada no
+shell privado.
+
+Sem logs nativos ou devices disponíveis nesta máquina, não é possível atribuir
+o encerramento a uma exceção nativa específica ou provar a pressão de memória
+de cada aparelho. A relação temporal, o ponto exato do handoff e a configuração
+cross-platform tornam a política de montagem a causa técnica de maior
+confiança. O smoke test em builds reais permanece obrigatório.
+
+## Correção
+
+O layout privado agora declara explicitamente:
+
+```tsx
+<Tabs
+  detachInactiveScreens
+  screenOptions={{
+    lazy: true,
+    // transição, tema e demais opções permanecem iguais
+  }}
+/>
+```
+
+Efeitos esperados:
+
+- somente a rota focada é montada na entrada da área autenticada;
+- cada tab é inicializada quando aberta pela primeira vez;
+- telas inativas saem da hierarquia nativa;
+- definições de rotas, estado de navegação, tab bar e transição horizontal
+  continuam inalterados.
+
+## Alternativas consideradas
+
+- **Remover a transição horizontal:** reduziria o escopo visual, mas a transição
+  não exige inicialização antecipada de todas as rotas.
+- **Dividir as 55 rotas em múltiplos navigators:** pode melhorar a arquitetura
+  no futuro, porém é uma mudança ampla e desnecessária para interromper o
+  incidente.
+- **Deixar os valores implícitos:** ambos já são padrões da biblioteca, mas os
+  valores explícitos tornam o contrato visível e testável contra regressões.
+
+## Validação automatizada
+
+Teste de regressão:
+
+```bash
+npm test -- --runInBand --forceExit __tests__/app/private-layout.test.tsx
+```
+
+Fluxo adjacente:
+
+```bash
+npm test -- --runInBand --forceExit \
+  features/auth/hooks/use-auth-mutations.test.ts \
+  features/auth/hooks/use-login-screen-controller.test.tsx \
+  core/session/session-store.test.ts \
+  core/session/session-storage.test.ts \
+  __tests__/app/private-layout.test.tsx
+```
+
+Resultado local: 5 suites, 34 testes, todos aprovados. O warning de i18n e a
+necessidade de `--forceExit` já existiam no harness do layout e não foram
+introduzidos pela correção.
+
+O quality gate completo também foi executado com sucesso:
+
+```bash
+GRAPHQL_SCHEMA_PATH=/caminho/para/auraxis-api/schema.graphql \
+  npm run quality-check
+```
+
+Resultado: lint, typecheck, nove verificações de governança, contratos, codegen,
+418 suites, 2.736 testes e seis snapshots aprovados.
+
+Os bundles de produção foram exportados para as duas plataformas:
+
+```bash
+npx expo export --platform ios --output-dir <diretorio-temporario>
+npx expo export --platform android --output-dir <diretorio-temporario>
+```
+
+As duas exportações concluíram sem erro. O aviso de configuração do Sentry usa
+variáveis do ambiente de build e não bloqueou os bundles.
+
+## Smoke test obrigatório em iOS e Android
+
+Executar em build que contenha a correção, uma vez em cada plataforma:
+
+1. Iniciar com estado limpo.
+2. Informar credenciais inválidas e confirmar que o app permanece no login com
+   mensagem de erro.
+3. Informar credenciais válidas e confirmar que o dashboard aparece sem
+   encerramento, tela branca ou reinício.
+4. Abrir, em sequência, `Transações`, `Insights`, `Cartões` e `Mais`.
+5. Voltar ao dashboard e confirmar que a tab bar e a transição horizontal
+   permanecem estáveis.
+6. Encerrar e reabrir o app; confirmar que a sessão persistida retorna à área
+   autenticada.
+7. Fazer logout e confirmar retorno ao login.
+
+O fluxo Maestro existente `.maestro/01_login.yaml` cobre login limpo e presença
+do dashboard. Ele deve ser executado em device/emulador iOS e Android quando o
+ambiente nativo estiver disponível.
+
+## Risco residual e observabilidade
+
+- Esta máquina não possui `simctl` nem `adb`; não houve smoke local em device.
+- O PR não altera `app.json`, `eas.json`, runtime version ou dependências
+  nativas.
+- Após distribuir o build, monitorar Sentry para encerramentos entre
+  `auth.session_established` e o primeiro evento de navegação do dashboard.
+- Se um crash nativo persistir, anexar à issue #704 o stack trace, modelo do
+  aparelho, versão do sistema, versão/build do app e canal de atualização.
+
+## Prevenção
+
+- Manter o teste de `lazy` e `detachInactiveScreens` no layout privado.
+- Tratar mudanças que montam vários módulos nativos no boot ou pós-login como
+  alterações de alto risco.
+- Validar em device qualquer mudança de navegação, splash ou runtime antes de
+  publicar OTA ou build de loja.


### PR DESCRIPTION
## Resumo

- restaura o carregamento sob demanda das rotas privadas com `lazy: true`;
- desanexa telas inativas da hierarquia nativa com `detachInactiveScreens`;
- mantém as cinco tabs, a tab bar customizada e a transição horizontal existentes;
- adiciona regressão para impedir a volta da montagem antecipada;
- documenta investigação, causa, decisão, validação e smoke test em `ARCHITECTURE.md`, `DATAFLOW.md` e [`docs/wiki/mobile-login-crash-2026-07-23.md`](https://github.com/italofelipe/auraxis-app/blob/fix/704-login-crash/docs/wiki/mobile-login-crash-2026-07-23.md).

## Causa raiz

O login persistia a sessão corretamente e navegava para o shell privado. Nesse mount, o navigator estava com `lazy: false` e `detachInactiveScreens: false`, configuração introduzida no redesign da navegação inferior. Com 55 arquivos de tela em `app/(private)`, o handoff inicializava antecipadamente o grafo privado e mantinha telas inativas na hierarquia nativa. A configuração compartilhada explica o encerramento observado tanto no iOS quanto no Android.

A correção explicita os padrões seguros do Bottom Tabs Navigator sem alterar API, tokens, SecureStore, rotas ou dependências nativas.

## Validação

- ciclo vermelho/verde do teste `__tests__/app/private-layout.test.tsx`;
- fluxo adjacente de auth/sessão/layout: 5 suites e 34 testes aprovados;
- `npm run quality-check` com schema GraphQL local: lint, typecheck, nove gates de governança, contratos, codegen, 418 suites, 2.736 testes e seis snapshots aprovados;
- cobertura total: 94,76% statements, 84,92% branches, 94,87% functions e 94,73% lines;
- export de bundle iOS concluído;
- export de bundle Android concluído;
- hooks de commit/push: gitleaks, políticas, contratos, typecheck e cobertura aprovados.

## Riscos residuais

- esta máquina não possui `simctl` nem `adb`, portanto o smoke em device real não pôde ser executado localmente;
- `.maestro/01_login.yaml` deve ser executado em build/device iOS e Android antes da distribuição;
- os warnings preexistentes de teardown/`act(...)`, i18n e dependências high/moderate não bloquearam os gates e não foram introduzidos por este diff;
- nenhum contrato de API/DB, `app.json`, `eas.json`, runtime version ou dependência foi alterado.

## Evidência visual

Não há mudança visual. Screenshot não foi anexado porque o diff altera apenas a política de montagem do navigator e o ambiente local não possui simulador/device nativo.

Closes #704