### PR TITLE
fix(release): automate deliveries with mandatory changelogs

### DIFF
--- a/.context/architecture.md
+++ b/.context/architecture.md
@@ -4,17 +4,17 @@
 
 | Camada | Tecnologia | Versão |
 |:-------|:-----------|:-------|
-| Framework | Expo SDK 54 | 54.x |
-| Toolchain | Node.js | 24 LTS |
-| Runtime | React Native | 0.81.6 |
+| Framework | Expo SDK 55 | 55.x |
+| Toolchain | Node.js | 25 LTS |
+| Runtime | React Native | 0.83.10 |
 | Navegação | Expo Router | v6 (file-based) |
 | Linguagem | TypeScript | strict mode |
 | Lint | ESLint + eslint-config-expo | latest |
 | Testes | Jest + React Native Testing Library | latest |
 | Storage seguro | expo-secure-store | latest |
 | HTTP | Axios + TanStack Query | canônico |
-| Build | EAS Build | baseline configurada via `eas.json` |
-| OTA | EAS Update | backlog posterior ao MVP1 |
+| Build | EAS Build | automático após CI quando muda o fingerprint |
+| OTA | EAS Update | automático após CI para runtime compatível |
 
 ## Estrutura de diretórios
 

--- a/.context/quality_gates.md
+++ b/.context/quality_gates.md
@@ -1,7 +1,7 @@
 # quality_gates.md — auraxis-app
 
 > Gates de qualidade obrigatórios para o aplicativo mobile do Auraxis.
-> Atualizado: 2026-04-08 — Node LTS unificado + stack completa (jest-expo + Gitleaks + TruffleHog + SonarCloud)
+> Atualizado: 2026-07-24 — Node 25 + changelog obrigatório + entrega automática por fingerprint
 
 ---
 
@@ -77,6 +77,7 @@ node scripts/ci-audit-gate.js
 |:----|:--------------|:----------|:----------------|
 | `lint` | ESLint | 0 erros | ✅ sim |
 | `typecheck` | TypeScript strict | 0 erros | ✅ sim |
+| `store-changelog` | 2+ notas pt-BR detalhadas no PR | 100–500 caracteres, sem placeholder | ✅ sim |
 | `test` | Jest + coverage | ≥ 85% (lines/functions/statements/branches) | ✅ sim |
 | `expo-bundle` | JS bundle compila | sem erros | ✅ sim |
 | `bundle-analysis` | Tamanho do bundle | ≤ 12 MB hard (Android/iOS) | ✅ sim (PR apenas) |
