### PR TITLE
fix(updates): adopt fingerprint runtimeVersion policy and align app version

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,9 +2,9 @@
   "expo": {
     "name": "auraxis-app",
     "slug": "auraxis-app",
-    "version": "1.0.0",
+    "version": "1.13.4",
     "runtimeVersion": {
-      "policy": "appVersion"
+      "policy": "fingerprint"
     },
     "updates": {
       "url": "https://u.expo.dev/f775e10b-89c3-4bb9-8af1-5073e68ac2ce",


### PR DESCRIPTION
## Resumo
Pré-requisito do build de recuperação (#657), fecha o achado da auditoria (#702):
- `version`: 1.0.0 → **1.13.4** (paridade com package.json; novo version train nas lojas).
- `runtimeVersion`: `appVersion` → **`fingerprint`**.

**Por quê:** todos os binários de loja compartilhavam runtime "1.0.0" — qualquer OTA atingia qualquer binário (mecanismo do brick de 10/07, evidência via `eas update:list` na #702). Com fingerprint, cada build tem runtime derivado do conteúdo nativo real; OTAs só chegam a binários comprovadamente compatíveis.

**Operacional pós-merge:** canal `production` com runtime 1.0.0 vira legado congelado (nunca mais publicar nele); próximo build EAS (production) nasce com fingerprint próprio; `autoIncrement` remoto segue a sequência (Android versionCode 22+).

## Validação
`npx expo config --type public` compila; pre-push completo verde (suíte inteira).

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WCQunEjQs5YziwSwFKqJJr