### PR TITLE
fix(subscription): habilitar gestão e cancelamento por provedor

### DIFF
--- a/.maestro/08_subscription_checkout_smoke.yaml
+++ b/.maestro/08_subscription_checkout_smoke.yaml
@@ -5,4 +5,8 @@ appId: com.sensoriumit.auraxis
 - openLink: auraxisapp://assinatura
 - assertVisible: "Sua assinatura"
 - assertVisible: "Planos disponiveis"
-- assertVisible: "Gerenciar assinatura"
+- assertVisible: "Cancelar assinatura"
+- tapOn: "Cancelar assinatura"
+- assertVisible: "Cancelar assinatura?"
+- assertVisible: "Manter assinatura"
+- tapOn: "Manter assinatura"

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,15 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - `TransactionForm` edits both fields independently; `useTransactionsScreenController` forwards `observation` through create, update and duplicate flows without introducing a new endpoint.
 - The feed view-model and action sheet render observations as a separate detail block so historical descriptions remain visible and untouched.
 
+## Subscription Management
+
+- `/assinatura` remains the canonical private mobile route and composes subscription state, plan catalog, checkout, trial and management in `SubscriptionScreen`.
+- `useSubscriptionManagementController` isolates cancellation side effects from the screen/checkout controller. It calls the existing `POST /subscriptions/cancel` mutation, writes the returned subscription into the canonical query cache and invalidates both `subscription` and `entitlements`.
+- `subscription-management.ts` resolves the management owner from the API `provider`: `abacatepay`, `asaas`, `stub` and provider-less trials use the Auraxis API; Apple and Google providers open their official store management centers; unknown providers fall back to the canonical Web route `/subscription`.
+- API-managed cancellation requires an explicit confirmation sheet, blocks concurrent submissions with a synchronous in-flight guard and preserves the confirmed access-end date returned by the backend.
+- Store-managed subscriptions never call the Auraxis cancellation endpoint. The store remains responsible for confirmation, renewal and cancellation.
+- The provider matrix, recovery behavior and iOS/Android smoke procedure are documented in `docs/wiki/subscription-management-and-cancellation-2026-07-23.md`.
+
 ## Shared Entries Surface
 
 - `/compartilhamentos` mounts `SharedEntriesScreen`, guarded by `PaywallGate` for the `shared_entries` entitlement.
@@ -65,5 +74,5 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 ## Validation
 
 - New or changed behavior must include tests in the same feature area.
-- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, private navigator lazy/detach guarantees, shared-entries mobile parity including outgoing invitations, and transaction observation form/feed/controller coverage.
+- For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, private navigator lazy/detach guarantees, shared-entries mobile parity including outgoing invitations, transaction observation form/feed/controller coverage, and subscription provider resolution/cancellation/controller/screen coverage.
 - No backend or database interface was added by this slice. If a future calculator starts consuming an API, run contracts checks and live database validation as required by `AGENTS.md`.

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -71,6 +71,21 @@ No network call or database mutation is required until the user explicitly saves
 5. `toFeedItem` copies `observation` into the feed view-model, and `TxCardBody` renders it under an `Observações` label when present.
 6. `TransactionActionSheet` shows description and observations as separate details before the action buttons.
 
+## Subscription Management Flow
+
+1. `SubscriptionScreen` reads `/subscriptions/me` through `useSubscriptionStateQuery`.
+2. `resolveSubscriptionManagementAction` normalizes the returned `provider` and chooses exactly one owner:
+   - `abacatepay`, `asaas`, `stub` or a provider-less active/trial subscription: Auraxis API;
+   - Apple aliases: App Store subscriptions center;
+   - Google aliases: Google Play subscriptions center;
+   - unknown provider: canonical Auraxis Web page `/subscription`.
+3. For an API-managed subscription, tapping `Cancelar assinatura` only opens the confirmation sheet. No request is sent before the explicit confirmation.
+4. Confirmation calls `useCancelSubscriptionMutation`, which sends `POST /subscriptions/cancel` without inventing a second provider contract.
+5. A synchronous in-flight guard rejects duplicate taps while the mutation is active.
+6. Success writes the returned `SubscriptionState` into `queryKeys.subscription.me()`, invalidates `subscription` and `entitlements`, closes the sheet and shows the final access date.
+7. Failure keeps the sheet open, preserves the existing subscription and exposes retry/close actions.
+8. Store-managed subscriptions open the official store surface; an opening failure stays on-screen with retry instead of silently dropping the action.
+
 ## Testing Flow
 
 - Pure calculator behavior is verified before screen tests.
@@ -79,3 +94,4 @@ No network call or database mutation is required until the user explicitly saves
 - Login tests assert the premium surface, localized placeholders, focus styling, preserved auth controller actions and safe lazy/detached initialization of the private navigator.
 - Shared-entries tests assert controller counts, summary rendering, tab counters, incoming/outgoing invitation separation, outgoing composer actions and stable tab actions.
 - Transaction observation tests cover schema validation, form submission/edit prefill, controller payloads, duplicate behavior, feed mapping, card rendering and action sheet details.
+- Subscription tests cover provider routing, canonical URL fallback, API response mapping, duplicate-request prevention, query/entitlement invalidation, explicit confirmation, retry, loading and post-cancellation states.

--- a/__tests__/app/subscription-screen.test.tsx
+++ b/__tests__/app/subscription-screen.test.tsx
@@ -79,14 +79,30 @@ describe("SubscriptionScreen", () => {
       trialOffer: null,
       isStartingCheckout: false,
       isStartingTrial: false,
+      isCancelingSubscription: false,
+      isCancelConfirmationOpen: false,
       checkoutError: null,
       trialError: null,
+      cancelError: null,
+      managementError: null,
       lastCheckoutOutcome: null,
+      lastCanceledSubscription: null,
+      managementAction: {
+        mode: "api",
+        label: "Cancelar assinatura",
+        description:
+          "O cancelamento interrompe a renovacao e preserva o acesso ja contratado.",
+        url: null,
+      },
       handleSubscribe: jest.fn().mockResolvedValue(undefined),
       handleStartTrial: jest.fn().mockResolvedValue(undefined),
       handleManageSubscription: jest.fn().mockResolvedValue(undefined),
+      handleCancelSubscription: jest.fn().mockResolvedValue(undefined),
+      closeCancelConfirmation: jest.fn(),
       dismissCheckoutError: jest.fn(),
       dismissTrialError: jest.fn(),
+      dismissManagementError: jest.fn(),
+      dismissCancellationFeedback: jest.fn(),
     });
 
     const { getByText } = render(
@@ -96,6 +112,6 @@ describe("SubscriptionScreen", () => {
     );
 
     expect(getByText("Sua assinatura")).toBeTruthy();
-    expect(getByText("Gerenciar assinatura")).toBeTruthy();
+    expect(getByText("Cancelar assinatura")).toBeTruthy();
   });
 });

--- a/core/observability/analytics-types.ts
+++ b/core/observability/analytics-types.ts
@@ -56,6 +56,13 @@ export interface SubscriptionCheckoutAnalyticsProperties
   readonly status?: "opened" | "completed" | "cancelled" | "unknown";
 }
 