@@ -209,8 +210,8 @@ jest.mock('expo-secure-store', () => ({
 
 | Item | Por quê |
 |:-----|:--------|
-| EAS Build nativo | Executado no CI/EAS após merge |
-| EAS Update / OTA | Executado após aprovação em produção |
+| EAS Build nativo | Executado automaticamente após CI quando o fingerprint não possui build compatível |
+| EAS Update / OTA | Executado automaticamente após CI quando o fingerprint é compatível |
 | Detox E2E | Requer macOS runner — executado separadamente |
 | Teste em dispositivo físico | Responsabilidade do reviewer |
 | Review de acessibilidade manual | Feito no PR review |

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,6 +4,17 @@
 
 Closes #<!-- número da issue -->
 
+## Changelog de loja
+
+<!--
+Obrigatório para todos os PRs que podem ser entregues.
+Escreva pelo menos 2 bullets claros, em pt-BR, totalizando 100–500 caracteres.
+Descreva o que mudou e o impacto percebido; não use "N/A", "TODO" ou placeholders.
+-->
+
+- Mudança percebida pelos usuários:
+- Impacto, correção ou melhoria entregue:
+
 ## Tipo de mudança
 
 - [ ] Feature nova

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ on:
     branches: [master, main]
 
 env:
-  NODE_VERSION: '25'
+  NODE_VERSION: "25"
 
 jobs:
   # ── 1. Lint (ESLint) ───────────────────────────────────────────────────
@@ -66,6 +66,21 @@ jobs:
           node-version-file: .nvmrc
       - name: Validate feature flags metadata
         run: node scripts/check-feature-flags.cjs
+
+  # ── 3.1 Changelog obrigatório para qualquer entrega ───────────────────
+  store-changelog:
+    name: Detailed Store Changelog
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+      - name: Validate pt-BR store notes
+        if: github.event_name == 'pull_request'
+        run: node scripts/store-release-notes.cjs validate-pr
 
   # ── 4. Frontend Governance Guardrails ──────────────────────────────────
   frontend-governance:
@@ -149,7 +164,15 @@ jobs:
     # Guard-rail (#510): sem timeout o job herdava o default de 360min do
     # GitHub e um export travado segurava a fila de runners por 6h.
     timeout-minutes: 20
-    needs: [lint, typecheck, feature-flag-hygiene, frontend-governance, test, contract-smoke, graphql-codegen]
+    needs:
+      - lint
+      - typecheck
+      - feature-flag-hygiene
+      - store-changelog
+      - frontend-governance
+      - test
+      - contract-smoke
+      - graphql-codegen
     outputs:
       enabled: ${{ steps.capability.outputs.enabled }}
     permissions:
@@ -180,7 +203,7 @@ jobs:
         if: steps.capability.outputs.enabled == 'true'
         uses: expo/expo-github-action@v9
         with:
-          eas-version: 16.13.0
+          eas-version: 21.2.0
           token: ${{ secrets.EXPO_TOKEN }}
       - name: Export JS bundle (Android + iOS)
         if: steps.capability.outputs.enabled == 'true'
@@ -302,7 +325,7 @@ jobs:
 
       - uses: actions/setup-node@v7
         with:
-          node-version: '25'
+          node-version: "25"
 
       - name: Install dependencies
         run: npm ci
@@ -328,7 +351,7 @@ jobs:
           avd-name: maestro-ci
           script: maestro test .maestro/01_login.yaml .maestro/02_dashboard_overview.yaml .maestro/05_logout.yaml
         env:
-          MAESTRO_DRIVER_STARTUP_TIMEOUT: '120000'
+          MAESTRO_DRIVER_STARTUP_TIMEOUT: "120000"
 
   # ── 6. Secret Scan (Gitleaks) ──────────────────────────────────────────
   secret-scan-gitleaks:

--- a/.github/workflows/delivery-after-ci.yml
+++ b/.github/workflows/delivery-after-ci.yml
@@ -1,0 +1,220 @@
+name: Delivery after CI
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+concurrency:
+  group: delivery-${{ github.event.workflow_run.event }}-${{ github.event.workflow_run.head_branch || github.event.workflow_run.head_sha }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  deliver:
+    name: Select OTA or native preview
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      (github.event.workflow_run.event == 'pull_request' ||
+       github.event.workflow_run.event == 'push')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve the reviewed source revision
+        id: context
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const run = context.payload.workflow_run;
+            const associated = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: run.head_sha,
+            });
+            const preferredNumber = run.pull_requests?.[0]?.number;
+            const pullRequest = associated.data.find((item) => item.number === preferredNumber)
+              ?? associated.data.find((item) => item.merged_at)
+              ?? associated.data[0];
+
+            if (!pullRequest) {
+              core.setOutput('enabled', 'false');
+              core.setOutput('reason', 'No pull request is associated with this CI revision.');
+              return;
+            }
+
+            if (pullRequest.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setOutput('enabled', 'false');
+              core.setOutput('reason', 'Fork pull requests never receive deployment credentials.');
+              return;
+            }
+
+            const trustedAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            if (!trustedAssociations.has(pullRequest.author_association)) {
+              core.setOutput('enabled', 'false');
+              core.setOutput('reason', 'Only trusted repository collaborators can receive deployment credentials.');
+              return;
+            }
+
+            if (/^chore\(main\): release \d+\.\d+\.\d+/.test(pullRequest.title)) {
+              core.setOutput('enabled', 'false');
+              core.setOutput('reason', 'Release Please PRs are delivered once by their v* tag.');
+              return;
+            }
+
+            const eventPath = `${process.env.RUNNER_TEMP}/delivery-pull-request.json`;
+            fs.writeFileSync(eventPath, JSON.stringify({ pull_request: pullRequest }));
+            const isPullRequest = run.event === 'pull_request';
+            core.setOutput('enabled', 'true');
+            core.setOutput('environment', isPullRequest ? 'preview' : 'production');
+            core.setOutput('event_path', eventPath);
+            core.setOutput('pr_number', String(pullRequest.number));
+            core.setOutput('profile', isPullRequest ? 'preview' : 'production');
+            core.setOutput('sha', isPullRequest ? pullRequest.head.sha : run.head_sha);
+            core.setOutput('target', isPullRequest ? 'pull-request' : 'main');
+
+      - name: Explain a safe skip
+        if: steps.context.outputs.enabled != 'true'
+        env:
+          REASON: ${{ steps.context.outputs.reason }}
+        run: |
+          {
+            echo "### Delivery skipped"
+            echo
+            echo "$REASON"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Checkout the exact CI-approved revision
+        if: steps.context.outputs.enabled == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ steps.context.outputs.sha }}
+
+      - name: Setup Node.js
+        if: steps.context.outputs.enabled == 'true'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        if: steps.context.outputs.enabled == 'true'
+        run: npm ci --ignore-scripts
+
+      - name: Validate deployment changelog
+        if: steps.context.outputs.enabled == 'true'
+        env:
+          GITHUB_EVENT_PATH: ${{ steps.context.outputs.event_path }}
+        run: node scripts/store-release-notes.cjs validate-pr > "$RUNNER_TEMP/store-notes.txt"
+
+      - name: Validate EXPO_TOKEN
+        if: steps.context.outputs.enabled == 'true'
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: |
+          if [ -z "${EXPO_TOKEN:-}" ]; then
+            echo "::error::Missing required secret: EXPO_TOKEN"
+            exit 1
+          fi
+
+      - name: Setup Expo
+        if: steps.context.outputs.enabled == 'true'
+        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
+        with:
+          eas-version: 21.2.0
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Compare native runtime fingerprints
+        if: steps.context.outputs.enabled == 'true'
+        id: policy
+        env:
+          PROFILE: ${{ steps.context.outputs.profile }}
+        run: |
+          set -euo pipefail
+          android_fingerprint="$(npx expo-updates fingerprint:generate --platform android | jq -r '.hash')"
+          ios_fingerprint="$(npx expo-updates fingerprint:generate --platform ios | jq -r '.hash')"
+          eas build:list --platform android --profile "$PROFILE" --limit 50 --json --non-interactive \
+            > "$RUNNER_TEMP/android-builds.json"
+          eas build:list --platform ios --profile "$PROFILE" --limit 50 --json --non-interactive \
+            > "$RUNNER_TEMP/ios-builds.json"
+          jq -s 'add' "$RUNNER_TEMP/android-builds.json" "$RUNNER_TEMP/ios-builds.json" \
+            > "$RUNNER_TEMP/eas-builds.json"
+          resolution="$(node scripts/release-delivery-policy.cjs \
+            --builds-file "$RUNNER_TEMP/eas-builds.json" \
+            --android-fingerprint "$android_fingerprint" \
+            --ios-fingerprint "$ios_fingerprint" \
+            --profile "$PROFILE")"
+          {
+            echo "mode=$(jq -r '.mode' <<< "$resolution")"
+            echo "android_state=$(jq -r '.states.android' <<< "$resolution")"
+            echo "ios_state=$(jq -r '.states.ios' <<< "$resolution")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build a native PR preview
+        if: >-
+          steps.context.outputs.enabled == 'true' &&
+          steps.context.outputs.target == 'pull-request' &&
+          steps.policy.outputs.mode == 'build'
+        env:
+          NOTES_FILE: ${{ runner.temp }}/store-notes.txt
+        run: |
+          eas build \
+            --platform all \
+            --profile preview \
+            --message "$(cat "$NOTES_FILE")" \
+            --non-interactive \
+            --no-wait
+
+      - name: Publish compatible OTA
+        if: >-
+          steps.context.outputs.enabled == 'true' &&
+          steps.policy.outputs.mode == 'ota'
+        env:
+          ENVIRONMENT: ${{ steps.context.outputs.environment }}
+          NOTES_FILE: ${{ runner.temp }}/store-notes.txt
+          PR_NUMBER: ${{ steps.context.outputs.pr_number }}
+          TARGET: ${{ steps.context.outputs.target }}
+        run: |
+          set -euo pipefail
+          if [ "$TARGET" = "pull-request" ]; then
+            destination=(--branch "pr-${PR_NUMBER}")
+          else
+            destination=(--channel production)
+          fi
+          eas update \
+            "${destination[@]}" \
+            --environment "$ENVIRONMENT" \
+            --message "$(cat "$NOTES_FILE")" \
+            --platform all \
+            --non-interactive
+
+      - name: Record delivery decision
+        if: steps.context.outputs.enabled == 'true'
+        env:
+          ANDROID_STATE: ${{ steps.policy.outputs.android_state }}
+          IOS_STATE: ${{ steps.policy.outputs.ios_state }}
+          MODE: ${{ steps.policy.outputs.mode }}
+          NOTES_FILE: ${{ runner.temp }}/store-notes.txt
+          TARGET: ${{ steps.context.outputs.target }}
+        run: |
+          {
+            echo "### Automatic mobile delivery"
+            echo
+            echo "- Target: \`$TARGET\`"
+            echo "- Decision: \`$MODE\`"
+            echo "- Android native runtime: \`$ANDROID_STATE\`"
+            echo "- iOS native runtime: \`$IOS_STATE\`"
+            if [ "$TARGET" = "main" ] && [ "$MODE" = "build" ]; then
+              echo "- Native change: the Release Please tag owns the single store build."
+            fi
+            if [ "$MODE" = "wait" ]; then
+              echo "- A compatible native build is already running; no duplicate was created."
+            fi
+            echo
+            echo "#### Detailed changelog"
+            echo
+            cat "$NOTES_FILE"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-minimum.yml
+++ b/.github/workflows/deploy-minimum.yml
@@ -13,6 +13,10 @@ on:
         options:
           - "false"
           - "true"
+      release_notes:
+        description: "Obrigatório se houver build: 2+ bullets pt-BR, 100–500 caracteres"
+        required: false
+        type: string
 
 jobs:
   web-baseline-artifact:
@@ -34,6 +38,14 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Validate detailed preview changelog
+        env:
+          STORE_RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          node scripts/store-release-notes.cjs from-text \
+            --version "$(jq -r '.version' package.json)" \
+            --output-dir build/store-release
 
       - name: Export web bundle
         env:
@@ -61,6 +73,9 @@ jobs:
   eas-preview-build:
     name: EAS Preview Build
     runs-on: ubuntu-latest
+    concurrency:
+      group: eas-preview-manual
+      cancel-in-progress: false
     if: github.event_name == 'workflow_dispatch' && inputs.run_eas_build == 'true'
     permissions:
       contents: read
@@ -89,8 +104,14 @@ jobs:
       - name: Setup Expo
         uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
         with:
-          eas-version: 16.13.0
+          eas-version: 21.2.0
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Trigger preview build
-        run: npx eas build --platform all --profile preview --non-interactive --no-wait
+        run: |
+          eas build \
+            --platform all \
+            --profile preview \
+            --message "$(jq -r '.releaseNotes' build/store-release/metadata.json)" \
+            --non-interactive \
+            --no-wait

--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -16,10 +16,14 @@ on:
         options:
           - preview
           - production
-      message:
-        description: "Mensagem do update (default: título do último commit)"
-        required: false
+      release_notes:
+        description: "Changelog detalhado pt-BR (2+ bullets, 100–500 caracteres)"
+        required: true
         type: string
+
+concurrency:
+  group: ota-update-${{ inputs.channel }}
+  cancel-in-progress: true
 
 jobs:
   publish-update:
@@ -40,6 +44,14 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Validate detailed OTA changelog
+        env:
+          STORE_RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          node scripts/store-release-notes.cjs from-text \
+            --version "$(jq -r '.version' package.json)" \
+            --output-dir build/store-release
+
       - name: Validate EXPO_TOKEN
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
@@ -52,7 +64,7 @@ jobs:
       - name: Setup Expo
         uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
         with:
-          eas-version: 16.13.0
+          eas-version: 21.2.0
           token: ${{ secrets.EXPO_TOKEN }}
 
       - name: Guard — require channel/environment
@@ -74,15 +86,11 @@ jobs:
       - name: Publish update
         env:
           CHANNEL: ${{ inputs.channel }}
-          MESSAGE: ${{ inputs.message }}
         run: |
           set -euo pipefail
           if [ -z "${CHANNEL:-}" ]; then
             echo "::error::CHANNEL/--environment vazio no passo de publish — abortando." >&2
             exit 1
-          fi
-          if [ -z "${MESSAGE:-}" ]; then
-            MESSAGE="$(git log -1 --pretty=%s)"
           fi
           # `--environment` é OBRIGATÓRIO: o Expo inlina `EXPO_PUBLIC_*` em
           # build-time. Sem ele, o bundle do OTA sai com essas envs `undefined`
@@ -92,5 +100,5 @@ jobs:
           eas update \
             --channel "$CHANNEL" \
             --environment "$CHANNEL" \
-            --message "$MESSAGE" \
+            --message "$(jq -r '.releaseNotes' build/store-release/metadata.json)" \
             --non-interactive

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -8,39 +8,43 @@ on:
         required: true
         default: all
         type: choice
-        options:
-          - android
-          - ios
-          - all
+        options: [android, ios, all]
       profile:
         description: "Perfil do EAS Build"
         required: true
         default: production
         type: choice
-        options:
-          - preview
-          - production
+        options: [preview, production]
       auto_submit:
-        description: "Submeter automaticamente para store"
-        required: false
+        description: "Submeter automaticamente para a loja"
+        required: true
         default: "false"
         type: choice
-        options:
-          - "false"
-          - "true"
+        options: ["false", "true"]
+      release_notes:
+        description: "Changelog detalhado pt-BR (2+ bullets, 100–500 caracteres)"
+        required: true
+        type: string
   push:
     tags:
       - "v*"
 
+concurrency:
+  group: store-release
+  cancel-in-progress: false
+
 jobs:
   build-and-submit:
-    name: Build/Submit to Stores
+    name: Build, submit and attach store changelog
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -51,77 +55,231 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Validate EXPO_TOKEN
+      - name: Resolve release parameters
+        id: params
         env:
-          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          DISPATCH_AUTO_SUBMIT: ${{ inputs.auto_submit }}
+          DISPATCH_PLATFORM: ${{ inputs.platform }}
+          DISPATCH_PROFILE: ${{ inputs.profile }}
         run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            platform="all"
+            profile="production"
+            auto_submit="true"
+            version="${GITHUB_REF_NAME#v}"
+          else
+            platform="${DISPATCH_PLATFORM:-all}"
+            profile="${DISPATCH_PROFILE:-production}"
+            auto_submit="${DISPATCH_AUTO_SUBMIT:-false}"
+            version="$(jq -r '.version' package.json)"
+          fi
+          {
+            echo "platform=$platform"
+            echo "profile=$profile"
+            echo "auto_submit=$auto_submit"
+            echo "version=$version"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Validate version alignment
+        env:
+          EXPECTED_VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          set -euo pipefail
+          package_version="$(jq -r '.version' package.json)"
+          app_version="$(jq -r '.expo.version' app.json)"
+          manifest_version="$(jq -r '.["."]' .release-please-manifest.json)"
+          for actual in "$package_version" "$app_version" "$manifest_version"; do
+            if [ "$actual" != "$EXPECTED_VERSION" ]; then
+              echo "::error::Version drift: expected $EXPECTED_VERSION, found $actual"
+              exit 1
+            fi
+          done
+
+      - name: Generate and validate detailed store changelog
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          STORE_RELEASE_NOTES: ${{ inputs.release_notes }}
+          VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            node scripts/store-release-notes.cjs generate-release \
+              --version "$VERSION" \
+              --output-dir build/store-release
+          else
+            node scripts/store-release-notes.cjs from-text \
+              --version "$VERSION" \
+              --output-dir build/store-release
+          fi
+
+      - name: Validate required credentials before building
+        env:
+          AUTO_SUBMIT: ${{ steps.params.outputs.auto_submit }}
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          PLATFORM: ${{ steps.params.outputs.platform }}
+          PROFILE: ${{ steps.params.outputs.profile }}
+        run: |
+          set -euo pipefail
           if [ -z "${EXPO_TOKEN:-}" ]; then
-            echo "Missing required secret: EXPO_TOKEN" >&2
+            echo "::error::Missing required secret: EXPO_TOKEN"
+            exit 1
+          fi
+          if [ "$AUTO_SUBMIT" = "true" ] && [ "$PROFILE" != "production" ]; then
+            echo "::error::Automatic store submission is only allowed with the production profile."
+            exit 1
+          fi
+          if [ "$AUTO_SUBMIT" = "true" ] &&
+             [ "$PROFILE" = "production" ] &&
+             { [ "$PLATFORM" = "android" ] || [ "$PLATFORM" = "all" ]; } &&
+             [ -z "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON:-}" ]; then
+            echo "::error::Missing GOOGLE_PLAY_SERVICE_ACCOUNT_JSON; Android cannot be finalized with release notes."
             exit 1
           fi
 
       - name: Setup Expo
         uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
         with:
-          eas-version: 16.13.0
+          eas-version: 21.2.0
           token: ${{ secrets.EXPO_TOKEN }}
 
-      - name: Verify EAS context
+      - name: Verify EAS context and Apple metadata
+        env:
+          PLATFORM: ${{ steps.params.outputs.platform }}
         run: |
           set -euo pipefail
           eas whoami
           eas project:info
+          if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "all" ]; then
+            eas metadata:lint --profile production
+          fi
 
-      - name: Resolve build parameters
-        id: params
+      - name: Prevent duplicate native builds
+        id: policy
         env:
-          DISPATCH_PLATFORM: ${{ inputs.platform }}
-          DISPATCH_PROFILE: ${{ inputs.profile }}
-          DISPATCH_AUTO_SUBMIT: ${{ inputs.auto_submit }}
+          PROFILE: ${{ steps.params.outputs.profile }}
+          VERSION: ${{ steps.params.outputs.version }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "push" ]; then
-            # Tag push (v*) — criada quando o PR do release-please é mergeado
-            # (auto-merge habilitado em release-please.yml). Dispara build nas
-            # duas plataformas com --auto-submit.
-            #
-            # IMPORTANTE — sem auto-promoção para produção (issue #645):
-            #   - Android: eas.json submit.production.android = track:internal +
-            #     releaseStatus:draft → o AAB entra como DRAFT no internal track,
-            #     nunca em produção. Promover interno→produção é MANUAL no Play
-            #     Console (gate one-click, ver docs/release-process.md).
-            #   - iOS: o submit sobe para o TestFlight; publicar na App Store
-            #     (produção) é MANUAL no App Store Connect.
-            platform="all"
-            profile="production"
-            auto_submit="true"
-          else
-            platform="${DISPATCH_PLATFORM:-all}"
-            profile="${DISPATCH_PROFILE:-production}"
-            auto_submit="${DISPATCH_AUTO_SUBMIT:-false}"
-          fi
+          android_fingerprint="$(npx expo-updates fingerprint:generate --platform android | jq -r '.hash')"
+          ios_fingerprint="$(npx expo-updates fingerprint:generate --platform ios | jq -r '.hash')"
+          eas build:list --platform android --profile "$PROFILE" --limit 50 --json --non-interactive \
+            > "$RUNNER_TEMP/android-builds.json"
+          eas build:list --platform ios --profile "$PROFILE" --limit 50 --json --non-interactive \
+            > "$RUNNER_TEMP/ios-builds.json"
+          jq -s 'add' "$RUNNER_TEMP/android-builds.json" "$RUNNER_TEMP/ios-builds.json" \
+            > "$RUNNER_TEMP/eas-builds.json"
+          resolution="$(node scripts/release-delivery-policy.cjs \
+            --builds-file "$RUNNER_TEMP/eas-builds.json" \
+            --android-fingerprint "$android_fingerprint" \
+            --ios-fingerprint "$ios_fingerprint" \
+            --app-version "$VERSION" \
+            --platform "${{ steps.params.outputs.platform }}" \
+            --profile "$PROFILE")"
           {
-            echo "platform=$platform"
-            echo "profile=$profile"
-            echo "auto_submit=$auto_submit"
+            echo "mode=$(jq -r '.mode' <<< "$resolution")"
+            echo "states=$(jq -c '.states' <<< "$resolution")"
+            echo "android_build_id=$(jq -r '.buildIds.android // empty' <<< "$resolution")"
+            echo "ios_build_id=$(jq -r '.buildIds.ios // empty' <<< "$resolution")"
           } >> "$GITHUB_OUTPUT"
-          echo "Resolved trigger=${{ github.event_name }} platform=$platform profile=$profile auto_submit=$auto_submit"
 
-      - name: Trigger build/submission
+      - name: Stop while an identical build is already running
+        if: steps.policy.outputs.mode == 'wait'
+        run: |
+          echo "::error::A build for this exact app version and native runtime is already running. Rerun after it completes."
+          exit 1
+
+      - name: Build and submit once
+        if: steps.policy.outputs.mode == 'build'
         env:
+          AUTO_SUBMIT: ${{ steps.params.outputs.auto_submit }}
+          NOTES_FILE: build/store-release/what-to-test-pt-BR.txt
           PLATFORM: ${{ steps.params.outputs.platform }}
           PROFILE: ${{ steps.params.outputs.profile }}
-          AUTO_SUBMIT: ${{ steps.params.outputs.auto_submit }}
         run: |
           set -euo pipefail
-
-          extra_args=""
+          args=(
+            --platform "$PLATFORM"
+            --profile "$PROFILE"
+            --message "$(cat "$NOTES_FILE")"
+            --non-interactive
+          )
           if [ "$AUTO_SUBMIT" = "true" ]; then
-            extra_args="--auto-submit"
+            args+=(--auto-submit)
+            if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "all" ]; then
+              args+=(--what-to-test "$(cat "$NOTES_FILE")")
+            fi
           fi
+          eas build "${args[@]}"
 
-          eas build \
-            --platform "$PLATFORM" \
-            --profile "$PROFILE" \
-            --non-interactive \
-            $extra_args
+      - name: Publish App Store release notes
+        if: >-
+          steps.policy.outputs.mode != 'wait' &&
+          steps.params.outputs.auto_submit == 'true' &&
+          steps.params.outputs.profile == 'production' &&
+          (steps.params.outputs.platform == 'ios' ||
+           steps.params.outputs.platform == 'all')
+        run: eas metadata:push --profile production --non-interactive
+
+      - name: Resolve submitted Android versionCode
+        id: android
+        if: >-
+          steps.policy.outputs.mode != 'wait' &&
+          steps.params.outputs.auto_submit == 'true' &&
+          steps.params.outputs.profile == 'production' &&
+          (steps.params.outputs.platform == 'android' ||
+           steps.params.outputs.platform == 'all')
+        env:
+          ANDROID_BUILD_ID: ${{ steps.policy.outputs.android_build_id }}
+          VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          set -euo pipefail
+          eas build:list --platform android --profile production --status finished \
+            --limit 50 --json --non-interactive > "$RUNNER_TEMP/finished-android-builds.json"
+          version_code="$(jq -r \
+            --arg build_id "$ANDROID_BUILD_ID" \
+            --arg sha "$GITHUB_SHA" \
+            --arg version "$VERSION" \
+            '[.[] | select(
+              (.appVersion == $version) and
+              (($build_id != "" and .id == $build_id) or
+               ($build_id == "" and .gitCommitHash == $sha))
+            )][0].appBuildVersion // empty' \
+            "$RUNNER_TEMP/finished-android-builds.json")"
+          if [ -z "$version_code" ]; then
+            echo "::error::The finished Android build for $GITHUB_SHA / $VERSION was not found."
+            exit 1
+          fi
+          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+
+      - name: Attach Google Play notes and complete internal release
+        if: steps.android.outputs.version_code != ''
+        env:
+          GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          node scripts/google-play-release.cjs \
+            --metadata-file build/store-release/metadata.json \
+            --package com.sensoriumit.auraxis \
+            --track internal \
+            --version-code "${{ steps.android.outputs.version_code }}"
+
+      - name: Release summary
+        if: always()
+        env:
+          MODE: ${{ steps.policy.outputs.mode }}
+          STATES: ${{ steps.policy.outputs.states }}
+          VERSION: ${{ steps.params.outputs.version }}
+        run: |
+          {
+            echo "### Store release ${VERSION}"
+            echo
+            echo "- Native decision: \`${MODE:-not-evaluated}\`"
+            echo "- Platform states: \`${STATES:-not-evaluated}\`"
+            if [ -f build/store-release/metadata.json ]; then
+              echo
+              echo "#### Changelog pt-BR"
+              echo
+              jq -r '.releaseNotes' build/store-release/metadata.json
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -5,7 +5,14 @@
     ".": {
       "package-name": "auraxis-app",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "app.json",
+          "jsonpath": "$.expo.version"
+        }
+      ]
     }
   }
 }

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,3 +76,13 @@ Auraxis App is the Expo/React Native client for logged-in Auraxis product flows.
 - New or changed behavior must include tests in the same feature area.
 - For this parity slice, the critical tests are the regional calculator model, regional screen, tools catalog, feature flag status, login screen handoff coverage, private navigator lazy/detach guarantees, shared-entries mobile parity including outgoing invitations, transaction observation form/feed/controller coverage, and subscription provider resolution/cancellation/controller/screen coverage.
 - No backend or database interface was added by this slice. If a future calculator starts consuming an API, run contracts checks and live database validation as required by `AGENTS.md`.
