### PR TITLE
fix(ota): limitar o job de OTA para não queimar 6h num hang

### DIFF
--- a/.github/workflows/ota-update.yml
+++ b/.github/workflows/ota-update.yml
@@ -29,6 +29,12 @@ jobs:
   publish-update:
     name: Publish OTA update
     runs-on: ubuntu-latest
+    # Sem limite, um `eas update` pendurado consome as 6h de teto do runner
+    # antes de o GitHub cancelar — foi o que aconteceu duas vezes em 01/08
+    # (#763), com o job travado no upload depois de exportar o bundle. O
+    # export leva ~2min e o upload alguns minutos; passar de 30 é sintoma,
+    # não trabalho em andamento.
+    timeout-minutes: 30
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
## Summary

`timeout-minutes: 30` no job do `OTA Update (EAS Update)`.

Em 01/08 o `eas update` travou duas vezes no upload e **cada tentativa consumiu as 6 horas de teto do runner** antes de o GitHub cancelar, sem publicar nada ([#763](https://github.com/italofelipe/auraxis-app/issues/763)). Doze horas de runner por zero entrega.

O export leva ~2min e o upload alguns minutos. Passar de 30 é sintoma, não trabalho em andamento.

**Isto não conserta o hang** — só para de pagar caro por ele, e faz a falha aparecer em meia hora em vez de seis.

## Changelog de loja

- Ajuste interno no processo que publica atualizações do aplicativo, para detectar falhas mais rápido.
- Nenhuma diferença no uso do app: esta mudança afeta apenas a automação de publicação.

## Refs

Closes #770
Refs #763