+export interface SubscriptionManagementAnalyticsProperties
+  extends AnalyticsProperties {
+  readonly provider?: string;
+  readonly mode?: "api" | "app-store" | "play-store" | "web";
+  readonly status?: "opened" | "completed";
+}
+
 export interface DashboardPeriodChangedAnalyticsProperties
   extends AnalyticsProperties {
   readonly period: string;
@@ -74,6 +81,8 @@ export interface AnalyticsEventPropertiesByName {
   readonly "tool.used": ToolUsedAnalyticsProperties;
   readonly "subscription.checkout.opened": SubscriptionCheckoutAnalyticsProperties;
   readonly "subscription.checkout.completed": SubscriptionCheckoutAnalyticsProperties;
+  readonly "subscription.management.opened": SubscriptionManagementAnalyticsProperties;
+  readonly "subscription.cancel.completed": SubscriptionManagementAnalyticsProperties;
   readonly "dashboard.period.changed": DashboardPeriodChangedAnalyticsProperties;
 }
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -127,8 +127,9 @@ incident note e confirmar que um dispositivo instalado recebe o rollback.
 - Dashboard carrega contra `api.auraxis.com.br` (nunca localhost — guard #521).
 - Transação: criar/excluir/restaurar; troca de período mensal.
 - Meta: criar e simular.
-- Assinatura abre hosted checkout; store checkout falha com segurança até
-  StoreKit/Play Billing serem configurados.
+- Assinatura abre hosted checkout; provider API exige confirmacao antes de
+  cancelar e atualiza a data final de acesso; providers Apple/Google abrem a
+  gestao oficial da loja.
 - Privacy center: opt-out de analytics interrompe eventos PostHog.
 - Push opt-in trata permissão negada/indisponível.
 - Deep links: link privado roteia após login; link inválido cai no fallback.

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -151,6 +151,7 @@ Eventos instrumentados no app:
 - `goal.created`, `goal.simulated`.
 - `tool.used`.
 - `subscription.checkout.opened`, `subscription.checkout.completed`.
+- `subscription.management.opened`, `subscription.cancel.completed`.
 - `dashboard.period.changed`.
 - screen views via Expo Router (`posthog.screen(pathname, metadata)`).
 
@@ -167,6 +168,12 @@ tela canonica de assinatura:
 Esse valor e publico e nao deve conter segredo. A decisao de entitlement e
 subscription continua no backend; o app apenas escolhe o provider de compra por
 canal e invalida `subscription`/`entitlements` depois do retorno.
+
+Depois da compra, a gestao usa o `provider` retornado por
+`GET /subscriptions/me`, nao `EXPO_PUBLIC_CHECKOUT_PROVIDER`. Assinaturas
+`abacatepay`, `asaas`, `stub` e trials internos cancelam por
+`POST /subscriptions/cancel`; assinaturas Apple/Google abrem a gestao oficial
+da loja; provider desconhecido usa `https://app.auraxis.com.br/subscription`.
 
 ## Push notifications
 

--- a/docs/wiki/subscription-management-and-cancellation-2026-07-23.md
+++ b/docs/wiki/subscription-management-and-cancellation-2026-07-23.md
@@ -1,0 +1,144 @@
+# Gestao e cancelamento de assinatura no app
+
+**Data:** 2026-07-23
+
+**Issue:** [auraxis-app#698](https://github.com/italofelipe/auraxis-app/issues/698)
+
+**Plataformas:** iOS e Android
+
+## Resumo
+
+A tela mobile de assinatura mostrava um botao `Gerenciar assinatura`, mas ele
+apenas tentava abrir `https://app.auraxis.com.br/conta/assinatura`. Essa rota
+nao existe no Web, cujo caminho canonico e `/subscription`. O app ja possuia o
+service e a mutation para `POST /subscriptions/cancel`, porem nenhum fluxo da
+tela os acionava.
+
+O resultado era uma gestao inoperante: assinaturas do gateway nao podiam ser
+canceladas no app e o fallback Web levava a um destino incorreto.
+
+## Causa raiz
+
+Havia tres partes implementadas isoladamente, sem orquestracao:
+
+1. `subscriptionService.cancelSubscription()` ja mapeava a resposta da API.
+2. `useCancelSubscriptionMutation()` ja encapsulava a mutation.
+3. `SubscriptionScreen` ignorava ambas e ligava o unico CTA diretamente a uma
+   constante Web desatualizada.
+
+Tambem nao existia uma decisao baseada no `provider`. Tratar da mesma forma uma
+assinatura controlada pela Auraxis e outra controlada pela App Store/Google
+Play poderia enviar o usuario ao sistema errado ou solicitar um cancelamento
+que a API nao possui autoridade para executar.
+
+## Solucao
+
+### Matriz de provider
+
+| Provider normalizado | Superficie de gestao | Comportamento |
+|---|---|---|
+| `abacatepay`, `asaas`, `stub` | API Auraxis | Confirmacao local e `POST /subscriptions/cancel` |
+| provider ausente em `trialing`, `active` ou `past_due` | API Auraxis | Mesmo fluxo, cobrindo trial interno |
+| `apple`, `app_store`, `app-store`, `appstore` | App Store | Abre `https://apps.apple.com/account/subscriptions` |
+| `google`, `google_play`, `google-play`, `play_store`, `play-store` | Google Play | Abre `https://play.google.com/store/account/subscriptions` |
+| outro provider ativo | Web Auraxis | Abre `https://app.auraxis.com.br/subscription` |
+
+Providers de loja continuam com acesso a gestao mesmo depois do status
+`canceled`, porque a loja pode oferecer detalhes ou reativacao. Providers da
+API nao exibem um novo cancelamento para `free`, `canceled` ou `expired`.
+
+### Cancelamento pela API
+
+1. O CTA abre um modal e nao dispara rede.
+2. O modal explica que a renovacao sera interrompida e mostra, quando
+   disponivel, `current_period_end` como data final de acesso.
+3. A confirmacao chama a mutation canonica.
+4. Um guard sincrono bloqueia taps duplicados, inclusive antes do rerender que
+   atualiza `isPending`.
+5. Sucesso grava a resposta em `["subscription", "me"]` e invalida os grupos
+   `subscription` e `entitlements`.
+6. A tela fecha o modal e confirma a data final de acesso.
+7. Erro mantem o modal aberto, nao altera o estado conhecido e oferece retry.
+
+### Gestao externa
+
+Apple e Google recebem uma explicacao de que a loja controla renovacao e
+cancelamento. Se o sistema nao conseguir abrir a URL, o app exibe erro com
+retry e permanece na tela.
+
+As URLs seguem a documentacao oficial:
+
+- [Apple — Handling Subscriptions Billing](https://developer.apple.com/documentation/storekit/handling-subscriptions-billing)
+- [Google Play Billing — About subscriptions](https://developer.android.com/google/play/billing/subscriptions)
+
+## Arquivos principais
+
+- `features/subscription/services/subscription-management.ts`: matriz e
+  fallback seguro.
+- `features/subscription/hooks/use-subscription-management-controller.ts`:
+  confirmacao, mutation, idempotencia, cache e analytics.
+- `features/subscription/components/subscription-cancel-modal.tsx`: confirmacao,
+  loading e retry.
+- `features/subscription/screens/subscription-screen.tsx`: contexto por
+  provider e feedback final.
+- `shared/config/web-urls.ts`: rota Web canonica e centros oficiais das lojas.
+
+## Validacao automatizada
+
+Cobertura focada:
+
+```bash
+CI=1 npm test -- --runInBand --forceExit \
+  features/subscription/services/subscription-management.test.ts \
+  features/subscription/services/subscription-service.test.ts \
+  features/subscription/hooks/use-subscription-management-controller.test.tsx \
+  features/subscription/hooks/use-subscription-screen-controller.test.tsx \
+  features/subscription/screens/subscription-screen.test.tsx
+```
+
+Os testes cobrem:
+
+- AbacatePay, Asaas, stub, trial sem provider, Apple, Google e provider
+  desconhecido;
+- rota e mapeamento de `POST /subscriptions/cancel`;
+- atualizacao de cache e invalidacao de entitlements;
+- bloqueio de duas requisicoes simultaneas;
+- erro e retry de API/Linking;
+- confirmacao, loading, data final e estado cancelado na tela.
+
+O gate completo obrigatorio e:
+
+```bash
+npm run quality-check
+```
+
+## Smoke obrigatorio em iOS e Android
+
+Executar o mesmo roteiro em um build iOS e em um Android:
+
+1. Entrar com usuario que tenha assinatura ativa AbacatePay/Asaas.
+2. Abrir `Mais > Assinatura` ou o deep link `auraxisapp://assinatura`.
+3. Confirmar plano, status, provider contextual e data da proxima cobranca.
+4. Tocar `Cancelar assinatura` e confirmar que nenhuma alteracao ocorre antes
+   do segundo CTA.
+5. Tocar `Manter assinatura` e confirmar que o modal fecha.
+6. Abrir novamente, confirmar o cancelamento e aguardar o feedback final.
+7. Confirmar status `Cancelada`, `Cancelada em` e `Acesso ate`.
+8. Fechar/reabrir o app e confirmar que o estado persiste.
+9. Em conta de teste Apple/Google, confirmar que o CTA abre a gestao da loja e
+   que a tela da Auraxis nao chama o endpoint de cancelamento.
+10. Desligar a conectividade antes da confirmacao e validar erro + retry.
+
+O fluxo Maestro `.maestro/08_subscription_checkout_smoke.yaml` cobre a
+abertura e o abandono seguro da confirmacao. O cancelamento real permanece
+manual porque altera o estado financeiro da conta de teste.
+
+## Riscos residuais
+
+- O app ainda nao implementa compra nativa StoreKit/Play Billing; os aliases de
+  provider deixam a gestao pronta para estados vindos do backend, sem fingir
+  uma integracao de compra que nao existe.
+- O smoke real depende de contas de teste com assinatura ativa em cada
+  provider e nao pode ser concluido apenas pelo Jest.
+- Provider novo cai intencionalmente na pagina Web canonica ate ser adicionado
+  de forma explicita a matriz.

--- a/features/subscription/components/subscription-cancel-modal.tsx
+++ b/features/subscription/components/subscription-cancel-modal.tsx
@@ -1,0 +1,101 @@
+import type { ReactElement } from "react";
+
+import { Modal } from "react-native";
+import { YStack } from "tamagui";
+
+import { AppButton } from "@/shared/components/app-button";
+import { AppErrorNotice } from "@/shared/components/app-error-notice";
+import { AppSurfaceCard } from "@/shared/components/app-surface-card";
+
+export interface SubscriptionCancelModalProps {
+  readonly visible: boolean;
+  readonly currentPeriodEnd: string | null;
+  readonly isSubmitting: boolean;
+  readonly error: unknown | null;
+  readonly onConfirm: () => void;
+  readonly onClose: () => void;
+}
+
+const formatAccessEnd = (currentPeriodEnd: string | null): string => {
+  if (!currentPeriodEnd) {
+    return "A API confirmara a data final de acesso depois do cancelamento.";
+  }
+
+  return `Seu acesso continua ate ${new Date(currentPeriodEnd).toLocaleDateString(
+    "pt-BR",
+  )}.`;
+};
+
+/**
+ * Explicit confirmation for API-managed subscription cancellation.
+ */
+export function SubscriptionCancelModal({
+  visible,
+  currentPeriodEnd,
+  isSubmitting,
+  error,
+  onConfirm,
+  onClose,
+}: SubscriptionCancelModalProps): ReactElement {
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={isSubmitting ? undefined : onClose}
+    >
+      <YStack
+        flex={1}
+        backgroundColor="rgba(0,0,0,0.45)"
+        justifyContent="flex-end"
+        testID="subscription-cancel-modal"
+      >
+        <YStack
+          backgroundColor="$background"
+          padding="$4"
+          gap="$3"
+          borderTopLeftRadius="$3"
+          borderTopRightRadius="$3"
+        >
+          <AppSurfaceCard
+            title="Cancelar assinatura?"
+            description={`A renovacao automatica sera interrompida. ${formatAccessEnd(
+              currentPeriodEnd,
+            )}`}
+          >
+            <YStack gap="$3">
+              {error ? (
+                <AppErrorNotice
+                  error={error}
+                  fallbackTitle="Nao foi possivel cancelar a assinatura"
+                  fallbackDescription="A assinatura nao foi alterada. Tente novamente."
+                  actionLabel="Tentar novamente"
+                  onAction={onConfirm}
+                  testID="subscription-cancel-error"
+                />
+              ) : null}
+              {!error ? (
+                <AppButton
+                  tone="danger"
+                  onPress={onConfirm}
+                  disabled={isSubmitting}
+                  testID="confirm-subscription-cancel"
+                >
+                  {isSubmitting ? "Cancelando..." : "Confirmar cancelamento"}
+                </AppButton>
+              ) : null}
+              <AppButton
+                tone="secondary"
+                onPress={onClose}
+                disabled={isSubmitting}
+                testID="keep-subscription"
+              >
+                Manter assinatura
+              </AppButton>
+            </YStack>
+          </AppSurfaceCard>
+        </YStack>
+      </YStack>
+    </Modal>
+  );
+}

--- a/features/subscription/hooks/use-subscription-management-controller.test.tsx
+++ b/features/subscription/hooks/use-subscription-management-controller.test.tsx
@@ -1,0 +1,245 @@
+import { act, renderHook } from "@testing-library/react-native";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { Linking } from "react-native";
+
+import { ApiError } from "@/core/http/api-error";
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+import { useAnalytics } from "@/core/observability/use-analytics";
+import type { SubscriptionState } from "@/features/subscription/contracts";
+import { useSubscriptionManagementController } from "@/features/subscription/hooks/use-subscription-management-controller";
+import { useCancelSubscriptionMutation } from "@/features/subscription/hooks/use-subscription-mutations";
+import {
+  APPLE_SUBSCRIPTIONS_URL,
+  MANAGE_SUBSCRIPTION_URL,
+} from "@/shared/config/web-urls";
+
+jest.mock("@/features/subscription/hooks/use-subscription-mutations", () => ({
+  useCancelSubscriptionMutation: jest.fn(),
+}));
+jest.mock("@/core/observability/use-analytics", () => ({
+  useAnalytics: jest.fn(),
+}));
+
+const mockedUseCancel = jest.mocked(useCancelSubscriptionMutation);
+const mockedUseAnalytics = jest.mocked(useAnalytics);
+const analyticsClient: jest.Mocked<AnalyticsClient> = {
+  capture: jest.fn(),
+  identify: jest.fn(),
+  reset: jest.fn(),
+  screen: jest.fn(),
+};
+
+const buildSubscription = (
+  override: Partial<SubscriptionState> = {},
+): SubscriptionState => ({
+  id: "sub-1",
+  userId: "user-1",
+  planCode: "premium",
+  offerCode: null,
+  status: "active",
+  billingCycle: "monthly",
+  provider: "abacatepay",
+  providerSubscriptionId: "provider-sub-1",
+  trialEndsAt: null,
+  currentPeriodStart: "2026-07-01T00:00:00Z",
+  currentPeriodEnd: "2026-08-01T00:00:00Z",
+  canceledAt: null,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+  ...override,
+});
+
+let client: QueryClient;
+let cancelMutateAsync: jest.Mock;
+let cancelReset: jest.Mock;
+
+const wrapper = ({ children }: { children: ReactNode }) => (
+  <QueryClientProvider client={client}>{children}</QueryClientProvider>
+);
+
+beforeEach(() => {
+  client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  cancelMutateAsync = jest.fn();
+  cancelReset = jest.fn();
+  mockedUseCancel.mockReturnValue({
+    mutateAsync: cancelMutateAsync,
+    reset: cancelReset,
+    isPending: false,
+    error: null,
+  } as never);
+  mockedUseAnalytics.mockReturnValue(analyticsClient);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe("subscription management via API", () => {
+  it("abre confirmacao local sem navegar para outra URL", async () => {
+    const openUrlSpy = jest.spyOn(Linking, "openURL");
+    const { result } = renderHook(
+      () => useSubscriptionManagementController(buildSubscription()),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleManageSubscription();
+    });
+
+    expect(result.current.managementAction?.mode).toBe("api");
+    expect(result.current.isCancelConfirmationOpen).toBe(true);
+    expect(openUrlSpy).not.toHaveBeenCalled();
+  });
+
+  it("atualiza cache e invalida assinatura e entitlements no sucesso", async () => {
+    const active = buildSubscription();
+    const canceled = buildSubscription({
+      status: "canceled",
+      canceledAt: "2026-07-23T22:00:00Z",
+    });
+    cancelMutateAsync.mockResolvedValueOnce(canceled);
+    const invalidateSpy = jest.spyOn(client, "invalidateQueries");
+    const { result } = renderHook(
+      () => useSubscriptionManagementController(active),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleCancelSubscription();
+    });
+
+    expect(client.getQueryData(["subscription", "me"])).toEqual(canceled);
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["subscription"],
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["entitlements"],
+    });
+    expect(result.current.lastCanceledSubscription).toEqual(canceled);
+    expect(analyticsClient.capture).toHaveBeenCalledWith(
+      "subscription.cancel.completed",
+      {
+        provider: "abacatepay",
+        mode: "api",
+        status: "completed",
+      },
+    );
+  });
+
+  it("impede duas requisicoes simultaneas", async () => {
+    let resolveCancellation: ((value: SubscriptionState) => void) | undefined;
+    cancelMutateAsync.mockImplementationOnce(
+      () =>
+        new Promise<SubscriptionState>((resolve) => {
+          resolveCancellation = resolve;
+        }),
+    );
+    const { result } = renderHook(
+      () => useSubscriptionManagementController(buildSubscription()),
+      { wrapper },
+    );
+
+    let firstRequest: Promise<void> | undefined;
+    await act(async () => {
+      firstRequest = result.current.handleCancelSubscription();
+      await result.current.handleCancelSubscription();
+    });
+    expect(cancelMutateAsync).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCancellation?.(buildSubscription({ status: "canceled" }));
+      await firstRequest;
+    });
+  });
+
+  it("mantem confirmacao aberta e permite retry depois de erro", async () => {
+    cancelMutateAsync
+      .mockRejectedValueOnce(
+        new ApiError({ message: "billing unavailable", status: 503 }),
+      )
+      .mockResolvedValueOnce(buildSubscription({ status: "canceled" }));
+    const { result } = renderHook(
+      () => useSubscriptionManagementController(buildSubscription()),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleManageSubscription();
+      await result.current.handleCancelSubscription();
+    });
+    expect(result.current.cancelError).toBeInstanceOf(ApiError);
+    expect(result.current.isCancelConfirmationOpen).toBe(true);
+
+    await act(async () => {
+      await result.current.handleCancelSubscription();
+    });
+    expect(cancelMutateAsync).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("subscription management via external owner", () => {
+  it("abre a gestao oficial da App Store", async () => {
+    const openUrlSpy = jest
+      .spyOn(Linking, "openURL")
+      .mockResolvedValueOnce(true as never);
+    const { result } = renderHook(
+      () =>
+        useSubscriptionManagementController(
+          buildSubscription({ provider: "app_store" }),
+        ),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleManageSubscription();
+    });
+
+    expect(openUrlSpy).toHaveBeenCalledWith(APPLE_SUBSCRIPTIONS_URL);
+    expect(result.current.isCancelConfirmationOpen).toBe(false);
+  });
+
+  it("usa a pagina Web canonica para provider desconhecido", async () => {
+    const openUrlSpy = jest
+      .spyOn(Linking, "openURL")
+      .mockResolvedValueOnce(true as never);
+    const { result } = renderHook(
+      () =>
+        useSubscriptionManagementController(
+          buildSubscription({ provider: "future-provider" }),
+        ),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleManageSubscription();
+    });
+
+    expect(openUrlSpy).toHaveBeenCalledWith(MANAGE_SUBSCRIPTION_URL);
+  });
+
+  it("expoe erro recuperavel quando o Linking falha", async () => {
+    jest
+      .spyOn(Linking, "openURL")
+      .mockRejectedValueOnce(new Error("cannot open"));
+    const { result } = renderHook(
+      () =>
+        useSubscriptionManagementController(
+          buildSubscription({ provider: "app_store" }),
+        ),
+      { wrapper },
+    );
+
+    await act(async () => {
+      await result.current.handleManageSubscription();
+    });
+    expect(result.current.managementError).toEqual(
+      expect.objectContaining({ message: "cannot open" }),
+    );
+
+    act(() => {
+      result.current.dismissManagementError();
+    });
+    expect(result.current.managementError).toBeNull();
+  });
+});

--- a/features/subscription/hooks/use-subscription-management-controller.ts
+++ b/features/subscription/hooks/use-subscription-management-controller.ts
@@ -1,0 +1,178 @@
+import { type QueryClient, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useRef, useState } from "react";
+import { Linking } from "react-native";
+
+import type { AnalyticsClient } from "@/core/observability/analytics-types";
+import { useAnalytics } from "@/core/observability/use-analytics";
+import { queryKeys } from "@/core/query/query-keys";
+import type { SubscriptionState } from "@/features/subscription/contracts";
+import { useCancelSubscriptionMutation } from "@/features/subscription/hooks/use-subscription-mutations";
+import {
+  resolveSubscriptionManagementAction,
+  type SubscriptionManagementAction,
+} from "@/features/subscription/services/subscription-management";
+
+export interface SubscriptionManagementController {
+  readonly isCancelingSubscription: boolean;
+  readonly isCancelConfirmationOpen: boolean;
+  readonly cancelError: unknown | null;
+  readonly managementError: unknown | null;
+  readonly lastCanceledSubscription: SubscriptionState | null;
+  readonly managementAction: SubscriptionManagementAction | null;
+  readonly handleManageSubscription: () => Promise<void>;
+  readonly handleCancelSubscription: () => Promise<void>;
+  readonly closeCancelConfirmation: () => void;
+  readonly dismissManagementError: () => void;
+  readonly dismissCancellationFeedback: () => void;
+}
+
+interface ManageHandlerOptions {
+  readonly action: SubscriptionManagementAction | null;
+  readonly subscription: SubscriptionState | null;
+  readonly analytics: AnalyticsClient;
+  readonly setCancelError: (error: unknown | null) => void;
+  readonly setManagementError: (error: unknown | null) => void;
+  readonly setConfirmationOpen: (open: boolean) => void;
+}
+
+const createManageHandler =
+  (options: ManageHandlerOptions) => async (): Promise<void> => {
+    const { action } = options;
+    if (!action) {
+      return;
+    }
+
+    options.setManagementError(null);
+    if (action.mode === "api") {
+      options.setCancelError(null);
+      options.setConfirmationOpen(true);
+      return;
+    }
+
+    if (!action.url) {
+      return;
+    }
+
+    try {
+      await Linking.openURL(action.url);
+      options.analytics.capture("subscription.management.opened", {
+        provider: options.subscription?.provider ?? "unknown",
+        mode: action.mode,
+        status: "opened",
+      });
+    } catch (error) {
+      options.setManagementError(error);
+    }
+  };
+
+interface CancelHandlerOptions {
+  readonly action: SubscriptionManagementAction | null;
+  readonly subscription: SubscriptionState | null;
+  readonly analytics: AnalyticsClient;
+  readonly queryClient: QueryClient;
+  readonly mutation: ReturnType<typeof useCancelSubscriptionMutation>;
+  readonly inFlight: { current: boolean };
+  readonly setError: (error: unknown | null) => void;
+  readonly setConfirmationOpen: (open: boolean) => void;
+  readonly setCanceledSubscription: (subscription: SubscriptionState) => void;
+}
+
+const createCancelHandler =
+  (options: CancelHandlerOptions) => async (): Promise<void> => {
+    const { action, inFlight, mutation, queryClient, subscription } = options;
+    if (inFlight.current || action?.mode !== "api" || !subscription) {
+      return;
+    }
+
+    inFlight.current = true;
+    options.setError(null);
+    mutation.reset();
+    try {
+      const canceledSubscription = await mutation.mutateAsync();
+      queryClient.setQueryData(
+        queryKeys.subscription.me(),
+        canceledSubscription,
+      );
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.subscription.root,
+      });
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.entitlements.root,
+      });
+      options.setCanceledSubscription(canceledSubscription);
+      options.setConfirmationOpen(false);
+      options.analytics.capture("subscription.cancel.completed", {
+        provider: subscription.provider ?? "internal",
+        mode: "api",
+        status: "completed",
+      });
+    } catch (error) {
+      options.setError(error);
+    } finally {
+      inFlight.current = false;
+    }
+  };
+
+/**
+ * Coordinates provider-aware subscription management and cancellation.
+ */
+export function useSubscriptionManagementController(
+  subscription: SubscriptionState | null,
+): SubscriptionManagementController {
+  const analytics = useAnalytics();
+  const queryClient = useQueryClient();
+  const cancelMutation = useCancelSubscriptionMutation();
+  const cancelInFlight = useRef(false);
+  const [cancelError, setCancelError] = useState<unknown | null>(null);
+  const [managementError, setManagementError] = useState<unknown | null>(null);
+  const [isCancelConfirmationOpen, setCancelConfirmationOpen] = useState(false);
+  const [lastCanceledSubscription, setLastCanceledSubscription] =
+    useState<SubscriptionState | null>(null);
+  const managementAction = useMemo(
+    () => resolveSubscriptionManagementAction(subscription),
+    [subscription],
+  );
+  const handleManageSubscription = createManageHandler({
+    action: managementAction,
+    subscription,
+    analytics,
+    setCancelError,
+    setManagementError,
+    setConfirmationOpen: setCancelConfirmationOpen,
+  });
+  const handleCancelSubscription = createCancelHandler({
+    action: managementAction,
+    subscription,
+    analytics,
+    queryClient,
+    mutation: cancelMutation,
+    inFlight: cancelInFlight,
+    setError: setCancelError,
+    setConfirmationOpen: setCancelConfirmationOpen,
+    setCanceledSubscription: setLastCanceledSubscription,
+  });
+
+  return {
+    isCancelingSubscription: cancelMutation.isPending,
+    isCancelConfirmationOpen,
+    cancelError,
+    managementError,
+    lastCanceledSubscription,
+    managementAction,
+    handleManageSubscription,
+    handleCancelSubscription,
+    closeCancelConfirmation: () => {
+      if (!cancelInFlight.current && !cancelMutation.isPending) {
+        cancelMutation.reset();
+        setCancelError(null);
+        setCancelConfirmationOpen(false);
+      }
+    },
+    dismissManagementError: () => {
+      setManagementError(null);
+    },
+    dismissCancellationFeedback: () => {
+      setLastCanceledSubscription(null);
+    },
+  };
+}