+
+## Mobile Delivery Architecture
+
+- `CI` is the mandatory trust boundary. `.github/workflows/delivery-after-ci.yml` only handles a trusted collaborator's same-repository PR revision after that exact SHA passes CI; forks and external authors never receive deployment credentials.
+- Every non-generated PR supplies the canonical `## Changelog de loja` source. `scripts/store-release-notes.cjs` validates it and later builds the localized release metadata for Google Play, TestFlight and App Store Connect.
+- `scripts/release-delivery-policy.cjs` compares Android/iOS Expo fingerprints with EAS builds from the target profile. A compatible finished runtime receives OTA, a missing runtime receives a native build, and an active compatible build suppresses duplicates.
+- Release Please owns public version bumps. Its `extra-files` rule keeps `app.json` aligned with `package.json` and `.release-please-manifest.json`; the store workflow rejects any drift.
+- Store builds are serialized globally. Android submission is deliberately draft until `scripts/google-play-release.cjs` attaches pt-BR notes to the exact `versionCode` and commits it as completed on the internal track.
+- `store.config.js` maps the same generated notes to the exact Apple version through EAS Metadata, while `--what-to-test` supplies TestFlight.
+- Internal delivery is automatic. Promotion to Google Play production or App Store production remains a human approval boundary.

--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1225,8 +1225,8 @@ Workflows adicionais:
 | Item | Situação | Quando implementar |
 |:-----|:---------|:-------------------|
 | Detox E2E no CI | Scaffold pronto — requer macOS runner | APP5 / Fase Beta |
-| EAS Build gate | Requer conta EAS | APP5 |
-| EAS Update / OTA | Requer aprovação de release | Pós-MVP |
+| EAS Build por fingerprint | Implementado após CI; changelog obrigatório | #719 |
+| EAS Update / OTA | Implementado após CI para runtime compatível | #719 |
 | Sentry (error tracking) | A integrar | APP3+ |
 | Stryker (mutation testing) | A avaliar | APP5+ |
 

--- a/DATAFLOW.md
+++ b/DATAFLOW.md
@@ -95,3 +95,16 @@ No network call or database mutation is required until the user explicitly saves
 - Shared-entries tests assert controller counts, summary rendering, tab counters, incoming/outgoing invitation separation, outgoing composer actions and stable tab actions.
 - Transaction observation tests cover schema validation, form submission/edit prefill, controller payloads, duplicate behavior, feed mapping, card rendering and action sheet details.
 - Subscription tests cover provider routing, canonical URL fallback, API response mapping, duplicate-request prevention, query/entitlement invalidation, explicit confirmation, retry, loading and post-cancellation states.
+
+## Automatic Mobile Delivery Flow
+
+1. A PR author writes two or more user-facing pt-BR bullets under `## Changelog de loja`.
+2. CI validates the notes, application quality and the exact PR SHA.
+3. A successful CI `workflow_run` resolves the associated same-repository PR and rejects forks or direct unassociated pushes.
+4. Expo generates Android and iOS native fingerprints; the delivery policy compares them with EAS builds from `preview` or `production`.
+5. A compatible runtime publishes EAS Update with the detailed changelog; a missing preview runtime starts one Android+iOS preview build; an active match creates no duplicate.
+6. On main, a native mismatch is handed to the Release Please tag instead of starting a competing build.
+7. The tag workflow validates package/app/manifest versions and aggregates the source PR changelogs into `build/store-release/metadata.json`.
+8. EAS builds/submits once. TestFlight receives What to Test and EAS Metadata writes App Store pt-BR release notes.
+9. Google Play receives the AAB as draft. The publisher script finds the exact versionCode, writes localized notes, changes it to completed and commits the edit.
+10. Human approval is still required to promote internal/TestFlight artifacts to the public stores.

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "auraxis-app",
     "slug": "auraxis-app",
-    "version": "1.13.4",
+    "version": "1.13.6",
     "runtimeVersion": {
       "policy": "fingerprint"
     },

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,162 +1,200 @@
-# Release process — ciclo alfa (Google Play internal + TestFlight)
+# Release process — PR, OTA, Google Play e TestFlight
 
