### PR TITLE
chore(locales): remove 43 orphan i18n keys from pt/en [#699]

### DIFF
--- a/shared/i18n/locales/en.json
+++ b/shared/i18n/locales/en.json
@@ -1,21 +1,7 @@
 {
   "common": {
     "actions": {
-      "save": "Save",
-      "cancel": "Cancel",
-      "confirm": "Confirm",
-      "delete": "Delete",
-      "edit": "Edit",
-      "close": "Close",
-      "back": "Back",
-      "tryAgain": "Try again",
-      "create": "Create",
-      "loading": "Loading..."
-    },
-    "errors": {
-      "unknown": "Something went wrong. Please try again shortly.",
-      "network": "No connection right now",
-      "validation": "Check the highlighted fields"
+      "save": "Save"
     },
     "appearance": {
       "title": "Appearance",
@@ -42,50 +28,27 @@
   },
   "auth": {
     "captcha": {
-      "label": "Security check",
       "testKeyHint": "Development mode — Turnstile test key.",
       "error": "Could not verify. Please try again shortly.",
       "missing": "Complete the security check before continuing."
     },
     "login": {
-      "title": "Sign in",
       "overline": "SECURE AND PROTECTED ACCESS",
       "headlinePrefix": "Organize your money with",
       "headlineAccent": "clarity.",
       "subtitle": "Access your private area and continue your financial routine with confidence.",
-      "emailLabel": "Email",
       "emailLabelPremium": "EMAIL",
       "emailPlaceholderPremium": "you@example.com",
-      "passwordLabel": "Password",
       "passwordLabelPremium": "PASSWORD",
       "passwordPlaceholderPremium": "Your password",
-      "submit": "Sign in",
       "submitPremium": "Sign in to Auraxis",
       "submitting": "Signing in...",
-      "forgotPassword": "I forgot my password",
       "forgotPasswordPremium": "Forgot your password?",
       "divider": "OR",
-      "noAccount": "Don't have an account yet?",
       "noAccountPremium": "Don't have an account?",
-      "createAccount": "Create account",
       "createAccountPremium": "Create a free account",
       "terms": "Terms of Use",
       "privacy": "Privacy"
-    },
-    "register": {
-      "title": "Create account",
-      "submit": "Create account",
-      "submitting": "Creating..."
-    },
-    "forgotPassword": {
-      "title": "Recover password",
-      "submit": "Send instructions",
-      "submitting": "Sending..."
-    },
-    "resetPassword": {
-      "title": "Set new password",
-      "submit": "Save new password",
-      "submitting": "Saving..."
     },
     "resendConfirmation": {
       "title": "Resend confirmation email",
@@ -112,19 +75,10 @@
     }
   },
   "transactions": {
-    "view": {
-      "list": "List",
-      "calendar": "Calendar"
-    },
     "calendar": {
       "dayTitle": "Transactions for the day",
       "empty": "Nothing on this day.",
       "close": "Close"
-    },
-    "actions": {
-      "duplicate": "Duplicate",
-      "duplicateDescription": "Creates a copy dated today.",
-      "title": "Actions"
     },
     "feed": {
       "invoiceBadge": "invoice {{month}}"
@@ -134,9 +88,7 @@
       "description": "Pick a format; we generate the file and open share.",
       "csv": "CSV",
       "pdf": "PDF",
-      "submit": "Export now",
       "submitting": "Generating file...",
-      "success": "Ready! Use share to send or save.",
       "errorTitle": "Could not export",
       "errorDescription": "Please try again shortly."
     }
@@ -210,13 +162,6 @@
     }
   },
   "dashboard": {
-    "title": "Dashboard",
-    "greeting": "Hello, {{name}}",
-    "balanceLabel": "Total balance",
-    "monthSummary": {
-      "title": "Monthly summary",
-      "description": "Income, expenses and balance for the selected period."
-    },
     "quickAdd": {
       "fabLabel": "Quick transaction",
       "title": "Quick entry",
@@ -242,9 +187,7 @@
     "upcomingDue": {
       "title": "Upcoming due",
       "description": "Pending transactions in the next 7 days.",
-      "empty": "No upcoming dues this week.",
-      "markPaid": "Mark as paid",
-      "marking": "Marking..."
+      "empty": "No upcoming dues this week."
     },
     "embeddedSummaries": {
       "goals": {

--- a/shared/i18n/locales/pt.json
+++ b/shared/i18n/locales/pt.json
@@ -1,21 +1,7 @@
 {
   "common": {
     "actions": {
-      "save": "Salvar",
-      "cancel": "Cancelar",
-      "confirm": "Confirmar",
-      "delete": "Excluir",
-      "edit": "Editar",
-      "close": "Fechar",
-      "back": "Voltar",
-      "tryAgain": "Tentar novamente",
-      "create": "Criar",
-      "loading": "Carregando..."
-    },
-    "errors": {
-      "unknown": "Algo deu errado. Tente novamente em instantes.",
-      "network": "Sem conexao para carregar agora",
-      "validation": "Verifique os campos destacados"
+      "save": "Salvar"
     },
     "appearance": {
       "title": "Aparencia",
@@ -42,50 +28,27 @@
   },
   "auth": {
     "captcha": {
-      "label": "Verificacao de seguranca",
       "testKeyHint": "Modo de desenvolvimento — chave de teste Turnstile.",
       "error": "Nao foi possivel verificar. Tente novamente em instantes.",
       "missing": "Complete a verificacao de seguranca antes de continuar."
     },
     "login": {
-      "title": "Entrar",
       "overline": "ACESSO SEGURO E PROTEGIDO",
       "headlinePrefix": "Organize suas finanças com",
       "headlineAccent": "clareza.",
       "subtitle": "Acesse sua área privada e continue sua rotina financeira com tranquilidade.",
-      "emailLabel": "Email",
       "emailLabelPremium": "E-MAIL",
       "emailPlaceholderPremium": "seu@email.com",
-      "passwordLabel": "Senha",
       "passwordLabelPremium": "SENHA",
       "passwordPlaceholderPremium": "Sua senha",
-      "submit": "Entrar",
       "submitPremium": "Entrar na Auraxis",
       "submitting": "Entrando...",
-      "forgotPassword": "Esqueci minha senha",
       "forgotPasswordPremium": "Esqueceu sua senha?",
       "divider": "OU",
-      "noAccount": "Ainda nao tem conta?",
       "noAccountPremium": "Não tem conta?",
-      "createAccount": "Criar conta",
       "createAccountPremium": "Criar conta gratuita",
       "terms": "Termos de Uso",
       "privacy": "Privacidade"
-    },
-    "register": {
-      "title": "Criar conta",
-      "submit": "Criar conta",
-      "submitting": "Criando..."
-    },
-    "forgotPassword": {
-      "title": "Recuperar senha",
-      "submit": "Enviar instrucoes",
-      "submitting": "Enviando..."
-    },
-    "resetPassword": {
-      "title": "Definir nova senha",
-      "submit": "Salvar nova senha",
-      "submitting": "Salvando..."
     },
     "resendConfirmation": {
       "title": "Reenviar e-mail de confirmacao",
@@ -112,19 +75,10 @@
     }
   },
   "transactions": {
-    "view": {
-      "list": "Lista",
-      "calendar": "Calendario"
-    },
     "calendar": {
       "dayTitle": "Movimentacoes do dia",
       "empty": "Nenhuma movimentacao neste dia.",
       "close": "Fechar"
-    },
-    "actions": {
-      "duplicate": "Duplicar",
-      "duplicateDescription": "Cria uma copia com a data de hoje.",
-      "title": "Acoes"
     },
     "feed": {
       "invoiceBadge": "fatura {{month}}"
@@ -134,9 +88,7 @@
       "description": "Escolha o formato; geramos o arquivo e abrimos o compartilhamento.",
       "csv": "CSV",
       "pdf": "PDF",
-      "submit": "Exportar agora",
       "submitting": "Gerando arquivo...",
-      "success": "Pronto! Use o compartilhamento para enviar ou salvar.",
       "errorTitle": "Nao foi possivel exportar",
       "errorDescription": "Tente novamente em instantes."
     }
@@ -210,13 +162,6 @@
     }
   },
   "dashboard": {
-    "title": "Dashboard",
-    "greeting": "Ola, {{name}}",
-    "balanceLabel": "Saldo geral",
-    "monthSummary": {
-      "title": "Resumo por mes",
-      "description": "Receitas, despesas e saldo do periodo selecionado."
-    },
     "quickAdd": {
       "fabLabel": "Nova transacao rapida",
       "title": "Lancamento rapido",
@@ -242,9 +187,7 @@
     "upcomingDue": {
       "title": "Proximos vencimentos",
       "description": "Transacoes pendentes nos proximos 7 dias.",
-      "empty": "Nenhum vencimento na semana.",
-      "markPaid": "Marcar como pago",
-      "marking": "Marcando..."
+      "empty": "Nenhum vencimento na semana."
     },
     "embeddedSummaries": {
       "goals": {


### PR DESCRIPTION
## Contexto
Faxina da issue #699 — 43 chaves de tradução definidas em `shared/i18n/locales/{pt,en}.json` mas **nunca referenciadas** no código.

## Método
Reconciliação exata: chaves-folha definidas menos as referenciadas no source, casando por chave **terminada em aspa** (`"`/`'`/crase) para não confundir prefixos — ex.: `auth.login.emailLabel` (órfã) vs `auth.login.emailLabelPremium` (em uso, após o rework da tela de login). Total reconcilia **exatamente 43**, incluindo o falso-positivo `plans.feature.*` que a própria issue previa.

## Mudança
- pt.json e en.json: 221 → **178 folhas cada** (remoção simétrica).
- Namespaces que ficaram vazios são podados: `common.errors`, `auth.register`, `auth.forgotPassword`, `auth.resetPassword`, `transactions.view`, `transactions.actions`, `dashboard.monthSummary`.
- **Preservados**: prefixos dinâmicos (`aiChat.errors.*`, `aiChat.messageLabels.*`, `plans.feature.*`) e as chaves `auth.login.*Premium`.

## Validação
- Spot-check: 6 chaves órfãs amostradas → 0 refs; chaves mantidas → refs presentes.
- `shared/i18n/index.test.ts` ✅ · `tsc --noEmit` ✅ · paridade pt↔en mantida (zero chaves exclusivas de um lado) · JSON válido.
- Sem guard de en-freeze no app (DEC-196 é do auraxis-web).

## Risco
Baixo — só remove dados não referenciados; nenhuma mudança de código ou de comportamento.

Closes #699