--- a/features/subscription/hooks/use-subscription-screen-controller.test.tsx
+++ b/features/subscription/hooks/use-subscription-screen-controller.test.tsx
@@ -5,12 +5,10 @@ import type { ReactNode } from "react";
 import { ApiError } from "@/core/http/api-error";
 import type { AnalyticsClient } from "@/core/observability/analytics-types";
 import { useAnalytics } from "@/core/observability/use-analytics";
-import type {
-  BillingPlan,
-  SubscriptionState,
-} from "@/features/subscription/contracts";
+import type { BillingPlan, SubscriptionState } from "@/features/subscription/contracts";
 import { useBillingPlansQuery } from "@/features/subscription/hooks/use-billing-plans-query";
 import { useCheckoutFlow } from "@/features/subscription/hooks/use-checkout-flow";
+import { useSubscriptionManagementController } from "@/features/subscription/hooks/use-subscription-management-controller";
 import { useStartTrialMutation } from "@/features/subscription/hooks/use-subscription-mutations";
 import { useSubscriptionStateQuery } from "@/features/subscription/hooks/use-subscription-query";
 import { useSubscriptionScreenController } from "@/features/subscription/hooks/use-subscription-screen-controller";
@@ -24,6 +22,9 @@ jest.mock("@/features/subscription/hooks/use-subscription-query", () => ({
 jest.mock("@/features/subscription/hooks/use-subscription-mutations", () => ({
   useStartTrialMutation: jest.fn(),
 }));
+jest.mock("@/features/subscription/hooks/use-subscription-management-controller", () => ({
+  useSubscriptionManagementController: jest.fn(),
+}));
 jest.mock("@/features/subscription/hooks/use-checkout-flow", () => ({
   useCheckoutFlow: jest.fn(),
 }));
@@ -34,6 +35,7 @@ jest.mock("@/core/observability/use-analytics", () => ({
 const mockedUsePlans = jest.mocked(useBillingPlansQuery);
 const mockedUseSubscription = jest.mocked(useSubscriptionStateQuery);
 const mockedUseTrial = jest.mocked(useStartTrialMutation);
+const mockedUseManagement = jest.mocked(useSubscriptionManagementController);
 const mockedUseCheckout = jest.mocked(useCheckoutFlow);
 const mockedUseAnalytics = jest.mocked(useAnalytics);
 
@@ -59,9 +61,7 @@ const buildPlan = (override: Partial<BillingPlan> = {}): BillingPlan => ({
   ...override,
 });
 
-const buildSubscription = (
-  override: Partial<SubscriptionState> = {},
-): SubscriptionState => ({
+const buildSubscription = (): SubscriptionState => ({
   id: "sub-1",
   userId: "u-1",
   planCode: "free",
@@ -76,7 +76,6 @@ const buildSubscription = (
   canceledAt: null,
   createdAt: null,
   updatedAt: null,
-  ...override,
 });
 
 const wrapper = (client: QueryClient) => {
@@ -85,6 +84,22 @@ const wrapper = (client: QueryClient) => {
   );
   Provider.displayName = "TestQueryClientProvider";
   return Provider;
+};
+
+const mockManagementController = (): void => {
+  mockedUseManagement.mockReturnValue({
+    isCancelingSubscription: false,
+    isCancelConfirmationOpen: false,
+    cancelError: null,
+    managementError: null,
+    lastCanceledSubscription: null,
+    managementAction: null,
+    handleManageSubscription: jest.fn().mockResolvedValue(undefined),
+    handleCancelSubscription: jest.fn().mockResolvedValue(undefined),
+    closeCancelConfirmation: jest.fn(),
+    dismissManagementError: jest.fn(),
+    dismissCancellationFeedback: jest.fn(),
+  });
 };
 
 describe("useSubscriptionScreenController", () => {
@@ -106,6 +121,7 @@ describe("useSubscriptionScreenController", () => {
       isPending: false,
       error: null,
     } as never);
+    mockManagementController();
     mockedUseCheckout.mockReturnValue({
       isStarting: false,
       lastError: null,
@@ -113,6 +129,10 @@ describe("useSubscriptionScreenController", () => {
       resetError: jest.fn(),
     } as never);
     mockedUseAnalytics.mockReturnValue(analyticsClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it("expoe presentations e trial offer derivados do comparador", () => {
@@ -141,14 +161,6 @@ describe("useSubscriptionScreenController", () => {
       billingCycle: "monthly",
     });
     expect(result.current.lastCheckoutOutcome).toBe("completed");
-    expect(analyticsClient.capture).toHaveBeenCalledWith(
-      "subscription.checkout.opened",
-      {
-        provider: "hosted",
-        planId: "premium-monthly",
-        status: "opened",
-      },
-    );
     expect(analyticsClient.capture).toHaveBeenCalledWith(
       "subscription.checkout.completed",
       {
@@ -193,15 +205,15 @@ describe("useSubscriptionScreenController", () => {
     expect(result.current.trialError).toBeInstanceOf(ApiError);
   });
 
-  it("dismissTrialError limpa estado e reseta mutation", async () => {
-    trialMutateAsync.mockRejectedValueOnce(new ApiError({ message: "x", status: 500 }));
+  it("limpa o erro de trial e reseta a mutation", async () => {
+    trialMutateAsync.mockRejectedValueOnce(new Error("trial fail"));
     const { result } = renderHook(() => useSubscriptionScreenController(), {
       wrapper: wrapper(client),
     });
-
     await act(async () => {
       await result.current.handleStartTrial();
     });
+
     act(() => {
       result.current.dismissTrialError();
     });
@@ -210,7 +222,7 @@ describe("useSubscriptionScreenController", () => {
     expect(trialReset).toHaveBeenCalled();
   });
 
-  it("constrói comando de checkout sem billingCycle quando plan e cycle null", async () => {
+  it("constroi checkout sem billingCycle quando o plano nao possui ciclo", async () => {
     const { result } = renderHook(() => useSubscriptionScreenController(), {
       wrapper: wrapper(client),
     });

--- a/features/subscription/hooks/use-subscription-screen-controller.ts
+++ b/features/subscription/hooks/use-subscription-screen-controller.ts
@@ -1,6 +1,5 @@
 import { useQueryClient } from "@tanstack/react-query";
 import { useMemo, useState } from "react";
-import { Linking } from "react-native";
 
 import { useAnalytics } from "@/core/observability/use-analytics";
 import { queryKeys } from "@/core/query/query-keys";
@@ -14,17 +13,19 @@ import {
   useCheckoutFlow,
   type CheckoutOutcome,
 } from "@/features/subscription/hooks/use-checkout-flow";
+import { useStartTrialMutation } from "@/features/subscription/hooks/use-subscription-mutations";
 import {
-  useStartTrialMutation,
-} from "@/features/subscription/hooks/use-subscription-mutations";
+  useSubscriptionManagementController,
+  type SubscriptionManagementController,
+} from "@/features/subscription/hooks/use-subscription-management-controller";
 import { useSubscriptionStateQuery } from "@/features/subscription/hooks/use-subscription-query";
 import {
   subscriptionPlanComparator,
   type PlanPresentation,
 } from "@/features/subscription/services/subscription-plan-comparator";
-import { MANAGE_SUBSCRIPTION_URL } from "@/shared/config/web-urls";
 
-export interface SubscriptionScreenController {
+export interface SubscriptionScreenController
+  extends SubscriptionManagementController {
   readonly subscriptionQuery: ReturnType<typeof useSubscriptionStateQuery>;
   readonly plansQuery: ReturnType<typeof useBillingPlansQuery>;
   readonly subscription: SubscriptionState | null;
@@ -37,7 +38,6 @@ export interface SubscriptionScreenController {
   readonly lastCheckoutOutcome: CheckoutOutcome | null;
   readonly handleSubscribe: (plan: BillingPlan) => Promise<void>;
   readonly handleStartTrial: () => Promise<void>;
-  readonly handleManageSubscription: () => Promise<void>;
   readonly dismissCheckoutError: () => void;
   readonly dismissTrialError: () => void;
 }
@@ -66,6 +66,8 @@ export function useSubscriptionScreenController(): SubscriptionScreenController 
     useState<CheckoutOutcome | null>(null);
 
   const subscription = subscriptionQuery.data ?? null;
+  const managementController =
+    useSubscriptionManagementController(subscription);
   const plansData = plansQuery.data;
   const plans = useMemo(() => plansData ?? [], [plansData]);
 
@@ -112,6 +114,7 @@ export function useSubscriptionScreenController(): SubscriptionScreenController 
   };
 
   return {
+    ...managementController,
     subscriptionQuery,
     plansQuery,
     subscription,
@@ -124,7 +127,6 @@ export function useSubscriptionScreenController(): SubscriptionScreenController 
     lastCheckoutOutcome,
     handleSubscribe,
     handleStartTrial,
-    handleManageSubscription: async () => Linking.openURL(MANAGE_SUBSCRIPTION_URL),
     dismissCheckoutError: () => {
       checkout.resetError();
       setLastCheckoutOutcome(null);

--- a/features/subscription/screens/subscription-screen.test.tsx
+++ b/features/subscription/screens/subscription-screen.test.tsx
@@ -1,0 +1,204 @@
+import { fireEvent, render } from "@testing-library/react-native";
+
+import type { SubscriptionState } from "@/features/subscription/contracts";
+import {
+  useSubscriptionScreenController,
+  type SubscriptionScreenController,
+} from "@/features/subscription/hooks/use-subscription-screen-controller";
+import { SubscriptionScreen } from "@/features/subscription/screens/subscription-screen";
+import { TestProviders } from "@/shared/testing/test-providers";
+
+jest.mock("@/features/subscription/hooks/use-subscription-screen-controller", () => ({
+  useSubscriptionScreenController: jest.fn(),
+}));
+
+jest.mock("expo-router", () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+    replace: jest.fn(),
+    back: jest.fn(),
+  }),
+}));
+
+const mockedUseController = jest.mocked(useSubscriptionScreenController);
+
+const buildSubscription = (
+  override: Partial<SubscriptionState> = {},
+): SubscriptionState => ({
+  id: "sub-1",
+  userId: "user-1",
+  planCode: "premium",
+  offerCode: "premium-monthly",
+  status: "active",
+  billingCycle: "monthly",
+  provider: "abacatepay",
+  providerSubscriptionId: "bill-1",
+  trialEndsAt: null,
+  currentPeriodStart: "2026-07-01T00:00:00Z",
+  currentPeriodEnd: "2026-08-01T12:00:00Z",
+  canceledAt: null,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+  ...override,
+});
+
+const buildQuery = <TData,>(data: TData) => ({
+  data,
+  error: null,
+  isPending: false,
+  isError: false,
+  isFetching: false,
+  refetch: jest.fn().mockResolvedValue(undefined),
+});
+
+const buildController = (
+  overrides: Partial<SubscriptionScreenController> = {},
+): SubscriptionScreenController => {
+  const subscription = buildSubscription();
+  return {
+    subscriptionQuery: buildQuery(subscription) as never,
+    plansQuery: buildQuery([]) as never,
+    subscription,
+    presentations: [],
+    trialOffer: null,
+    isStartingCheckout: false,
+    isStartingTrial: false,
+    isCancelingSubscription: false,
+    isCancelConfirmationOpen: false,
+    checkoutError: null,
+    trialError: null,
+    cancelError: null,
+    managementError: null,
+    lastCheckoutOutcome: null,
+    lastCanceledSubscription: null,
+    managementAction: {
+      mode: "api",
+      label: "Cancelar assinatura",
+      description:
+        "O cancelamento interrompe a renovacao e preserva o acesso ja contratado.",
+      url: null,
+    },
+    handleSubscribe: jest.fn().mockResolvedValue(undefined),
+    handleStartTrial: jest.fn().mockResolvedValue(undefined),
+    handleManageSubscription: jest.fn().mockResolvedValue(undefined),
+    handleCancelSubscription: jest.fn().mockResolvedValue(undefined),
+    closeCancelConfirmation: jest.fn(),
+    dismissCheckoutError: jest.fn(),
+    dismissTrialError: jest.fn(),
+    dismissManagementError: jest.fn(),
+    dismissCancellationFeedback: jest.fn(),
+    ...overrides,
+  };
+};
+
+const renderScreen = (
+  controller: SubscriptionScreenController,
+): ReturnType<typeof render> => {
+  mockedUseController.mockReturnValue(controller);
+  return render(
+    <TestProviders>
+      <SubscriptionScreen />
+    </TestProviders>,
+  );
+};
+
+describe("SubscriptionScreen", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("mostra cancelamento para provider gerenciado pela API", () => {
+    const controller = buildController();
+    const { getByText, getByTestId } = renderScreen(controller);
+
+    expect(getByText("Ativa")).toBeTruthy();
+    expect(getByText("Cancelar assinatura")).toBeTruthy();
+    fireEvent.press(getByTestId("manage-subscription-button"));
+
+    expect(controller.handleManageSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("explica e confirma o efeito antes de cancelar", () => {
+    const controller = buildController({
+      isCancelConfirmationOpen: true,
+    });
+    const { getByText, getByTestId } = renderScreen(controller);
+
+    expect(getByText("Cancelar assinatura?")).toBeTruthy();
+    expect(getByText(/Seu acesso continua ate 01\/08\/2026/)).toBeTruthy();
+    fireEvent.press(getByTestId("confirm-subscription-cancel"));
+
+    expect(controller.handleCancelSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("exibe erro recuperavel e retry dentro da confirmacao", () => {
+    const controller = buildController({
+      isCancelConfirmationOpen: true,
+      cancelError: new Error("billing unavailable"),
+    });
+    const { getByText } = renderScreen(controller);
+
+    expect(getByText("Nao foi possivel cancelar a assinatura")).toBeTruthy();
+    fireEvent.press(getByText("Tentar novamente"));
+
+    expect(controller.handleCancelSubscription).toHaveBeenCalledTimes(1);
+  });
+
+  it("bloqueia as acoes enquanto o cancelamento esta em andamento", () => {
+    const controller = buildController({
+      isCancelConfirmationOpen: true,
+      isCancelingSubscription: true,
+    });
+    const { getByText, getByTestId } = renderScreen(controller);
+
+    expect(getByText("Cancelando...")).toBeTruthy();
+    expect(getByTestId("confirm-subscription-cancel").props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true }),
+    );
+    expect(getByTestId("keep-subscription").props.accessibilityState).toEqual(
+      expect.objectContaining({ disabled: true }),
+    );
+  });
+
+  it("mostra a gestao do provider de loja sem oferecer cancelamento pela API", () => {
+    const subscription = buildSubscription({ provider: "app_store" });
+    const controller = buildController({
+      subscription,
+      subscriptionQuery: buildQuery(subscription) as never,
+      managementAction: {
+        mode: "app-store",
+        label: "Gerenciar na App Store",
+        description:
+          "A Apple controla a renovacao e o cancelamento desta assinatura.",
+        url: "https://apps.apple.com/account/subscriptions",
+      },
+    });
+    const { getByText, queryByText } = renderScreen(controller);
+
+    expect(getByText("Gerenciar na App Store")).toBeTruthy();
+    expect(queryByText("Cancelar assinatura")).toBeNull();
+  });
+
+  it("confirma o cancelamento concluido e a data final de acesso", () => {
+    const canceledSubscription = buildSubscription({
+      status: "canceled",
+      canceledAt: "2026-07-23T22:00:00Z",
+    });
+    const controller = buildController({
+      subscription: canceledSubscription,
+      subscriptionQuery: buildQuery(canceledSubscription) as never,
+      managementAction: null,
+      lastCanceledSubscription: canceledSubscription,
+    });
+    const { getAllByText, getByText, queryByTestId } = renderScreen(controller);
+
+    expect(getByText("Cancelada")).toBeTruthy();
+    expect(getAllByText(/Acesso continua ate 01\/08\/2026/i).length).toBeGreaterThan(
+      0,
+    );
+    expect(queryByTestId("manage-subscription-button")).toBeNull();
+    fireEvent.press(getByText("Entendi"));
+
+    expect(controller.dismissCancellationFeedback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/features/subscription/screens/subscription-screen.tsx
+++ b/features/subscription/screens/subscription-screen.tsx
@@ -6,11 +6,16 @@ import { Paragraph, YStack } from "tamagui";
 import { appRoutes } from "@/core/navigation/routes";
 import { BillingPlanCard } from "@/features/subscription/components/billing-plan-card";
 import { CheckoutOutcomeCard } from "@/features/subscription/components/checkout-outcome-card";
+import { SubscriptionCancelModal } from "@/features/subscription/components/subscription-cancel-modal";
 import {
   useSubscriptionScreenController,
   type SubscriptionScreenController,
 } from "@/features/subscription/hooks/use-subscription-screen-controller";
-import type { SubscriptionState } from "@/features/subscription/contracts";
+import type {
+  SubscriptionState,
+  SubscriptionStatus,
+} from "@/features/subscription/contracts";
+import type { SubscriptionManagementAction } from "@/features/subscription/services/subscription-management";
 import { AppBadge } from "@/shared/components/app-badge";
 import { AppButton } from "@/shared/components/app-button";
 import { AppErrorNotice } from "@/shared/components/app-error-notice";
@@ -33,6 +38,15 @@ const SUCCESS_NOTICE: Record<string, { title: string; description: string }> = {
   },
 };
 
+const STATUS_LABELS: Record<SubscriptionStatus, string> = {
+  free: "Gratuito",
+  trialing: "Periodo gratuito",
+  active: "Ativa",
+  past_due: "Pagamento pendente",
+  canceled: "Cancelada",
+  expired: "Expirada",
+};
+
 /**
  * Canonical subscription screen composition for the mobile app.
  *
@@ -44,9 +58,20 @@ export function SubscriptionScreen(): ReactElement {
   return (
     <AppScreen>
       <CurrentSubscriptionCard controller={controller} />
+      <CancellationFeedback controller={controller} />
       <TrialCallout controller={controller} />
       <CheckoutFeedback controller={controller} />
       <PlansCard controller={controller} />
+      <SubscriptionCancelModal
+        visible={controller.isCancelConfirmationOpen}
+        currentPeriodEnd={controller.subscription?.currentPeriodEnd ?? null}
+        isSubmitting={controller.isCancelingSubscription}
+        error={controller.cancelError}
+        onConfirm={() => {
+          void controller.handleCancelSubscription();
+        }}
+        onClose={controller.closeCancelConfirmation}
+      />
     </AppScreen>
   );
 }
@@ -81,7 +106,10 @@ function CurrentSubscriptionCard({ controller }: ControllerProps): ReactElement 
         {(subscription) => (
           <SubscriptionDetails
             subscription={subscription}
+            managementAction={controller.managementAction}
+            managementError={controller.managementError}
             onManage={controller.handleManageSubscription}
+            onDismissManagementError={controller.dismissManagementError}
           />
         )}
       </AppQueryState>
@@ -91,13 +119,22 @@ function CurrentSubscriptionCard({ controller }: ControllerProps): ReactElement 
 
 interface SubscriptionDetailsProps {
   readonly subscription: SubscriptionState;
+  readonly managementAction: SubscriptionManagementAction | null;
+  readonly managementError: unknown | null;
   readonly onManage: () => Promise<void>;
+  readonly onDismissManagementError: () => void;
 }
 
 function SubscriptionDetails({
   subscription,
+  managementAction,
+  managementError,
   onManage,
+  onDismissManagementError,
 }: SubscriptionDetailsProps): ReactElement {
+  const periodEndLabel =
+    subscription.status === "canceled" ? "Acesso ate" : "Proxima cobranca";
+
   return (
     <YStack gap="$3">
       <AppKeyValueRow
@@ -108,13 +145,13 @@ function SubscriptionDetails({
         label="Status"
         value={
           <AppBadge tone={subscription.status === "past_due" ? "danger" : "primary"}>
-            {subscription.status}
+            {STATUS_LABELS[subscription.status]}
           </AppBadge>
         }
       />
       {subscription.currentPeriodEnd ? (
         <AppKeyValueRow
-          label="Proxima cobranca"
+          label={periodEndLabel}
           value={new Date(subscription.currentPeriodEnd).toLocaleDateString("pt-BR")}
         />
       ) : null}
@@ -124,16 +161,70 @@ function SubscriptionDetails({
           value={new Date(subscription.trialEndsAt).toLocaleDateString("pt-BR")}
         />
       ) : null}
+      {subscription.canceledAt ? (
+        <AppKeyValueRow
+          label="Cancelada em"
+          value={new Date(subscription.canceledAt).toLocaleDateString("pt-BR")}
+        />
+      ) : null}
+      {managementError ? (
+        <AppErrorNotice
+          error={managementError}
+          fallbackTitle="Nao foi possivel abrir a gestao da assinatura"
+          fallbackDescription="Tente novamente ou use a pagina Web da Auraxis."
+          actionLabel="Tentar novamente"
+          onAction={() => {
+            void onManage();
+          }}
+          secondaryActionLabel="Fechar"
+          onSecondaryAction={onDismissManagementError}
+          testID="subscription-management-error"
+        />
+      ) : null}
+      {managementAction ? (
+        <>
+          <Paragraph color="$muted" fontFamily="$body" fontSize="$3">
+            {managementAction.description}
+          </Paragraph>
+          <AppButton
+            tone={managementAction.mode === "api" ? "danger" : "secondary"}
+            onPress={() => {
+              void onManage();
+            }}
+            testID="manage-subscription-button"
+          >
+            {managementAction.label}
+          </AppButton>
+        </>
+      ) : null}
+    </YStack>
+  );
+}
+
+function CancellationFeedback({
+  controller,
+}: ControllerProps): ReactElement | null {
+  const canceledSubscription = controller.lastCanceledSubscription;
+  if (!canceledSubscription) {
+    return null;
+  }
+
+  const description = canceledSubscription.currentPeriodEnd
+    ? `A renovacao foi interrompida. Seu acesso continua ate ${new Date(
+        canceledSubscription.currentPeriodEnd,
+      ).toLocaleDateString("pt-BR")}.`
+    : "A renovacao foi interrompida. O estado atualizado ja foi sincronizado.";
+
+  return (
+    <AppSurfaceCard title="Assinatura cancelada" description={description}>
       <AppButton
         tone="secondary"
-        onPress={() => {
-          void onManage();
-        }}
-        testID="manage-subscription-button"
+        onPress={controller.dismissCancellationFeedback}
+        testID="dismiss-cancellation-feedback"
       >
-        Gerenciar assinatura
+        Entendi
       </AppButton>
-    </YStack>
+    </AppSurfaceCard>
   );
 }
 

--- a/features/subscription/services/subscription-management.test.ts
+++ b/features/subscription/services/subscription-management.test.ts
@@ -1,0 +1,105 @@
+import type { SubscriptionState } from "@/features/subscription/contracts";
+import { resolveSubscriptionManagementAction } from "@/features/subscription/services/subscription-management";
+import {
+  APPLE_SUBSCRIPTIONS_URL,
+  GOOGLE_PLAY_SUBSCRIPTIONS_URL,
+  MANAGE_SUBSCRIPTION_URL,
+} from "@/shared/config/web-urls";
+
+const buildSubscription = (
+  override: Partial<SubscriptionState> = {},
+): SubscriptionState => ({
+  id: "sub-1",
+  userId: "user-1",
+  planCode: "premium",
+  offerCode: null,
+  status: "active",
+  billingCycle: "monthly",
+  provider: "abacatepay",
+  providerSubscriptionId: "provider-sub-1",
+  trialEndsAt: null,
+  currentPeriodStart: "2026-07-01T00:00:00Z",
+  currentPeriodEnd: "2026-08-01T00:00:00Z",
+  canceledAt: null,
+  createdAt: "2026-07-01T00:00:00Z",
+  updatedAt: "2026-07-01T00:00:00Z",
+  ...override,
+});
+
+describe("resolveSubscriptionManagementAction", () => {
+  it.each(["abacatepay", "asaas", "stub"])(
+    "cancela provider %s pela API canonica",
+    (provider) => {
+      expect(
+        resolveSubscriptionManagementAction(buildSubscription({ provider })),
+      ).toMatchObject({
+        mode: "api",
+        label: "Cancelar assinatura",
+        url: null,
+      });
+    },
+  );
+
+  it("permite cancelar trial interno sem provider pela API", () => {
+    expect(
+      resolveSubscriptionManagementAction(
+        buildSubscription({ provider: null, status: "trialing" }),
+      ),
+    ).toMatchObject({ mode: "api" });
+  });
+
+  it.each(["apple", "app_store", "app-store", "appstore"])(
+    "direciona provider Apple %s para a App Store",
+    (provider) => {
+      expect(
+        resolveSubscriptionManagementAction(buildSubscription({ provider })),
+      ).toMatchObject({
+        mode: "app-store",
+        url: APPLE_SUBSCRIPTIONS_URL,
+      });
+    },
+  );
+
+  it.each(["google", "google_play", "google-play", "play_store", "play-store"])(
+    "direciona provider Google %s para o Google Play",
+    (provider) => {
+      expect(
+        resolveSubscriptionManagementAction(buildSubscription({ provider })),
+      ).toMatchObject({
+        mode: "play-store",
+        url: GOOGLE_PLAY_SUBSCRIPTIONS_URL,
+      });
+    },
+  );
+
+  it("usa a pagina Web canonica para provider desconhecido", () => {
+    expect(
+      resolveSubscriptionManagementAction(
+        buildSubscription({ provider: "future-provider" }),
+      ),
+    ).toMatchObject({
+      mode: "web",
+      url: MANAGE_SUBSCRIPTION_URL,
+    });
+    expect(MANAGE_SUBSCRIPTION_URL).toBe(
+      "https://app.auraxis.com.br/subscription",
+    );
+  });
+
+  it.each(["free", "canceled", "expired"] as const)(
+    "nao oferece novo cancelamento para status %s gerenciado pela API",
+    (status) => {
+      expect(
+        resolveSubscriptionManagementAction(buildSubscription({ status })),
+      ).toBeNull();
+    },
+  );
+
+  it("mantem acesso a gestao da loja depois do cancelamento", () => {
+    expect(
+      resolveSubscriptionManagementAction(
+        buildSubscription({ provider: "google_play", status: "canceled" }),
+      ),
+    ).toMatchObject({ mode: "play-store" });
+  });
+});

--- a/features/subscription/services/subscription-management.ts
+++ b/features/subscription/services/subscription-management.ts
@@ -1,0 +1,104 @@
+import type {
+  SubscriptionState,
+  SubscriptionStatus,
+} from "@/features/subscription/contracts";
+import {
+  APPLE_SUBSCRIPTIONS_URL,
+  GOOGLE_PLAY_SUBSCRIPTIONS_URL,
+  MANAGE_SUBSCRIPTION_URL,
+} from "@/shared/config/web-urls";
+
+export type SubscriptionManagementMode =
+  | "api"
+  | "app-store"
+  | "play-store"
+  | "web";
+
+export interface SubscriptionManagementAction {
+  readonly mode: SubscriptionManagementMode;
+  readonly label: string;
+  readonly description: string;
+  readonly url: string | null;
+}
+
+const API_MANAGED_PROVIDERS = new Set(["abacatepay", "asaas", "stub"]);
+const APP_STORE_PROVIDERS = new Set([
+  "apple",
+  "app_store",
+  "app-store",
+  "appstore",
+]);
+const PLAY_STORE_PROVIDERS = new Set([
+  "google",
+  "google_play",
+  "google-play",
+  "play_store",
+  "play-store",
+]);
+const CANCELLABLE_STATUSES = new Set<SubscriptionStatus>([
+  "trialing",
+  "active",
+  "past_due",
+]);
+
+const normalizeProvider = (provider: string | null): string | null => {
+  const normalized = provider?.trim().toLowerCase();
+  return normalized ? normalized : null;
+};
+
+/**
+ * Resolves the safe management surface for the subscription's billing owner.
+ * Store-owned subscriptions must be managed by the corresponding store,
+ * whereas Auraxis billing providers use the canonical cancellation endpoint.
+ */
+export const resolveSubscriptionManagementAction = (
+  subscription: SubscriptionState | null,
+): SubscriptionManagementAction | null => {
+  if (!subscription) {
+    return null;
+  }
+
+  const provider = normalizeProvider(subscription.provider);
+
+  if (provider && APP_STORE_PROVIDERS.has(provider)) {
+    return {
+      mode: "app-store",
+      label: "Gerenciar na App Store",
+      description:
+        "A Apple controla a renovacao e o cancelamento desta assinatura.",
+      url: APPLE_SUBSCRIPTIONS_URL,
+    };
+  }
+
+  if (provider && PLAY_STORE_PROVIDERS.has(provider)) {
+    return {
+      mode: "play-store",
+      label: "Gerenciar no Google Play",
+      description:
+        "O Google Play controla a renovacao e o cancelamento desta assinatura.",
+      url: GOOGLE_PLAY_SUBSCRIPTIONS_URL,
+    };
+  }
+
+  if (!CANCELLABLE_STATUSES.has(subscription.status)) {
+    return null;
+  }
+
+  if (!provider || API_MANAGED_PROVIDERS.has(provider)) {
+    return {
+      mode: "api",
+      label: "Cancelar assinatura",
+      description:
+        "O cancelamento interrompe a renovacao e preserva o acesso ja contratado.",
+      url: null,
+    };
+  }
+
+  return {
+    mode: "web",
+    label: "Gerenciar na Web",
+    description:
+      "Este provedor deve ser gerenciado na pagina segura de assinatura da Auraxis.",
+    url: MANAGE_SUBSCRIPTION_URL,
+  };
+};

--- a/features/subscription/services/subscription-service.test.ts
+++ b/features/subscription/services/subscription-service.test.ts
@@ -1,0 +1,62 @@
+import type { AxiosInstance } from "axios";
+
+import { createSubscriptionService } from "@/features/subscription/services/subscription-service";
+import { apiContractMap } from "@/shared/contracts/api-contract-map";
+
+const createClient = (): jest.Mocked<Pick<AxiosInstance, "get" | "post">> => ({
+  get: jest.fn(),
+  post: jest.fn(),
+});
+
+describe("subscriptionService", () => {
+  it("cancela pela rota canonica e mapeia o estado retornado", async () => {
+    const client = createClient();
+    client.post.mockResolvedValue({
+      data: {
+        data: {
+          subscription: {
+            id: "sub-1",
+            user_id: "user-1",
+            plan_code: "premium",
+            offer_code: "premium-monthly",
+            status: "canceled",
+            billing_cycle: "monthly",
+            provider: "abacatepay",
+            provider_subscription_id: "bill-1",
+            trial_ends_at: null,
+            current_period_start: "2026-07-01T00:00:00Z",
+            current_period_end: "2026-08-01T00:00:00Z",
+            canceled_at: "2026-07-23T22:00:00Z",
+            created_at: "2026-07-01T00:00:00Z",
+            updated_at: "2026-07-23T22:00:00Z",
+          },
+        },
+      },
+    });
+
+    const service = createSubscriptionService(
+      client as unknown as AxiosInstance,
+    );
+    const result = await service.cancelSubscription();
+
+    expect(client.post).toHaveBeenCalledWith(
+      apiContractMap.subscriptionCancel.path,
+    );
+    expect(result).toEqual({
+      id: "sub-1",
+      userId: "user-1",
+      planCode: "premium",
+      offerCode: "premium-monthly",
+      status: "canceled",
+      billingCycle: "monthly",
+      provider: "abacatepay",
+      providerSubscriptionId: "bill-1",
+      trialEndsAt: null,
+      currentPeriodStart: "2026-07-01T00:00:00Z",
+      currentPeriodEnd: "2026-08-01T00:00:00Z",
+      canceledAt: "2026-07-23T22:00:00Z",
+      createdAt: "2026-07-01T00:00:00Z",
+      updatedAt: "2026-07-23T22:00:00Z",
+    });
+  });
+});

--- a/shared/config/web-urls.ts
+++ b/shared/config/web-urls.ts
@@ -8,4 +8,8 @@ const resolveWebBaseUrl = (): string => {
 const WEB_BASE_URL = resolveWebBaseUrl();
 
 export const PLANS_URL = `${WEB_BASE_URL}/plans` as const;
-export const MANAGE_SUBSCRIPTION_URL = `${WEB_BASE_URL}/conta/assinatura` as const;
+export const MANAGE_SUBSCRIPTION_URL = `${WEB_BASE_URL}/subscription` as const;
+export const APPLE_SUBSCRIPTIONS_URL =
+  "https://apps.apple.com/account/subscriptions" as const;
+export const GOOGLE_PLAY_SUBSCRIPTIONS_URL =
+  "https://play.google.com/store/account/subscriptions" as const;


### PR DESCRIPTION
## Resumo

- torna a tela `/assinatura` consciente do provider de cobrança;
- habilita cancelamento AbacatePay/Asaas/stub pelo contrato canônico `POST /subscriptions/cancel`;
- direciona assinaturas Apple e Google aos centros oficiais das lojas;
- corrige o fallback Web de `/conta/assinatura` para `/subscription`;
- adiciona confirmação explícita, data final de acesso, loading, erro/retry e bloqueio de requisições duplicadas;
- atualiza cache de assinatura e invalida entitlements depois do cancelamento;
- documenta arquitetura, dataflow, runtime, runbook Wiki e smoke Maestro.

## Causa raiz

O service e a mutation de cancelamento já existiam, mas a tela não os consumia. O único CTA abria uma rota Web inexistente e não diferenciava assinaturas controladas pelo gateway daquelas controladas pela App Store ou Google Play.

## Validação

- `npm run quality-check`: lint, typecheck, 9 gates de governança, contratos, codegen, **422 suites / 2.768 testes / 6 snapshots**;
- suíte focada: **6 suites / 39 testes** cobrindo provider routing, endpoint, cache, entitlements, idempotência, confirmação, loading, erro/retry e estado cancelado;
- `lint-staged` e `gitleaks protect --staged`: aprovados;
- pre-push: auditoria crítica, contratos, tipos e cobertura aprovados;
- Maestro `.maestro/08_subscription_checkout_smoke.yaml` atualizado para abrir e abandonar a confirmação sem alterar a conta.

## Evidência visual

Screenshot não anexado: este host não possui `simctl` nem `adb`. O smoke real em iOS e Android está detalhado em `docs/wiki/subscription-management-and-cancellation-2026-07-23.md` e permanece obrigatório em contas de teste antes da liberação.

## Riscos residuais

- compra nativa StoreKit/Play Billing ainda não existe; a mudança cobre corretamente estados de loja recebidos pelo backend, sem simular compra nativa;
- cancelamento financeiro real e abertura das lojas dependem de contas/devices de teste;
- provider novo usa o fallback Web canônico até ser adicionado explicitamente à matriz.

Closes #698