-Runbook canônico do ciclo de publicação do app durante o alfa.
-Épico de referência: [#518](https://github.com/italofelipe/auraxis-app/issues/518).
+Runbook canônico da entrega móvel. A política de changelog desta página é
+obrigatória: nenhum preview, OTA, build ou release de loja pode ser criado sem
+descrever detalhadamente, em pt-BR, o que mudou para os usuários.
 
-## Visão geral do ciclo
+## Fluxo automático
 
-```
-mudança JS-only  ──────────────► OTA via EAS Update (workflow ota-update.yml)
-                                  └─ não gasta build credits, chega em minutos
+```text
+PR aberto/atualizado
+  └─ CI verde
+      └─ delivery-after-ci.yml
+          ├─ runtime nativo compatível → EAS Update no branch pr-<número>
+          └─ runtime nativo diferente → build preview Android + iOS
 
-mudança nativa / bump version ─► build + submit (workflow store-release.yml)
-                                  ├─ Android → Play internal testing (draft)
-                                  └─ iOS → TestFlight
-```
+merge na main
+  └─ CI verde
+      ├─ runtime nativo compatível → OTA no canal production
+      └─ runtime nativo diferente → aguarda a tag do Release Please
 
-Gatilhos do `store-release.yml`:
-
-- **Tag `v*`** (criada pelo release-please ao mergear o PR de release):
-  build `production` nas duas plataformas com `--auto-submit`.
-- **Manual (`workflow_dispatch`)**: escolhe plataforma, profile e auto-submit.
-
-### Cadeia automática de release (issues #648 / #645)
-
-O ciclo é encadeado ponta a ponta, sem passo manual até a promoção:
-
-```
-commits na main ─► release-please abre "chore(main): release X.Y.Z"
-                   │  (auto-merge squash habilitado — release-please.yml)
-                   ▼
-                   PR entra sozinho quando os checks ficam verdes
-                   │
-                   ▼
-                   release-please cria a tag v* + GitHub Release
-                   │
-                   ▼
-                   store-release.yml (push da tag) ─► eas build --auto-submit
-                   ├─ Android → internal track como DRAFT
-                   └─ iOS → TestFlight
+tag vX.Y.Z
+  └─ store-release.yml, uma execução por vez
+      ├─ gera changelog a partir dos PRs da versão
+      ├─ valida versão + credenciais + duplicidade
+      ├─ build e submit Android/iOS
+      ├─ App Store/TestFlight recebe What to Test + release notes
+      └─ Google Play draft recebe release notes e só então vira completed
 ```
 
-> **Sem auto-promoção para produção.** A cadeia para no track interno
-> (Android draft) e no TestFlight (iOS). Promover para produção pública é
-> sempre **manual** — ver o gate abaixo. Motivação: um fix P0 não deve ficar
-> preso esperando merge do release (#648), mas também não deve ir sozinho para
-> produção sem um humano no loop (#645).
+O PR mecânico `chore(main): release X.Y.Z` não cria outro preview ou build. A
+tag gerada pelo Release Please é a proprietária única do build de loja. Essa
+exceção evita os dois builds concorrentes observados em 24/07/2026.
 
-### Gate de promoção interno → produção (one-click, manual)
+## Changelog obrigatório
 
-Depois que o build entra no internal/TestFlight, a promoção é um passo humano:
+Todo PR não gerado pelo Release Please deve conter:
 
-- **Android** — Play Console → Testing → Internal testing → selecionar o build →
-  **Promote release** → Production → revisar rollout % → **Rollout to Production**.
-- **iOS** — App Store Connect → o build do TestFlight → adicionar à versão da
-  App Store → **Submit for Review** → após aprovação, liberar (manual ou
-  phased release).
+```md
+## Changelog de loja
 
-Nenhum secret ou automação promove para produção; o gate é intencionalmente
-manual.
+- Mudança percebida pelos usuários, escrita de forma clara e específica.
+- Impacto, correção ou melhoria entregue para quem usa o aplicativo.
+```
 
-Gatilho do `ota-update.yml`: somente manual (`workflow_dispatch`), escolhendo
-canal `preview` ou `production` — publica o estado JS do commit checked-out.
+Regras verificadas pelo CI:
 
-## OTA vs build novo — regra de decisão
+- idioma `pt-BR`;
+- no mínimo 2 bullets e 100 caracteres;
+- no máximo 500 caracteres, limite adotado para o Google Play;
+- cada bullet deve ter pelo menos 25 caracteres;
+- `N/A`, `TODO`, “não se aplica”, “sem alterações” e placeholders são
+  rejeitados.
 
-Use **OTA** (EAS Update) apenas para mudanças de JavaScript/TypeScript, assets,
-copy, i18n e feature flags.
+O release de tag lê os PRs referenciados na seção atual do `CHANGELOG.md`,
+agrega os textos e falha antes do build caso uma nota esteja ausente ou o total
+ultrapasse o limite. Não existe fallback para título de commit: se não há
+changelog detalhado, não há deploy.
 
-Exige **build nativo novo** qualquer mudança em: dependência com código nativo,
-plugin Expo, permissão, `app.json` (bundle id, plist, manifest, ícones, splash),
-`eas.json`, ou bump de `version`.
+OTAs e releases manuais também exigem o texto completo no formulário do
+workflow. As notas são usadas como mensagem do EAS Update/build e registradas no
+resumo da execução.
 
-> **Atenção — `runtimeVersion.policy: appVersion`**: um OTA publicado só
-> alcança builds instalados com a **mesma `version`** do `app.json`. Depois de
-> um release que bumpou a version, builds antigos não recebem mais OTA — eles
-> precisam atualizar pela loja.
+## Decisão OTA versus build
 
-## Variáveis de ambiente (EAS)
+O `runtimeVersion` usa `policy: fingerprint`. Para Android e iOS, o workflow
+calcula o fingerprint nativo atual e compara com os builds do mesmo perfil:
 
-As envs de runtime ficam no **EAS environment** (`eas env:list --environment
-production|preview`), não em secrets do GitHub. Matriz mínima de produção
-(issue [#522](https://github.com/italofelipe/auraxis-app/issues/522)):
+- ambos possuem build finalizado e compatível: publica OTA;
+- algum fingerprint não possui build: cria build nativo;
+- existe build compatível em andamento: aguarda, sem criar duplicata.
 
-| Var | Valor (produção) |
-|-----|------------------|
-| `EXPO_PUBLIC_API_URL` | `https://api.auraxis.com.br` |
-| `EXPO_PUBLIC_APP_ENV` | `production` |
-| `EXPO_PUBLIC_SENTRY_DSN` | DSN do projeto Sentry `auraxis-app` |
-| `EXPO_PUBLIC_POSTHOG_API_KEY` / `EXPO_PUBLIC_POSTHOG_HOST` | key/host do PostHog |
-| `SENTRY_AUTH_TOKEN` | secret — upload de source maps no build |
-| `APPLE_TEAM_ID`, `ASC_*` (5 vars) | submit iOS (já configuradas) |
-| `GOOGLE_SERVICE_ACCOUNT` | secret file — submit Android (setup no guia do Play) |
+Mudanças apenas em JavaScript, TypeScript, assets, copy, i18n e feature flags
+normalmente conservam o fingerprint. Dependências nativas, plugins Expo,
+permissões, configuração nativa, ícones e splash normalmente alteram o
+fingerprint.
 
-GitHub Actions precisa apenas de `EXPO_TOKEN`.
+A comparação é conservadora: ausência de informação produz build, nunca OTA
+potencialmente incompatível.
 
-## Fluxos
+## Versões e deduplicação
 
-### Release completo (build + lojas)
+`package.json`, `app.json` (`expo.version`) e
+`.release-please-manifest.json` devem ter exatamente a mesma versão. O Release
+Please atualiza os três; o workflow de loja repete a validação antes de consumir
+créditos.
 
-1. Mergear o PR do release-please (cria a tag `v*`) — ou disparar
-   `store-release.yml` manualmente.
-2. Acompanhar o build no [dashboard do EAS](https://expo.dev/accounts/italofelipe/projects/auraxis-app/builds).
-3. Android: o submit entra como **draft** no internal track — promover no Play
-   Console. iOS: o build aparece no TestFlight após o processamento.
+O `versionCode` Android e o `buildNumber` iOS continuam remotos e
+auto-incrementais no EAS. Para deduplicar uma release, o workflow exige ao mesmo
+tempo:
 
-### OTA (JS-only)
+- mesma versão pública;
+- mesmo fingerprint nativo;
+- mesmo perfil e plataforma;
+- build finalizado ou em andamento.
 
-1. Garantir que a mudança está mergeada em `main`.
-2. Actions → "OTA Update (EAS Update)" → Run workflow → canal `production`
-   (ou `preview` para validar antes em build interno).
-3. Verificar com `eas update:list --channel <canal> --limit 3`.
-4. Apps instalados aplicam o update no segundo relaunch.
+Todas as execuções de loja compartilham a mesma fila de concorrência. Um
+dispatch manual e uma tag não podem mais iniciar builds em paralelo.
+
+## Google Play internal
+
+O EAS Submit envia somente o AAB. Ele não administra release notes. Por isso o
+perfil Android permanece com `releaseStatus: draft`, que não serve o APK/AAB
+aos testadores.
+
+Depois que o submit termina:
+
+1. o workflow localiza o build Android pelo `GITHUB_SHA`, versão e
+   `versionCode`;
+2. abre um edit na Google Play Developer API;
+3. localiza exatamente esse `versionCode` no track `internal`;
+4. grava nome da release e `releaseNotes` em `pt-BR`;
+5. muda somente essa release de `draft` para `completed`;
+6. commita o edit.
+
+Qualquer falha mantém o draft não distribuído. A promoção
+`internal → production` continua manual no Play Console.
+
+O segredo GitHub `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` contém a mesma service
+account usada pelo EAS e precisa das permissões “Release apps to testing tracks”
+e “View app information”.
+
+## TestFlight e App Store
+
+O build iOS recebe o mesmo changelog no campo **What to Test** do TestFlight.
+Depois do submit, o EAS Metadata sincroniza `releaseNotes` em `pt-BR` para a
+versão exata da App Store usando `store.config.js`.
+
+O upload para TestFlight não publica o app na App Store. Selecionar o build,
+submeter para App Review e liberar a versão pública continuam sendo gates
+manuais no App Store Connect.
+
+## Promoção pública manual
+
+- Android: Play Console → Testing → Internal testing → release validada →
+  Promote release → Production → revisar rollout → Rollout to Production.
+- iOS: App Store Connect → versão com notas → selecionar build do TestFlight →
+  Submit for Review → liberar manualmente ou em phased release.
+
+Antes da promoção, conferir versão, build number/versionCode, changelog,
+screenshots/listing e smoke checklist.
+
+## Secrets e configuração
+
+GitHub Actions:
+
+| Secret | Uso |
+|---|---|
+| `EXPO_TOKEN` | EAS Build, Submit, Update e Metadata |
+| `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON` | anexar notas e concluir o track interno |
+| `RELEASE_PLEASE_TOKEN` | criar/mergear release PR e tag |
+
+As variáveis do app ficam nos ambientes EAS `preview` e `production`, incluindo
+`EXPO_PUBLIC_API_URL`, `EXPO_PUBLIC_APP_ENV`, Sentry e PostHog. Nunca colocar
+essas variáveis públicas ou credenciais de loja diretamente no YAML.
+
+## Operação manual
+
+### OTA
+
+Actions → `OTA Update (EAS Update)` → escolher canal → informar changelog
+detalhado → executar. O mesmo limite de 100–500 caracteres é aplicado.
+
+### Build de loja
+
+Actions → `Store Release (Manual + Tag)` → escolher plataforma/profile →
+informar changelog detalhado → executar. `auto_submit=true` só é aceito no
+profile `production`.
 
 ### Rollback de OTA
 
-```bash
-eas update:list --channel production --limit 10
-```
+Identificar o update bom em `eas update:list --channel production`, republicar o
+estado anterior ou usar o rollback do dashboard EAS. Registrar o update ID e
+confirmar em dispositivo real após dois relaunches.
 
-Republicar o estado JS anterior (checkout do commit bom + `eas update`) ou usar
-o rollback do dashboard EAS no branch/canal afetado. Registrar o update ID no
-incident note e confirmar que um dispositivo instalado recebe o rollback.
+## Smoke checklist
 
-## Smoke checklist (alfa)
-
-- Cadastro de conta nova + login + logout.
-- Dashboard carrega contra `api.auraxis.com.br` (nunca localhost — guard #521).
-- Transação: criar/excluir/restaurar; troca de período mensal.
-- Meta: criar e simular.
-- Assinatura abre hosted checkout; provider API exige confirmacao antes de
-  cancelar e atualiza a data final de acesso; providers Apple/Google abrem a
-  gestao oficial da loja.
-- Privacy center: opt-out de analytics interrompe eventos PostHog.
-- Push opt-in trata permissão negada/indisponível.
-- Deep links: link privado roteia após login; link inválido cai no fallback.
-- Sentry recebe erro de teste sem PII.
-- PostHog recebe eventos de tela/produto sem email/CPF/token/valores brutos.
-- OTA de teste aplicado em dispositivo com o build instalado.
-
-## Maestro
-
-Smoke local:
-
-```bash
-maestro test .maestro/01_login.yaml
-maestro test .maestro/02_dashboard_overview.yaml
-maestro test .maestro/06_privacy_analytics_opt_out.yaml
-maestro test .maestro/07_tool_usage.yaml
-maestro test .maestro/08_subscription_checkout_smoke.yaml
-maestro test .maestro/09_notification_preferences_smoke.yaml
-maestro test .maestro/05_logout.yaml
-```
+- Cadastro, login e logout.
+- Dashboard usa `https://api.auraxis.com.br`, nunca localhost.
+- Criar, editar, excluir e restaurar transação.
+- Criar e simular meta.
+- Abrir/cancelar assinatura conforme o provedor.
+- Privacy center, push opt-in e deep links.
+- Sentry e PostHog sem PII.
+- Android: tester interno enxerga versão e changelog corretos.
+- iOS: TestFlight mostra What to Test e versão correta.
+- OTA compatível é aplicado no segundo relaunch.
 
 ## Troubleshooting
 
 | Sintoma | Causa provável | Ação |
-|---------|----------------|------|
-| Build iOS falha com "Distribution Certificate is not validated for non-interactive builds" | Cert nunca validado interativamente | Italo roda `npx eas-cli credentials` (iOS) uma vez |
-| Build falha com warning de channel sem expo-updates | Pacote `expo-updates` ausente | Issue #519 |
-| Submit Android falha por credencial | `GOOGLE_SERVICE_ACCOUNT` ausente/sem permissão | Guia `docs/runbooks/googleplay-setup-italo.md` |
-| OTA não chega no dispositivo | `version` do build ≠ version do update (`runtimeVersion: appVersion`) | Publicar build novo pela loja |
-| App de produção aponta para localhost | EAS env `EXPO_PUBLIC_API_URL` ausente | Issue #522 / guard #521 |
+|---|---|---|
+| Play mostra `com.sensoriumit.auraxis (unreviewed)` | listing interno inicial ainda não propagou | aguardar até 48h e completar o store listing; isso é separado do AAB |
+| Release Android continua draft | etapa de notas/API falhou ou secret sem permissão | corrigir a falha e repetir o workflow; não promover manualmente sem notas |
+| Versão do AAB difere da tag | drift entre package/app/manifest | corrigir os três; o preflight deve bloquear |
+| OTA não chega | fingerprint do update não possui build compatível | criar build nativo para esse fingerprint |
+| Segundo build idêntico apareceu | execução anterior ao guard de #719 ou mudança de versão/fingerprint | comparar versão, fingerprint e SHA no EAS |
+| Metadata iOS falha | versão ainda não disponível ou credencial Apple inválida | validar no App Store Connect e repetir; binário não vira produção sozinho |
+
+O diagnóstico do incidente original está em
+`docs/wiki/google-play-empty-release-notes-2026-07-24.md`.

--- a/docs/runbooks/googleplay-setup-italo.md
+++ b/docs/runbooks/googleplay-setup-italo.md
@@ -62,9 +62,12 @@ Permite que o pipeline envie AABs ao Play sem você. Só precisa ser feito 1 vez
    - Permissões mínimas: **"Release apps to testing tracks"** + **"View app
      information and download bulk reports"**
    - Send invite
-6. **Me entregar o JSON** (caminho local do arquivo — NÃO commitar, NÃO colar
-   em chat público). Eu gravo como EAS secret file `GOOGLE_SERVICE_ACCOUNT`
-   (já referenciado no `eas.json`) e deleto a cópia local.
+6. **Guardar o JSON fora do Git** e registrar a mesma credencial em dois
+   cofres:
+   - EAS, para o upload do AAB;
+   - GitHub Actions, secret `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`, para anexar
+     release notes e concluir o draft pelo Android Publisher API.
+   Nunca commitar nem colar a chave em chat ou logs.
 
 ## Parte D — Primeiro release no internal testing (~10 min, depois do 1º build)
 
@@ -103,7 +106,8 @@ Rode direto nesta sessão do Claude com o prefixo `!`:
 
 ## Depois disso (volta pro Claude)
 
-- [ ] Gravar `GOOGLE_SERVICE_ACCOUNT` como EAS secret file e validar `eas submit`
+- [ ] Validar a service account no EAS e no secret GitHub
+      `GOOGLE_PLAY_SERVICE_ACCOUNT_JSON`
 - [ ] Criar projeto Sentry + gravar `EXPO_PUBLIC_SENTRY_DSN`/`SENTRY_AUTH_TOKEN`
 - [ ] Disparar o primeiro ciclo completo (store-release dispatch) e o smoke alfa
       (checklist em `docs/release-process.md`)

--- a/docs/wiki/google-play-empty-release-notes-2026-07-24.md
+++ b/docs/wiki/google-play-empty-release-notes-2026-07-24.md
@@ -1,0 +1,81 @@
+# Incidente — Google Play sem versão e sem release notes (2026-07-24)
+
+## Relato
+
+No Samsung S26 Ultra, a página de teste do Google Play exibia
+`com.sensoriumit.auraxis (unreviewed)`, ícone genérico e nenhuma informação de
+versão ou mudanças. iOS/TestFlight aparentava receber builds automaticamente,
+enquanto Android não entregava uma atualização utilizável.
+
+Issue de correção:
+[#719](https://github.com/italofelipe/auraxis-app/issues/719).
+
+## Evidências
+
+- O run de release `v1.13.5` terminou como verde no GitHub e o EAS confirmou o
+  submit, mas a configuração usada era `track=internal` +
+  `releaseStatus=draft`.
+- O EAS construiu tags `v1.13.5` e `v1.13.6` com **App Version 1.13.4**. Na
+  mesma revisão, `package.json` e o manifesto já estavam em 1.13.6.
+- Um dispatch manual e a tag `v1.13.6` iniciaram dois builds Android para o
+  mesmo fingerprint nativo.
+- Consulta autenticada ao track `internal` em 24/07/2026 encontrou o
+  `versionCode 25` em `draft`, sem `releaseNotes`.
+- O EAS Submit envia o binário, mas não administra release notes ou o store
+  listing.
+
+O nome temporário do package e o ícone genérico não provam falha de upload. O
+Google pode mostrar informações temporárias na primeira publicação interna por
+até 48 horas. O draft sem notas, a divergência de versão e a execução duplicada
+eram falhas independentes e reais do pipeline.
+
+## Causa raiz
+
+1. O workflow tratava “AAB enviado” como conclusão do release.
+2. `releaseStatus: draft` era intencional para segurança, mas não existia uma
+   segunda etapa para anexar notas e concluir o track interno.
+3. Não havia fonte obrigatória de changelog detalhado por PR.
+4. O Release Please atualizava `package.json`, mas não `app.json`.
+5. Dispatch manual e tag tinham grupos de concorrência diferentes/inexistentes.
+6. A decisão OTA versus build era manual e não comparava fingerprints.
+
+## Correção
+
+- CI bloqueia PR sem `## Changelog de loja` válido.
+- Entrega pós-CI escolhe OTA ou preview nativo por fingerprint.
+- Release Please sincroniza `app.json`.
+- Store release é serializado e deduplicado por versão/fingerprint.
+- Google continua recebendo um draft; a Developer API anexa notas em pt-BR e
+  muda exatamente o `versionCode` enviado para `completed`.
+- TestFlight recebe What to Test; EAS Metadata sincroniza release notes da App
+  Store.
+- Releases públicas continuam com aprovação humana.
+
+## Política permanente
+
+Nenhum preview, OTA, build ou release de loja pode ser iniciado sem changelog
+detalhado. Falta, placeholder ou texto acima do limite bloqueiam a execução
+antes do build. Em caso de falha posterior, o Android fica draft e não é servido
+aos testadores.
+
+## Verificação
+
+Para cada tag:
+
+1. versão em `package.json`, `app.json` e manifesto é idêntica;
+2. somente um build por plataforma e fingerprint;
+3. Play internal mostra release `X.Y.Z (versionCode)`, status completed e notas
+   pt-BR;
+4. TestFlight mostra What to Test;
+5. App Store Connect contém What’s New em pt-BR;
+6. promoção pública permanece pendente até aprovação humana.
+
+## Riscos residuais
+
+- O listing, nome, ícone, classificação e screenshots continuam dependendo do
+  preenchimento/propagação no Play Console.
+- A conta de serviço precisa manter permissões no app.
+- EAS Metadata é beta; uma falha impede o workflow de ficar verde, mas não
+  publica o binário iOS automaticamente na App Store.
+- Releases antigas sem a nova seção de changelog não podem ser republicadas
+  automaticamente sem notas manuais validadas.

--- a/eas.json
+++ b/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "version": ">= 16.13.0",
+    "version": ">= 21.2.0",
     "appVersionSource": "remote"
   },
   "build": {
@@ -46,7 +46,8 @@
       },
       "ios": {
         "ascAppId": "6772551270",
-        "appleTeamId": "725XG6A2A7"
+        "appleTeamId": "725XG6A2A7",
+        "metadataPath": "./store.config.js"
       }
     }
   }

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -10,16 +10,20 @@ module.exports = {
   // --no-warn-ignored: suprime warning de arquivos ignorados (e.g., e2e/)
   // shared/types/generated/** é ignorado via eslint.config.js para preservar
   // o formato byte-identical ao output do graphql-codegen (usado em codegen:check).
-  '**/*.{ts,tsx}': [
-    'eslint --fix --max-warnings 0 --no-warn-ignored',
-    'node scripts/check-frontend-governance.cjs',
-    'node scripts/check-api-contract-governance.cjs',
-    'node scripts/check-openapi-secret-hygiene.cjs',
+  "**/*.{ts,tsx}": [
+    "eslint --fix --max-warnings 0 --no-warn-ignored",
+    "node scripts/check-frontend-governance.cjs",
+    "node scripts/check-api-contract-governance.cjs",
+    "node scripts/check-openapi-secret-hygiene.cjs",
   ],
 
   // JSON — formatação
-  '**/*.json': [
-    'prettier --write',
-    'node scripts/check-openapi-secret-hygiene.cjs',
-  ],
-}
+  "**/*.json": ["prettier --write", "node scripts/check-openapi-secret-hygiene.cjs"],
+
+  "{package.json,package-lock.json,.nvmrc,app.json,eas.json,.release-please-config.json,lint-staged.config.js,store.config.js,README.md,CODING_STANDARDS.md,steering.md,.context/quality_gates.md,.context/architecture.md,.github/pull_request_template.md,.github/workflows/ci.yml,.github/workflows/delivery-after-ci.yml,.github/workflows/deploy-minimum.yml,.github/workflows/ota-update.yml,.github/workflows/store-release.yml,scripts/run_ci_like_actions_local.sh,scripts/release-delivery-policy.cjs,scripts/store-release-notes.cjs,scripts/google-play-release.cjs}":
+    [
+      "node scripts/check-runtime-release-governance.cjs",
+      "node scripts/check-client-security-governance.cjs",
+      "node scripts/check-client-logging-governance.cjs",
+    ],
+};

--- a/scripts/check-runtime-release-governance.cjs
+++ b/scripts/check-runtime-release-governance.cjs
@@ -69,8 +69,9 @@ const validateNodeRuntimeGovernance = ({
 };
 
 const hasPlugin = (plugins, pluginName) => {
-  return Array.isArray(plugins)
-    && plugins.some((entry) => {
+  return (
+    Array.isArray(plugins) &&
+    plugins.some((entry) => {
       if (typeof entry === "string") {
         return entry === pluginName;
       }
@@ -80,7 +81,8 @@ const hasPlugin = (plugins, pluginName) => {
       }
 
       return false;
-    });
+    })
+  );
 };
 
 const validateReleaseReadinessGovernance = ({ appConfig, easConfig }) => {
@@ -183,6 +185,85 @@ const validateReleaseReadinessGovernance = ({ appConfig, easConfig }) => {
   return errors;
 };
 
+const validateReleaseVersionGovernance = ({
+  appConfig,
+  deliveryWorkflow,
+  easConfig,
+  minimumDeployWorkflow,
+  otaWorkflow,
+  packageJson,
+  pullRequestTemplate,
+  releaseManifest,
+  releasePleaseConfig,
+  storeReleaseWorkflow,
+}) => {
+  const errors = [];
+  const packageVersion = packageJson?.version;
+  const appVersion = appConfig?.expo?.version;
+  const manifestVersion = releaseManifest?.["."];
+
+  if (packageVersion !== appVersion || packageVersion !== manifestVersion) {
+    errors.push("package.json, app.json and release manifest versions must match");
+  }
+
+  if (appConfig?.expo?.runtimeVersion?.policy !== "fingerprint") {
+    errors.push("app.json must use expo.runtimeVersion.policy=fingerprint");
+  }
+
+  const extraFiles = releasePleaseConfig?.packages?.["."]?.["extra-files"] ?? [];
+  const syncsAppVersion = extraFiles.some(
+    (entry) =>
+      entry?.type === "json" && entry?.path === "app.json" && entry?.jsonpath === "$.expo.version",
+  );
+
+  if (!syncsAppVersion) {
+    errors.push("Release Please must synchronize app.json expo.version");
+  }
+
+  if (!String(easConfig?.cli?.version ?? "").includes("21.2.0")) {
+    errors.push("eas.json must require EAS CLI 21.2.0 or newer");
+  }
+
+  if (easConfig?.submit?.production?.android?.releaseStatus !== "draft") {
+    errors.push("Android submit must remain draft until detailed notes are attached");
+  }
+
+  if (easConfig?.submit?.production?.ios?.metadataPath !== "./store.config.js") {
+    errors.push("iOS submit must use the generated EAS Metadata config");
+  }
+
+  if (!/^## Changelog de loja$/mu.test(pullRequestTemplate)) {
+    errors.push("PR template must require a store changelog section");
+  }
+
+  if (
+    !/store-release-notes\.cjs validate-pr/u.test(otaWorkflow) &&
+    !/store-release-notes\.cjs from-text/u.test(otaWorkflow)
+  ) {
+    errors.push("OTA workflow must validate detailed release notes");
+  }
+
+  if (!/store-release-notes\.cjs from-text/u.test(minimumDeployWorkflow)) {
+    errors.push("Manual preview builds must validate detailed release notes");
+  }
+
+  if (
+    !/GOOGLE_PLAY_SERVICE_ACCOUNT_JSON/u.test(storeReleaseWorkflow) ||
+    !/google-play-release\.cjs/u.test(storeReleaseWorkflow)
+  ) {
+    errors.push("Store workflow must attach notes before completing Google Play release");
+  }
+
+  if (
+    !/workflow_run:/u.test(deliveryWorkflow) ||
+    !/release-delivery-policy\.cjs/u.test(deliveryWorkflow)
+  ) {
+    errors.push("Post-CI workflow must classify OTA versus native delivery");
+  }
+
+  return errors;
+};
+
 const validateBundleGovernance = ({
   ciWorkflow,
   qualityGatesDoc,
@@ -194,33 +275,52 @@ const validateBundleGovernance = ({
   const hardLimitPattern = new RegExp(`≤ ${EXPECTED_BUNDLE_HARD_MB} MB`, "u");
 
   if (!warningPattern.test(ciWorkflow) || !hardLimitPattern.test(ciWorkflow)) {
-    errors.push(`.github/workflows/ci.yml must document the ${EXPECTED_BUNDLE_WARNING_MB} MB warning and ${EXPECTED_BUNDLE_HARD_MB} MB hard limit`);
+    errors.push(
+      `.github/workflows/ci.yml must document the ${EXPECTED_BUNDLE_WARNING_MB} MB warning and ${EXPECTED_BUNDLE_HARD_MB} MB hard limit`,
+    );
   }
 
-  const hardLimitConstantPattern = new RegExp(`const hardLimit = ${EXPECTED_BUNDLE_HARD_MB} \\* 1024 \\* 1024;`, "u");
+  const hardLimitConstantPattern = new RegExp(
+    `const hardLimit = ${EXPECTED_BUNDLE_HARD_MB} \\* 1024 \\* 1024;`,
+    "u",
+  );
   if (!hardLimitConstantPattern.test(ciWorkflow)) {
     errors.push(`.github/workflows/ci.yml must enforce a ${EXPECTED_BUNDLE_HARD_MB} MB hard limit`);
   }
 
-  const androidQualityRow = new RegExp(`\\| Android \\| > ${EXPECTED_BUNDLE_WARNING_MB} MB \\| > ${EXPECTED_BUNDLE_HARD_MB} MB \\|`, "u");
+  const androidQualityRow = new RegExp(
+    `\\| Android \\| > ${EXPECTED_BUNDLE_WARNING_MB} MB \\| > ${EXPECTED_BUNDLE_HARD_MB} MB \\|`,
+    "u",
+  );
   if (!androidQualityRow.test(qualityGatesDoc)) {
-    errors.push(`.context/quality_gates.md must document Android bundle thresholds (${EXPECTED_BUNDLE_WARNING_MB} MB / ${EXPECTED_BUNDLE_HARD_MB} MB)`);
+    errors.push(
+      `.context/quality_gates.md must document Android bundle thresholds (${EXPECTED_BUNDLE_WARNING_MB} MB / ${EXPECTED_BUNDLE_HARD_MB} MB)`,
+    );
   }
 
-  const iosQualityRow = new RegExp(`\\| iOS \\| > ${EXPECTED_BUNDLE_WARNING_MB} MB \\| > ${EXPECTED_BUNDLE_HARD_MB} MB \\|`, "u");
+  const iosQualityRow = new RegExp(
+    `\\| iOS \\| > ${EXPECTED_BUNDLE_WARNING_MB} MB \\| > ${EXPECTED_BUNDLE_HARD_MB} MB \\|`,
+    "u",
+  );
   if (!iosQualityRow.test(qualityGatesDoc)) {
-    errors.push(`.context/quality_gates.md must document iOS bundle thresholds (${EXPECTED_BUNDLE_WARNING_MB} MB / ${EXPECTED_BUNDLE_HARD_MB} MB)`);
+    errors.push(
+      `.context/quality_gates.md must document iOS bundle thresholds (${EXPECTED_BUNDLE_WARNING_MB} MB / ${EXPECTED_BUNDLE_HARD_MB} MB)`,
+    );
   }
 
   const steeringHardPattern = new RegExp(`bundle Android/iOS ≤ ${EXPECTED_BUNDLE_HARD_MB} MB`, "u");
   const steeringWarnPattern = new RegExp(`a partir de ${EXPECTED_BUNDLE_WARNING_MB} MB`, "u");
   if (!steeringHardPattern.test(steeringDoc) || !steeringWarnPattern.test(steeringDoc)) {
-    errors.push(`steering.md must document the ${EXPECTED_BUNDLE_WARNING_MB} MB warning and ${EXPECTED_BUNDLE_HARD_MB} MB hard limit`);
+    errors.push(
+      `steering.md must document the ${EXPECTED_BUNDLE_WARNING_MB} MB warning and ${EXPECTED_BUNDLE_HARD_MB} MB hard limit`,
+    );
   }
 
   const codingHardPattern = new RegExp(`hard limit ${EXPECTED_BUNDLE_HARD_MB} MB`, "u");
   if (!codingHardPattern.test(codingStandardsDoc)) {
-    errors.push(`CODING_STANDARDS.md must document the ${EXPECTED_BUNDLE_HARD_MB} MB bundle hard limit`);
+    errors.push(
+      `CODING_STANDARDS.md must document the ${EXPECTED_BUNDLE_HARD_MB} MB bundle hard limit`,
+    );
   }
 
   return errors;
@@ -233,13 +333,23 @@ const loadGovernanceInputs = () => {
     ciWorkflow: readTextFile(".github/workflows/ci.yml"),
     codingStandardsDoc: readTextFile("CODING_STANDARDS.md"),
     easConfig: readJsonFile("eas.json"),
+    deliveryWorkflow: readTextFile(".github/workflows/delivery-after-ci.yml"),
+    minimumDeployWorkflow: readTextFile(".github/workflows/deploy-minimum.yml"),
     nvmrc: readTextFile(".nvmrc"),
     packageJson: readJsonFile("package.json"),
+    pullRequestTemplate: readTextFile(".github/pull_request_template.md"),
     qualityGatesDoc: readTextFile(".context/quality_gates.md"),
+    releaseManifest: readJsonFile(".release-please-manifest.json"),
+    releasePleaseConfig: readJsonFile(".release-please-config.json"),
+    otaWorkflow: readTextFile(".github/workflows/ota-update.yml"),
     steeringDoc: readTextFile("steering.md"),
+    storeReleaseWorkflow: readTextFile(".github/workflows/store-release.yml"),
     workflowFiles: {
       ".github/workflows/ci.yml": readTextFile(".github/workflows/ci.yml"),
       ".github/workflows/deploy-minimum.yml": readTextFile(".github/workflows/deploy-minimum.yml"),
+      ".github/workflows/delivery-after-ci.yml": readTextFile(
+        ".github/workflows/delivery-after-ci.yml",
+      ),
       ".github/workflows/store-release.yml": readTextFile(".github/workflows/store-release.yml"),
     },
   };
@@ -250,6 +360,7 @@ const run = () => {
   const errors = [
     ...validateNodeRuntimeGovernance(inputs),
     ...validateReleaseReadinessGovernance(inputs),
+    ...validateReleaseVersionGovernance(inputs),
     ...validateBundleGovernance(inputs),
   ];
 
@@ -278,4 +389,5 @@ module.exports = {
   validateBundleGovernance,
   validateNodeRuntimeGovernance,
   validateReleaseReadinessGovernance,
+  validateReleaseVersionGovernance,
 };

--- a/scripts/check-runtime-release-governance.test.ts
+++ b/scripts/check-runtime-release-governance.test.ts
@@ -2,6 +2,7 @@ import {
   validateBundleGovernance,
   validateNodeRuntimeGovernance,
   validateReleaseReadinessGovernance,
+  validateReleaseVersionGovernance,
 } from "./check-runtime-release-governance.cjs";
 
 const createValidRuntimeInputs = () => {
@@ -21,7 +22,8 @@ const createValidRuntimeInputs = () => {
       "NODE_VERSION_FILE=\"$ROOT_DIR/.nvmrc\"",
       "NODE_DOCKER_IMAGE=\"node:${NODE_VERSION}-bookworm\"",
     ].join("\n"),
-    qualityGatesDoc: "nvm use 25\n# Paridade CI local (ambiente dockerizado Node 25, igual ao runner Linux):",
+    qualityGatesDoc:
+      "nvm use 25\n# Paridade CI local (ambiente dockerizado Node 25, igual ao runner Linux):",
     steeringDoc: "| Toolchain | Node.js | 25 LTS |",
   };
 };
@@ -41,10 +43,7 @@ describe("check-runtime-release-governance", () => {
     });
 
     expect(errors).toEqual(
-      expect.arrayContaining([
-        "package.json engines.node must be 25.x",
-        ".nvmrc must pin Node 25",
-      ]),
+      expect.arrayContaining(["package.json engines.node must be 25.x", ".nvmrc must pin Node 25"]),
     );
   });
 
@@ -68,10 +67,7 @@ describe("check-runtime-release-governance", () => {
               projectId: "project-id",
             },
           },
-          plugins: [
-            "expo-router",
-            ["expo-splash-screen", {}],
-          ],
+          plugins: ["expo-router", ["expo-splash-screen", {}]],
         },
       },
       easConfig: {
@@ -152,7 +148,99 @@ describe("check-runtime-release-governance", () => {
 
     expect(errors).toContain("app.json must define expo.ios.bundleIdentifier");
   });
+});
 
+describe("release version governance", () => {
+  test("accepts aligned versions and mandatory store changelog automation", () => {
+    expect(
+      validateReleaseVersionGovernance({
+        appConfig: {
+          expo: {
+            runtimeVersion: { policy: "fingerprint" },
+            version: "1.13.6",
+          },
+        },
+        deliveryWorkflow: "workflow_run:\nrelease-delivery-policy.cjs",
+        easConfig: {
+          cli: { version: ">= 21.2.0" },
+          submit: {
+            production: {
+              android: { releaseStatus: "draft" },
+              ios: { metadataPath: "./store.config.js" },
+            },
+          },
+        },
+        minimumDeployWorkflow: "store-release-notes.cjs from-text",
+        otaWorkflow: "store-release-notes.cjs from-text",
+        packageJson: { version: "1.13.6" },
+        pullRequestTemplate: "## Changelog de loja",
+        releaseManifest: { ".": "1.13.6" },
+        releasePleaseConfig: {
+          packages: {
+            ".": {
+              "extra-files": [
+                {
+                  type: "json",
+                  path: "app.json",
+                  jsonpath: "$.expo.version",
+                },
+              ],
+            },
+          },
+        },
+        storeReleaseWorkflow: ["GOOGLE_PLAY_SERVICE_ACCOUNT_JSON", "google-play-release.cjs"].join(
+          "\n",
+        ),
+      }),
+    ).toEqual([]);
+  });
+
+  test("rejects version drift before a store build can start", () => {
+    const errors = validateReleaseVersionGovernance({
+      appConfig: {
+        expo: {
+          runtimeVersion: { policy: "fingerprint" },
+          version: "1.13.4",
+        },
+      },
+      deliveryWorkflow: "workflow_run:\nrelease-delivery-policy.cjs",
+      easConfig: {
+        cli: { version: ">= 21.2.0" },
+        submit: {
+          production: {
+            android: { releaseStatus: "draft" },
+            ios: { metadataPath: "./store.config.js" },
+          },
+        },
+      },
+      minimumDeployWorkflow: "store-release-notes.cjs from-text",
+      otaWorkflow: "store-release-notes.cjs from-text",
+      packageJson: { version: "1.13.6" },
+      pullRequestTemplate: "## Changelog de loja",
+      releaseManifest: { ".": "1.13.6" },
+      releasePleaseConfig: {
+        packages: {
+          ".": {
+            "extra-files": [
+              {
+                type: "json",
+                path: "app.json",
+                jsonpath: "$.expo.version",
+              },
+            ],
+          },
+        },
+      },
+      storeReleaseWorkflow: ["GOOGLE_PLAY_SERVICE_ACCOUNT_JSON", "google-play-release.cjs"].join(
+        "\n",
+      ),
+    });
+
+    expect(errors).toContain("package.json, app.json and release manifest versions must match");
+  });
+});
+
+describe("bundle governance", () => {
   test("accepts the canonical bundle policy baseline", () => {
     expect(
       validateBundleGovernance({
@@ -160,11 +248,11 @@ describe("check-runtime-release-governance", () => {
           "> Thresholds: ≤ 10 MB (aviso) · ≤ 12 MB",
           "const hardLimit = 12 * 1024 * 1024;",
         ].join("\n"),
-        qualityGatesDoc: [
-          "| Android | > 10 MB | > 12 MB |",
-          "| iOS | > 10 MB | > 12 MB |",
-        ].join("\n"),
-        steeringDoc: "bundle Android/iOS ≤ 12 MB (hard limit no CI), com alerta operacional a partir de 10 MB.",
+        qualityGatesDoc: ["| Android | > 10 MB | > 12 MB |", "| iOS | > 10 MB | > 12 MB |"].join(
+          "\n",
+        ),
+        steeringDoc:
+          "bundle Android/iOS ≤ 12 MB (hard limit no CI), com alerta operacional a partir de 10 MB.",
         codingStandardsDoc: "bundle-analysis   (comenta tamanho no PR; hard limit 12 MB)",
       }),
     ).toEqual([]);

--- a/scripts/google-play-release.cjs
+++ b/scripts/google-play-release.cjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+
+const ANDROID_PUBLISHER_SCOPE = "https://www.googleapis.com/auth/androidpublisher";
+const GOOGLE_API_ROOT = "https://androidpublisher.googleapis.com/androidpublisher/v3";
+const GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+const encodeBase64Url = (value) => {
+  return Buffer.from(value).toString("base64url");
+};
+
+const createServiceAccountAssertion = ({ credentials, now = Date.now() }) => {
+  const issuedAt = Math.floor(now / 1000);
+  const header = encodeBase64Url(JSON.stringify({ alg: "RS256", typ: "JWT" }));
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      aud: GOOGLE_TOKEN_URL,
+      exp: issuedAt + 3600,
+      iat: issuedAt,
+      iss: credentials.client_email,
+      scope: ANDROID_PUBLISHER_SCOPE,
+    }),
+  );
+  const unsignedToken = `${header}.${payload}`;
+  const signature = crypto.sign("RSA-SHA256", Buffer.from(unsignedToken), credentials.private_key);
+  return `${unsignedToken}.${signature.toString("base64url")}`;
+};
+
+const requestAccessToken = async ({ credentials, fetchImpl = fetch }) => {
+  const assertion = createServiceAccountAssertion({ credentials });
+  const body = new URLSearchParams({
+    assertion,
+    grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+  });
+  const response = await fetchImpl(GOOGLE_TOKEN_URL, {
+    body,
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    method: "POST",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Google OAuth failed (${response.status})`);
+  }
+
+  const token = await response.json();
+  return token.access_token;
+};
+
+const googleRequest = async ({ accessToken, body, fetchImpl, method = "GET", url }) => {
+  const response = await fetchImpl(url, {
+    body: body ? JSON.stringify(body) : undefined,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    method,
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    throw new Error(`Google Play API ${method} failed (${response.status}): ${details}`);
+  }
+
+  if (response.status === 204) {
+    return {};
+  }
+
+  return response.json();
+};
+
+const updateRelease = ({ release, releaseNotes, version, versionCode }) => {
+  return {
+    ...release,
+    name: `${version} (${versionCode})`,
+    releaseNotes: [
+      {
+        language: "pt-BR",
+        text: releaseNotes,
+      },
+    ],
+    status: "completed",
+  };
+};
+
+const updateTrackForVersion = ({ track, releaseNotes, version, versionCode }) => {
+  const trackReleases = track.releases ?? [];
+  const matchingIndexes = trackReleases
+    .map((release, index) => (release.versionCodes?.includes(String(versionCode)) ? index : -1))
+    .filter((index) => index >= 0);
+
+  if (matchingIndexes.length !== 1) {
+    throw new Error(
+      `Expected one ${track.track} release for versionCode ${versionCode}, found ${matchingIndexes.length}`,
+    );
+  }
+
+  const releases = trackReleases.map((release, index) => {
+    if (index !== matchingIndexes[0]) {
+      return release;
+    }
+
+    return updateRelease({ release, releaseNotes, version, versionCode });
+  });
+
+  return { ...track, releases };
+};
+
+const publishGooglePlayRelease = async ({
+  accessToken,
+  fetchImpl = fetch,
+  packageName,
+  releaseNotes,
+  trackName = "internal",
+  version,
+  versionCode,
+}) => {
+  const applicationUrl = `${GOOGLE_API_ROOT}/applications/${packageName}`;
+  const edit = await googleRequest({
+    accessToken,
+    fetchImpl,
+    method: "POST",
+    url: `${applicationUrl}/edits`,
+  });
+  const trackUrl = `${applicationUrl}/edits/${edit.id}/tracks/${trackName}`;
+  const track = await googleRequest({ accessToken, fetchImpl, url: trackUrl });
+  const updatedTrack = updateTrackForVersion({
+    releaseNotes,
+    track,
+    version,
+    versionCode,
+  });
+
+  await googleRequest({
+    accessToken,
+    body: updatedTrack,
+    fetchImpl,
+    method: "PUT",
+    url: trackUrl,
+  });
+  await googleRequest({
+    accessToken,
+    fetchImpl,
+    method: "POST",
+    url: `${applicationUrl}/edits/${edit.id}:commit`,
+  });
+
+  return updatedTrack;
+};
+
+const parseArguments = (argv) => {
+  const values = {};
+
+  for (let index = 0; index < argv.length; index += 2) {
+    values[argv[index].replace(/^--/u, "")] = argv[index + 1];
+  }
+
+  return values;
+};
+
+const run = async () => {
+  const args = parseArguments(process.argv.slice(2));
+  const credentials = JSON.parse(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON);
+  const metadata = JSON.parse(fs.readFileSync(args["metadata-file"], "utf8"));
+  const accessToken = await requestAccessToken({ credentials });
+
+  await publishGooglePlayRelease({
+    accessToken,
+    packageName: args.package,
+    releaseNotes: metadata.releaseNotes,
+    trackName: args.track ?? "internal",
+    version: metadata.version,
+    versionCode: args["version-code"],
+  });
+  process.stdout.write(
+    `Google Play ${args.track ?? "internal"} release ${metadata.version} (${args["version-code"]}) completed with pt-BR notes.\n`,
+  );
+};
+
+if (require.main === module) {
+  run().catch((error) => {
+    process.stderr.write(`[google-play-release] ${error.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  ANDROID_PUBLISHER_SCOPE,
+  GOOGLE_API_ROOT,
+  GOOGLE_TOKEN_URL,
+  createServiceAccountAssertion,
+  publishGooglePlayRelease,
+  requestAccessToken,
+  updateRelease,
+  updateTrackForVersion,
+};

--- a/scripts/google-play-release.test.ts
+++ b/scripts/google-play-release.test.ts
@@ -1,0 +1,155 @@
+import {
+  GOOGLE_API_ROOT,
+  GOOGLE_TOKEN_URL,
+  createServiceAccountAssertion,
+  publishGooglePlayRelease,
+  requestAccessToken,
+  updateTrackForVersion,
+} from "./google-play-release.cjs";
+import { generateKeyPairSync } from "node:crypto";
+
+const releaseNotes = [
+  "- Agora a versão Android informa claramente as melhorias entregues aos usuários.",
+  "- O track interno só é liberado após o changelog em português ser anexado.",
+].join("\n");
+
+const response = (body: unknown, status = 200) => ({
+  json: async () => body,
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => JSON.stringify(body),
+});
+
+describe("google-play-release", () => {
+  test("creates a scoped, one-hour service account assertion", () => {
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 1024,
+    });
+    const assertion = createServiceAccountAssertion({
+      credentials: {
+        client_email: "publisher@example.iam.gserviceaccount.com",
+        private_key: privateKey.export({ format: "pem", type: "pkcs8" }),
+      },
+      now: 1_000_000,
+    });
+    const [, payload] = assertion.split(".");
+    const claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"));
+
+    expect(claims).toEqual(
+      expect.objectContaining({
+        aud: GOOGLE_TOKEN_URL,
+        exp: 4600,
+        iat: 1000,
+        iss: "publisher@example.iam.gserviceaccount.com",
+      }),
+    );
+  });
+
+  test("exchanges the signed assertion without exposing the private key", async () => {
+    const { privateKey } = generateKeyPairSync("rsa", {
+      modulusLength: 1024,
+    });
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValue(response({ access_token: "google-access-token" }));
+
+    await expect(
+      requestAccessToken({
+        credentials: {
+          client_email: "publisher@example.iam.gserviceaccount.com",
+          private_key: privateKey.export({ format: "pem", type: "pkcs8" }),
+        },
+        fetchImpl,
+      }),
+    ).resolves.toBe("google-access-token");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      GOOGLE_TOKEN_URL,
+      expect.objectContaining({
+        body: expect.any(URLSearchParams),
+        method: "POST",
+      }),
+    );
+  });
+
+  test("updates only the requested draft with notes and completed status", () => {
+    const updated = updateTrackForVersion({
+      releaseNotes,
+      track: {
+        track: "internal",
+        releases: [
+          { status: "completed", versionCodes: ["40"] },
+          { status: "draft", versionCodes: ["41"] },
+        ],
+      },
+      version: "1.13.7",
+      versionCode: "41",
+    });
+
+    expect(updated.releases).toEqual([
+      { status: "completed", versionCodes: ["40"] },
+      {
+        name: "1.13.7 (41)",
+        releaseNotes: [{ language: "pt-BR", text: releaseNotes }],
+        status: "completed",
+        versionCodes: ["41"],
+      },
+    ]);
+  });
+
+  test("refuses to publish when the exact versionCode is absent", () => {
+    expect(() =>
+      updateTrackForVersion({
+        releaseNotes,
+        track: {
+          track: "internal",
+          releases: [{ status: "draft", versionCodes: ["40"] }],
+        },
+        version: "1.13.7",
+        versionCode: "41",
+      }),
+    ).toThrow("Expected one internal release for versionCode 41, found 0");
+  });
+
+  test("creates an edit, updates the track and commits atomically", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(response({ id: "edit-123" }))
+      .mockResolvedValueOnce(
+        response({
+          track: "internal",
+          releases: [{ status: "draft", versionCodes: ["41"] }],
+        }),
+      )
+      .mockResolvedValueOnce(response({ track: "internal" }))
+      .mockResolvedValueOnce(response({}));
+
+    await publishGooglePlayRelease({
+      accessToken: "access-token",
+      fetchImpl,
+      packageName: "com.sensoriumit.auraxis",
+      releaseNotes,
+      version: "1.13.7",
+      versionCode: "41",
+    });
+
+    const applicationUrl = `${GOOGLE_API_ROOT}/applications/com.sensoriumit.auraxis`;
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      1,
+      `${applicationUrl}/edits`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      `${applicationUrl}/edits/edit-123/tracks/internal`,
+      expect.objectContaining({
+        body: expect.stringContaining("\"status\":\"completed\""),
+        method: "PUT",
+      }),
+    );
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      4,
+      `${applicationUrl}/edits/edit-123:commit`,
+      expect.objectContaining({ method: "POST" }),
+    );
+  });
+});

--- a/scripts/release-delivery-policy.cjs
+++ b/scripts/release-delivery-policy.cjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+
+const ACTIVE_BUILD_STATUSES = new Set(["NEW", "IN_QUEUE", "IN_PROGRESS", "PENDING_CANCEL"]);
+const FINISHED_BUILD_STATUS = "FINISHED";
+const PLATFORMS = ["android", "ios"];
+
+const normalizePlatform = (platform) => {
+  return String(platform ?? "")
+    .trim()
+    .toLowerCase();
+};
+
+const matchingBuilds = ({ appVersion = "", builds, fingerprint, platform }) => {
+  return builds.filter((build) => {
+    return (
+      normalizePlatform(build.platform) === platform &&
+      build.runtimeVersion === fingerprint &&
+      (!appVersion || build.appVersion === appVersion) &&
+      build.buildProfile
+    );
+  });
+};
+
+const platformState = ({ appVersion = "", builds, fingerprint, platform, profile }) => {
+  const matches = matchingBuilds({ appVersion, builds, fingerprint, platform }).filter(
+    (build) => build.buildProfile === profile,
+  );
+
+  if (matches.some((build) => build.status === FINISHED_BUILD_STATUS)) {
+    return "ready";
+  }
+
+  if (matches.some((build) => ACTIVE_BUILD_STATUSES.has(build.status))) {
+    return "building";
+  }
+
+  return "missing";
+};
+
+const selectFinishedBuildId = ({ appVersion = "", builds, fingerprint, platform, profile }) => {
+  const matches = matchingBuilds({ appVersion, builds, fingerprint, platform })
+    .filter((build) => build.buildProfile === profile && build.status === FINISHED_BUILD_STATUS)
+    .sort((left, right) =>
+      String(right.createdAt ?? "").localeCompare(String(left.createdAt ?? "")),
+    );
+  return matches[0]?.id ?? null;
+};
+
+const resolveDeliveryMode = ({
+  appVersion = "",
+  builds,
+  fingerprints,
+  platforms = PLATFORMS,
+  profile,
+}) => {
+  const states = Object.fromEntries(
+    platforms.map((platform) => [
+      platform,
+      platformState({
+        appVersion,
+        builds,
+        fingerprint: fingerprints[platform],
+        platform,
+        profile,
+      }),
+    ]),
+  );
+  const buildIds = Object.fromEntries(
+    platforms.map((platform) => [
+      platform,
+      selectFinishedBuildId({
+        appVersion,
+        builds,
+        fingerprint: fingerprints[platform],
+        platform,
+        profile,
+      }),
+    ]),
+  );
+
+  if (platforms.every((platform) => states[platform] === "ready")) {
+    return { buildIds, mode: "ota", states };
+  }
+
+  if (platforms.some((platform) => states[platform] === "building")) {
+    return { buildIds, mode: "wait", states };
+  }
+
+  return { buildIds, mode: "build", states };
+};
+
+const parseArguments = (argv) => {
+  const values = {};
+
+  for (let index = 0; index < argv.length; index += 2) {
+    const key = argv[index]?.replace(/^--/u, "");
+    values[key] = argv[index + 1];
+  }
+
+  return values;
+};
+
+const run = () => {
+  const args = parseArguments(process.argv.slice(2));
+  const builds = JSON.parse(fs.readFileSync(args["builds-file"], "utf8"));
+  const result = resolveDeliveryMode({
+    appVersion: args["app-version"],
+    builds,
+    fingerprints: {
+      android: args["android-fingerprint"],
+      ios: args["ios-fingerprint"],
+    },
+    platforms: args.platform && args.platform !== "all" ? [args.platform] : PLATFORMS,
+    profile: args.profile,
+  });
+
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+};
+
+if (require.main === module) {
+  run();
+}
+
+module.exports = {
+  ACTIVE_BUILD_STATUSES,
+  FINISHED_BUILD_STATUS,
+  matchingBuilds,
+  platformState,
+  resolveDeliveryMode,
+  selectFinishedBuildId,
+};

--- a/scripts/release-delivery-policy.test.ts
+++ b/scripts/release-delivery-policy.test.ts
@@ -1,0 +1,169 @@
+import { matchingBuilds, platformState, resolveDeliveryMode } from "./release-delivery-policy.cjs";
+
+type Build = {
+  appVersion: string;
+  buildProfile: string;
+  createdAt: string;
+  id: string;
+  platform: string;
+  runtimeVersion: string;
+  status: string;
+};
+
+const build = (
+  platform: "ANDROID" | "IOS",
+  status: string,
+  runtimeVersion = "native-hash",
+): Build => ({
+  appVersion: "1.13.6",
+  buildProfile: "production",
+  createdAt: "2026-07-24T12:00:00Z",
+  id: `${platform.toLowerCase()}-${status.toLowerCase()}`,
+  platform,
+  runtimeVersion,
+  status,
+});
+
+describe("release-delivery-policy", () => {
+  test("selects OTA when both native runtimes have finished builds", () => {
+    const result = resolveDeliveryMode({
+      builds: [build("ANDROID", "FINISHED"), build("IOS", "FINISHED")],
+      fingerprints: {
+        android: "native-hash",
+        ios: "native-hash",
+      },
+      profile: "production",
+    });
+
+    expect(result).toEqual({
+      buildIds: {
+        android: "android-finished",
+        ios: "ios-finished",
+      },
+      mode: "ota",
+      states: {
+        android: "ready",
+        ios: "ready",
+      },
+    });
+  });
+
+  test("selects a native build when either platform is missing", () => {
+    const result = resolveDeliveryMode({
+      builds: [build("ANDROID", "FINISHED")],
+      fingerprints: {
+        android: "native-hash",
+        ios: "native-hash",
+      },
+      profile: "production",
+    });
+
+    expect(result.mode).toBe("build");
+    expect(result.states).toEqual({
+      android: "ready",
+      ios: "missing",
+    });
+  });
+
+  test("does not duplicate a build that is already active", () => {
+    const result = resolveDeliveryMode({
+      builds: [build("ANDROID", "IN_PROGRESS"), build("IOS", "FINISHED")],
+      fingerprints: {
+        android: "native-hash",
+        ios: "native-hash",
+      },
+      profile: "production",
+    });
+
+    expect(result).toEqual({
+      buildIds: {
+        android: null,
+        ios: "ios-finished",
+      },
+      mode: "wait",
+      states: {
+        android: "building",
+        ios: "ready",
+      },
+    });
+  });
+
+  test("waits when one platform is building and the other is not visible yet", () => {
+    const result = resolveDeliveryMode({
+      builds: [build("ANDROID", "IN_PROGRESS")],
+      fingerprints: {
+        android: "native-hash",
+        ios: "native-hash",
+      },
+      profile: "production",
+    });
+
+    expect(result.mode).toBe("wait");
+    expect(result.states).toEqual({
+      android: "building",
+      ios: "missing",
+    });
+  });
+
+  test("ignores builds from another profile or runtime fingerprint", () => {
+    const builds = [
+      build("ANDROID", "FINISHED", "old-hash"),
+      {
+        ...build("ANDROID", "FINISHED", "native-hash"),
+        buildProfile: "preview",
+      },
+    ];
+
+    expect(
+      platformState({
+        builds,
+        fingerprint: "native-hash",
+        platform: "android",
+        profile: "production",
+      }),
+    ).toBe("missing");
+    expect(
+      matchingBuilds({
+        builds,
+        fingerprint: "native-hash",
+        platform: "android",
+      }),
+    ).toHaveLength(1);
+  });
+
+  test("requires an exact app version when store deduplication requests it", () => {
+    const result = resolveDeliveryMode({
+      appVersion: "1.13.7",
+      builds: [build("ANDROID", "FINISHED"), build("IOS", "FINISHED")],
+      fingerprints: {
+        android: "native-hash",
+        ios: "native-hash",
+      },
+      profile: "production",
+    });
+
+    expect(result.mode).toBe("build");
+    expect(result.states).toEqual({
+      android: "missing",
+      ios: "missing",
+    });
+  });
+
+  test("deduplicates a single-platform manual release independently", () => {
+    const result = resolveDeliveryMode({
+      builds: [build("ANDROID", "FINISHED")],
+      fingerprints: {
+        android: "native-hash",
+        ios: "native-hash",
+      },
+      platforms: ["android"],
+      profile: "production",
+    });
+
+    expect(result).toEqual({
+      buildIds: { android: "android-finished" },
+      mode: "ota",
+      states: { android: "ready" },
+    });
+  });
+});

--- a/scripts/store-config.test.ts
+++ b/scripts/store-config.test.ts
@@ -1,0 +1,28 @@
+import loadStoreConfig, { createStoreConfig } from "../store.config";
+
+describe("store.config", () => {
+  test("maps generated pt-BR notes to the exact App Store version", () => {
+    expect(
+      createStoreConfig({
+        releaseNotes: "- Mudança detalhada para os usuários.",
+        version: "1.13.7",
+      }),
+    ).toEqual({
+      configVersion: 0,
+      apple: {
+        version: "1.13.7",
+        info: {
+          "pt-BR": {
+            privacyPolicyUrl: "https://app.auraxis.com.br/privacy-policy",
+            releaseNotes: "- Mudança detalhada para os usuários.",
+            title: "Auraxis",
+          },
+        },
+      },
+    });
+  });
+
+  test("exports the dynamic EAS Metadata loader", () => {
+    expect(typeof loadStoreConfig).toBe("function");
+  });
+});

--- a/scripts/store-release-notes.cjs
+++ b/scripts/store-release-notes.cjs
@@ -1,0 +1,293 @@
+#!/usr/bin/env node
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const APPLE_MAX_LENGTH = 4000;
+const GOOGLE_MAX_LENGTH = 500;
+const MIN_LENGTH = 100;
+const MIN_BULLETS = 2;
+const STORE_CHANGELOG_HEADING = "Changelog de loja";
+const PLACEHOLDER_PATTERN = /\b(?:n\/a|não se aplica|sem alterações|todo|tbd|placeholder)\b/iu;
+
+const extractStoreChangelog = (body) => {
+  const heading = new RegExp(`^##\\s+${STORE_CHANGELOG_HEADING}\\s*$`, "imu");
+  const match = heading.exec(body ?? "");
+
+  if (!match) {
+    return "";
+  }
+
+  const tail = body.slice(match.index + match[0].length);
+  const nextHeading = tail.search(/^##\s+/mu);
+  return (nextHeading === -1 ? tail : tail.slice(0, nextHeading)).trim();
+};
+
+const normalizeNotes = (notes) => {
+  return String(notes ?? "")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.replace(/^[-*]\s+/u, "- "))
+    .join("\n");
+};
+
+const getBullets = (notes) => {
+  return normalizeNotes(notes)
+    .split("\n")
+    .filter((line) => /^-\s+\S/u.test(line));
+};
+
+const validateStoreNotes = (notes, { maxLength = GOOGLE_MAX_LENGTH } = {}) => {
+  const normalized = normalizeNotes(notes);
+  const bullets = getBullets(normalized);
+  const errors = [];
+
+  if (normalized.length < MIN_LENGTH) {
+    errors.push(`changelog must contain at least ${MIN_LENGTH} characters`);
+  }
+
+  if (normalized.length > maxLength) {
+    errors.push(`changelog exceeds the ${maxLength} character store limit`);
+  }
+
+  if (bullets.length < MIN_BULLETS) {
+    errors.push(`changelog must contain at least ${MIN_BULLETS} detailed bullets`);
+  }
+
+  if (bullets.some((bullet) => bullet.length < 25)) {
+    errors.push("every changelog bullet must contain at least 25 characters");
+  }
+
+  if (PLACEHOLDER_PATTERN.test(normalized)) {
+    errors.push("changelog contains a placeholder or non-applicable answer");
+  }
+
+  return { errors, notes: normalized };
+};
+
+const validatePullRequestBody = (body) => {
+  const extracted = extractStoreChangelog(body);
+
+  if (!extracted) {
+    return {
+      errors: [`PR body must include a "## ${STORE_CHANGELOG_HEADING}" section`],
+      notes: "",
+    };
+  }
+
+  return validateStoreNotes(extracted, { maxLength: GOOGLE_MAX_LENGTH });
+};
+
+const extractReleaseSection = (changelog, version) => {
+  const escapedVersion = version.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&");
+  const heading = new RegExp(`^##\\s+\\[?${escapedVersion}\\]?\\b.*$`, "mu");
+  const match = heading.exec(changelog);
+
+  if (!match) {
+    throw new Error(`CHANGELOG.md has no section for version ${version}`);
+  }
+
+  const tail = changelog.slice(match.index + match[0].length);
+  const nextVersion = tail.search(/^##\s+\[?\d+\.\d+\.\d+/mu);
+  return (nextVersion === -1 ? tail : tail.slice(0, nextVersion)).trim();
+};
+
+const extractPullRequestNumbers = (releaseSection) => {
+  const matches = releaseSection.matchAll(/(?:\[#|\(#|\/(?:issues|pull)\/)(\d+)(?:\]|\)|\b)/gu);
+  return [...new Set(Array.from(matches, (match) => Number(match[1])))];
+};
+
+const loadPullRequestNotes = async ({
+  fetchImpl = fetch,
+  repository,
+  token,
+  pullRequestNumbers,
+}) => {
+  const pullRequests = [];
+
+  for (const number of pullRequestNumbers) {
+    const response = await fetchImpl(`https://api.github.com/repos/${repository}/pulls/${number}`, {
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+
+    if (response.status === 404) {
+      continue;
+    }
+
+    if (!response.ok) {
+      throw new Error(`GitHub PR #${number} lookup failed (${response.status})`);
+    }
+
+    const pullRequest = await response.json();
+    const validation = validatePullRequestBody(pullRequest.body);
+
+    if (validation.errors.length > 0) {
+      throw new Error(`PR #${number}: ${validation.errors.join("; ")}`);
+    }
+
+    pullRequests.push({ notes: validation.notes, number });
+  }
+
+  return pullRequests;
+};
+
+const createReleaseMetadata = ({ pullRequests, version }) => {
+  const releaseNotes = [...new Set(pullRequests.map(({ notes }) => notes))]
+    .flatMap((notes) => notes.split("\n"))
+    .filter((line, index, lines) => lines.indexOf(line) === index)
+    .join("\n");
+  const validation = validateStoreNotes(releaseNotes, {
+    maxLength: GOOGLE_MAX_LENGTH,
+  });
+
+  if (validation.errors.length > 0) {
+    throw new Error(`Release ${version}: ${validation.errors.join("; ")}`);
+  }
+
+  return {
+    language: "pt-BR",
+    releaseNotes: validation.notes,
+    sourcePullRequests: pullRequests.map(({ number }) => number),
+    version,
+  };
+};
+
+const writeReleaseArtifacts = ({ metadata, outputDirectory }) => {
+  fs.mkdirSync(outputDirectory, { recursive: true });
+  fs.writeFileSync(
+    path.join(outputDirectory, "metadata.json"),
+    `${JSON.stringify(metadata, null, 2)}\n`,
+  );
+  fs.writeFileSync(
+    path.join(outputDirectory, "google-play-pt-BR.txt"),
+    `${metadata.releaseNotes}\n`,
+  );
+  fs.writeFileSync(path.join(outputDirectory, "app-store-pt-BR.txt"), `${metadata.releaseNotes}\n`);
+  fs.writeFileSync(
+    path.join(outputDirectory, "what-to-test-pt-BR.txt"),
+    `${metadata.releaseNotes}\n`,
+  );
+};
+
+const parseArguments = (argv) => {
+  const [command, ...pairs] = argv;
+  const values = { command };
+
+  for (let index = 0; index < pairs.length; index += 2) {
+    values[pairs[index].replace(/^--/u, "")] = pairs[index + 1];
+  }
+
+  return values;
+};
+
+const assertValid = (validation) => {
+  if (validation.errors.length > 0) {
+    throw new Error(validation.errors.join("; "));
+  }
+};
+
+const isReleasePleasePullRequest = (title) => {
+  return /^chore\(main\): release \d+\.\d+\.\d+/u.test(title ?? "");
+};
+
+const runValidatePullRequest = (eventPath) => {
+  const event = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+
+  if (isReleasePleasePullRequest(event.pull_request?.title)) {
+    process.stdout.write("Release Please PR inherits validated source changelogs.\n");
+    return;
+  }
+
+  const validation = validatePullRequestBody(event.pull_request?.body);
+  assertValid(validation);
+  process.stdout.write(`${validation.notes}\n`);
+};
+
+const runGenerateRelease = async (args) => {
+  const changelog = fs.readFileSync(args.changelog ?? "CHANGELOG.md", "utf8");
+  const section = extractReleaseSection(changelog, args.version);
+  const pullRequestNumbers = extractPullRequestNumbers(section);
+
+  if (pullRequestNumbers.length === 0) {
+    throw new Error(`Release ${args.version} does not reference any source PR`);
+  }
+
+  const pullRequests = await loadPullRequestNotes({
+    repository: process.env.GITHUB_REPOSITORY,
+    token: process.env.GITHUB_TOKEN,
+    pullRequestNumbers,
+  });
+  if (pullRequests.length === 0) {
+    throw new Error(`Release ${args.version} has no source PR with store notes`);
+  }
+
+  const metadata = createReleaseMetadata({ pullRequests, version: args.version });
+  writeReleaseArtifacts({
+    metadata,
+    outputDirectory: args["output-dir"],
+  });
+};
+
+const runFromText = (args) => {
+  const validation = validateStoreNotes(process.env.STORE_RELEASE_NOTES);
+  assertValid(validation);
+  const metadata = createReleaseMetadata({
+    pullRequests: [{ notes: validation.notes, number: "manual" }],
+    version: args.version,
+  });
+  writeReleaseArtifacts({
+    metadata,
+    outputDirectory: args["output-dir"],
+  });
+};
+
+const run = async () => {
+  const args = parseArguments(process.argv.slice(2));
+
+  if (args.command === "validate-pr") {
+    runValidatePullRequest(process.env.GITHUB_EVENT_PATH);
+    return;
+  }
+
+  if (args.command === "generate-release") {
+    await runGenerateRelease(args);
+    return;
+  }
+
+  if (args.command === "from-text") {
+    runFromText(args);
+    return;
+  }
+
+  throw new Error(`Unsupported command: ${args.command ?? "<missing>"}`);
+};
+
+if (require.main === module) {
+  run().catch((error) => {
+    process.stderr.write(`[store-release-notes] ${error.message}\n`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  APPLE_MAX_LENGTH,
+  GOOGLE_MAX_LENGTH,
+  MIN_BULLETS,
+  MIN_LENGTH,
+  STORE_CHANGELOG_HEADING,
+  createReleaseMetadata,
+  extractPullRequestNumbers,
+  extractReleaseSection,
+  extractStoreChangelog,
+  isReleasePleasePullRequest,
+  loadPullRequestNotes,
+  normalizeNotes,
+  validatePullRequestBody,
+  validateStoreNotes,
+  writeReleaseArtifacts,
+};

--- a/scripts/store-release-notes.test.ts
+++ b/scripts/store-release-notes.test.ts
@@ -1,0 +1,111 @@
+import {
+  createReleaseMetadata,
+  extractPullRequestNumbers,
+  extractReleaseSection,
+  extractStoreChangelog,
+  isReleasePleasePullRequest,
+  loadPullRequestNotes,
+  validatePullRequestBody,
+  validateStoreNotes,
+} from "./store-release-notes.cjs";
+
+const validBody = `
+## Descrição
+
+Corrige a entrega móvel.
+
+## Changelog de loja
+
+- Agora cada versão mostra claramente as funcionalidades e correções entregues aos usuários.
+- A publicação Android só é liberada depois que as notas detalhadas foram anexadas à versão.
+
+## Validação
+
+Testes verdes.
+`;
+
+describe("store-release-notes", () => {
+  test("extracts and validates a detailed localized changelog section", () => {
+    expect(extractStoreChangelog(validBody)).toContain("Agora cada versão");
+    expect(validatePullRequestBody(validBody)).toEqual({
+      errors: [],
+      notes: [
+        "- Agora cada versão mostra claramente as funcionalidades e correções entregues aos usuários.",
+        "- A publicação Android só é liberada depois que as notas detalhadas foram anexadas à versão.",
+      ].join("\n"),
+    });
+  });
+
+  test("rejects missing, short and placeholder changelogs", () => {
+    expect(validatePullRequestBody("## Descrição\nSem seção").errors).toHaveLength(1);
+    expect(validateStoreNotes("- TODO\n- N/A").errors).toEqual(
+      expect.arrayContaining([
+        "changelog must contain at least 100 characters",
+        "every changelog bullet must contain at least 25 characters",
+        "changelog contains a placeholder or non-applicable answer",
+      ]),
+    );
+  });
+
+  test("enforces the Google Play 500 character limit", () => {
+    const oversized = [
+      `- ${"Mudança relevante para usuários ".repeat(10)}`,
+      `- ${"Impacto explicado com detalhes ".repeat(10)}`,
+    ].join("\n");
+
+    expect(validateStoreNotes(oversized).errors).toContain(
+      "changelog exceeds the 500 character store limit",
+    );
+  });
+
+  test("finds the requested release section and referenced PRs", () => {
+    const changelog = [
+      "# Changelog",
+      "## [1.13.7](https://example.test) (2026-07-24)",
+      "### Bug Fixes",
+      "* delivery ([#719](https://github.com/italofelipe/auraxis-app/pull/719))",
+      "* notes (https://github.com/italofelipe/auraxis-app/pull/720)",
+      "## [1.13.6](https://example.test)",
+      "* older (#718)",
+    ].join("\n");
+    const section = extractReleaseSection(changelog, "1.13.7");
+
+    expect(section).not.toContain("older");
+    expect(extractPullRequestNumbers(section)).toEqual([719, 720]);
+  });
+
+  test("loads and combines only validated source PR notes", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ body: validBody }),
+    });
+    const pullRequests = await loadPullRequestNotes({
+      fetchImpl,
+      repository: "italofelipe/auraxis-app",
+      token: "token",
+      pullRequestNumbers: [719],
+    });
+    const metadata = createReleaseMetadata({
+      pullRequests,
+      version: "1.13.7",
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.github.com/repos/italofelipe/auraxis-app/pulls/719",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer token" }),
+      }),
+    );
+    expect(metadata).toEqual({
+      language: "pt-BR",
+      releaseNotes: expect.stringContaining("publicação Android"),
+      sourcePullRequests: [719],
+      version: "1.13.7",
+    });
+  });
+
+  test("identifies only generated Release Please PRs as policy exceptions", () => {
+    expect(isReleasePleasePullRequest("chore(main): release 1.13.7")).toBe(true);
+    expect(isReleasePleasePullRequest("fix: release notes")).toBe(false);
+  });
+});

--- a/store.config.js
+++ b/store.config.js
@@ -1,0 +1,29 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+const DEFAULT_METADATA_PATH = "build/store-release/metadata.json";
+
+const createStoreConfig = (metadata) => {
+  return {
+    configVersion: 0,
+    apple: {
+      version: metadata.version,
+      info: {
+        "pt-BR": {
+          privacyPolicyUrl: "https://app.auraxis.com.br/privacy-policy",
+          releaseNotes: metadata.releaseNotes,
+          title: "Auraxis",
+        },
+      },
+    },
+  };
+};
+
+const loadStoreConfig = () => {
+  const metadataPath = process.env.STORE_RELEASE_METADATA_PATH ?? DEFAULT_METADATA_PATH;
+  const metadata = JSON.parse(fs.readFileSync(path.resolve(process.cwd(), metadataPath), "utf8"));
+  return createStoreConfig(metadata);
+};
+
+module.exports = loadStoreConfig;
+module.exports.createStoreConfig = createStoreConfig;


### PR DESCRIPTION
## Resumo

- automatiza a entrega de cada PR após CI verde, escolhendo OTA ou build nativo por fingerprint;
- exige changelog detalhado em pt-BR para PR, OTA, preview e release de loja;
- sincroniza a versão pública entre Release Please, package.json e app.json;
- serializa/deduplica builds e finaliza o Google Play internal somente após anexar notas ao versionCode exato;
- envia What to Test ao TestFlight e release notes à App Store via EAS Metadata.

Closes #719

## Changelog de loja

- Agora cada entrega móvel informa claramente, em português, as funcionalidades, correções e impactos percebidos pelos usuários.
- O Google Play só libera a versão interna após validar versão, versionCode e changelog; TestFlight e App Store recebem as mesmas notas.

## Validação

- npm run quality-check com GRAPHQL_SCHEMA_PATH explícito: 426 suítes e 2.790 testes verdes; lint, tipos, contratos, codegen, coverage e governança aprovados.
- Testes dirigidos dos classificadores, notas, EAS Metadata e Google Publisher API.
- actionlint nos quatro workflows alterados.
- lint-staged e gitleaks no diff staged.
- eas metadata:lint: store configuration valid.
- fingerprints Android/iOS gerados localmente.
- service account autenticada; leitura do Play internal confirmou versionCode 25 em draft e sem release notes.

## Riscos residuais

- EAS Metadata continua beta; falhas bloqueiam o workflow sem publicar iOS na App Store.
- Nome/ícone temporários do primeiro listing interno podem levar até 48h para propagar.
- Promoções públicas Android e iOS continuam manuais.
- O versionCode 25 legado permanece seguro como draft; a primeira entrega corrigida virá da próxima tag.

## Evidência visual

A mudança não altera telas do app. A captura do Play Console que originou o incidente foi registrada no diagnóstico e confirmada pela API; por isso não há screenshot de UI para anexar a este PR.