### PR TITLE
feat(ota): apontar o cliente para o servidor de updates próprio

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -74,3 +74,7 @@ AuthKey_*.p8
 gen-lang-client-*.json
 *service-account*.json
 *.keystore
+# Chave privada de code signing (platform#978): fora do git e fora do
+# tarball do build — o gate de runtime-release exige superset do .gitignore.
+*.pem
+private-key*.pem

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,11 @@ reports/mutation/
 # EAS submit credentials — NUNCA commitar
 *.p8
 AuthKey_*.p8
+# Chave privada de code signing do OTA (platform#978). Entra aqui ANTES de
+# qualquer chave ser gerada: uma privada commitada por engano obriga a
+# rotacionar e a republicar binário, porque o certificado vai embarcado.
+*.pem
+private-key*.pem
 gen-lang-client-*.json
 *service-account*.json
 *.keystore

--- a/app.json
+++ b/app.json
@@ -7,8 +7,13 @@
       "policy": "fingerprint"
     },
     "updates": {
-      "url": "https://u.expo.dev/f775e10b-89c3-4bb9-8af1-5073e68ac2ce",
-      "fallbackToCacheTimeout": 0
+      "url": "https://api.auraxis.com.br/v2/ota/manifest",
+      "fallbackToCacheTimeout": 0,
+      "codeSigningCertificate": "./certs/certificate.pem",
+      "codeSigningMetadata": {
+        "keyid": "main",
+        "alg": "rsa-v1_5-sha256"
+      }
     },
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
@@ -130,27 +135,19 @@
         "NSPrivacyAccessedAPITypes": [
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryFileTimestamp",
-            "NSPrivacyAccessedAPITypeReasons": [
-              "C617.1"
-            ]
+            "NSPrivacyAccessedAPITypeReasons": ["C617.1"]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryUserDefaults",
-            "NSPrivacyAccessedAPITypeReasons": [
-              "CA92.1"
-            ]
+            "NSPrivacyAccessedAPITypeReasons": ["CA92.1"]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategorySystemBootTime",
-            "NSPrivacyAccessedAPITypeReasons": [
-              "35F9.1"
-            ]
+            "NSPrivacyAccessedAPITypeReasons": ["35F9.1"]
           },
           {
             "NSPrivacyAccessedAPIType": "NSPrivacyAccessedAPICategoryDiskSpace",
-            "NSPrivacyAccessedAPITypeReasons": [
-              "E174.1"
-            ]
+            "NSPrivacyAccessedAPITypeReasons": ["E174.1"]
           }
         ]
       }


### PR DESCRIPTION
> ## ⛔ Draft deliberado — não mergear antes do go-live de 01/09
>
> Este PR é a última peça do épico [platform#978](https://github.com/italofelipe/auraxis-platform/issues/978) e é o único que **não** pode entrar agora.

## Summary

`updates.url` passa a apontar para o nosso servidor, e o app passa a exigir manifest assinado (`codeSigningCertificate` + `codeSigningMetadata`).

## Por que fica em draft

`updates.url` é gravada no `Expo.plist` e no `AndroidManifest` **em tempo de build**. Consequências:

1. Não afeta ninguém que já tem o app — esses continuam em `u.expo.dev` para sempre.
2. Passa a valer no primeiro binário publicado depois do merge, e a partir dele o app **deixa de consultar o EAS**.
3. Se esse binário sair antes de a infra estar de pé, ele nasce **sem nenhuma via de OTA** — pior que a situação atual.

Some-se o freeze de 24-30/08: trocar o mecanismo de entrega de correção justamente na janela em que ele mais pode ser necessário é o oposto do que este épico quer resolver.

## Pré-requisitos para tirar do draft

- [ ] Bucket S3 + distribuição CloudFront provisionados e registrados em `.context/09_infra_map.md`
- [ ] `npx expo-updates codesigning:generate` executado; certificado em `certs/`, privada em `OTA_CODE_SIGNING_PRIVATE_KEY` no servidor
- [ ] `OTA_PUBLISH_TOKEN` configurado nos dois lados
- [ ] api-v2#117 e app#765 mergeados e em produção
- [ ] Um update publicado e servido com sucesso pelo pipeline próprio
- [ ] Go-live de 01/09 concluído

## Sobre a proteção das chaves

`*.pem` entra no `.gitignore` **e** no `.easignore` antes de qualquer chave existir. O gate `runtime-release` exige que o segundo seja superset do primeiro — e com razão: o EAS usa o `.easignore` para montar o tarball do build, então uma chave ignorada só pelo git ainda subiria junto. Chave privada vazada aqui obriga a rotacionar **e** a republicar binário, porque o certificado vai embarcado no app.

## Convivência com o EAS

O canal do EAS deve continuar vivo em paralelo até a versão nova ter adoção relevante — o parque instalado antigo segue ouvindo `u.expo.dev`, e desligar aquele canal deixaria essa base sem correção.

## Refs

Closes #764