### PR TITLE
fix(transactions): dar caminho de criação na aba Transações

### DIFF
--- a/features/transactions/components/transaction-feed-empty-import-cta.test.tsx
+++ b/features/transactions/components/transaction-feed-empty-import-cta.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react-native";
+import { fireEvent, render } from "@testing-library/react-native";
 
 import { AppProviders } from "@/core/providers/app-providers";
 import { IMPORT_FEATURE_FLAG_KEY } from "@/features/import/import-config";
@@ -17,9 +17,12 @@ beforeAll(async () => {
   await initI18n("pt");
 });
 
+const handleOpenCreate = jest.fn();
+
 const buildController = (): TransactionsFeedController =>
   ({
     feedItems: [],
+    handleOpenCreate,
     viewMode: "facil",
     setViewMode: jest.fn(),
     periodLabel: "Julho de 2026",
@@ -69,5 +72,53 @@ describe("TransactionFeed — CTA de import no estado vazio", () => {
     );
 
     expect(queryByText("Importar de uma planilha")).toBeNull();
+  });
+});
+
+describe("TransactionFeed — CTA de criar no estado vazio (#755)", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedIsFeatureEnabled.mockReturnValue(false);
+  });
+
+  it("oferece criar transação e chama o controller", () => {
+    const { getByText } = render(
+      <AppProviders>
+        <TransactionFeed controller={buildController()} />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByText("Nova transação"));
+    expect(handleOpenCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("não cita mais o botão central inexistente na tab bar", () => {
+    const { queryByText, getByText } = render(
+      <AppProviders>
+        <TransactionFeed controller={buildController()} />
+      </AppProviders>,
+    );
+
+    expect(queryByText(/botão central/i)).toBeNull();
+    expect(
+      getByText(
+        "Toque em “Nova transação” para lançar um movimento ou troque o filtro para ver outros lançamentos.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("mantém criar como ação principal e o import como secundária", () => {
+    mockedIsFeatureEnabled.mockImplementation(
+      (key: string) => key === IMPORT_FEATURE_FLAG_KEY,
+    );
+
+    const { getByText } = render(
+      <AppProviders>
+        <TransactionFeed controller={buildController()} />
+      </AppProviders>,
+    );
+
+    expect(getByText("Nova transação")).toBeTruthy();
+    expect(getByText("Importar de uma planilha")).toBeTruthy();
   });
 });

--- a/features/transactions/components/transaction-feed-list.tsx
+++ b/features/transactions/components/transaction-feed-list.tsx
@@ -83,10 +83,13 @@ function FeedList({
       <AppEmptyState
         illustration="transactions"
         title="Nenhuma transação no filtro atual"
-        description="Crie uma nova transação no botão central ou troque o filtro para visualizar movimentos."
+        // A copy antiga mandava usar um "botão central" que não existe na tab
+        // bar; o caminho real é o [+] do herói, replicado aqui como CTA (#755).
+        description="Toque em “Nova transação” para lançar um movimento ou troque o filtro para ver outros lançamentos."
+        cta={{ label: "Nova transação", onPress: controller.handleOpenCreate }}
         // Feed vazio é o melhor momento para oferecer o import: quem chega aqui
         // ou não lançou nada ainda, ou tem o histórico só na planilha (#749).
-        cta={
+        secondaryCta={
           importEnabled
             ? {
                 label: t("import.entry.emptyCta"),
@@ -97,7 +100,7 @@ function FeedList({
         testID="transactions-empty-state"
       />
     ),
-    [importEnabled, router, t],
+    [controller.handleOpenCreate, importEnabled, router, t],
   );
 
   return (

--- a/features/transactions/components/tx-components.test.tsx
+++ b/features/transactions/components/tx-components.test.tsx
@@ -107,6 +107,7 @@ describe("TxHero", () => {
         periodLabel="Junho de 2026"
         kpis={kpis}
         onToggleCalendar={jest.fn()}
+        onCreate={jest.fn()}
         calendarActive={false}
       />,
     );
@@ -122,12 +123,28 @@ describe("TxHero", () => {
         periodLabel="Junho de 2026"
         kpis={kpis}
         onToggleCalendar={onToggleCalendar}
+        onCreate={jest.fn()}
         calendarActive={false}
       />,
     );
     expect(queryByTestId("tx-hero-theme-toggle")).toBeNull();
     fireEvent.press(getByTestId("tx-hero-calendar-toggle"));
     expect(onToggleCalendar).toHaveBeenCalled();
+  });
+
+  it("dispara a criação de transação pelo botão do herói (#755)", () => {
+    const onCreate = jest.fn();
+    const { getByTestId } = wrap(
+      <TxHero
+        periodLabel="Junho de 2026"
+        kpis={kpis}
+        onToggleCalendar={jest.fn()}
+        onCreate={onCreate}
+        calendarActive={false}
+      />,
+    );
+    fireEvent.press(getByTestId("tx-hero-create-button"));
+    expect(onCreate).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/features/transactions/components/tx-hero.tsx
+++ b/features/transactions/components/tx-hero.tsx
@@ -26,6 +26,8 @@ export interface TxHeroProps {
   readonly kpis: FeedKpis;
   /** Alterna entre lista e calendário. */
   readonly onToggleCalendar: () => void;
+  /** Abre o formulário de criação de transação (#755). */
+  readonly onCreate: () => void;
   /** True quando a visão de calendário está ativa (controla ícone/label). */
   readonly calendarActive: boolean;
 }
@@ -131,8 +133,9 @@ function HeroResultRow({ kpis }: { readonly kpis: FeedKpis }): ReactElement {
 /**
  * Herói teal da tela de Transações: título, período + nº de lançamentos,
  * RESULTADO (mono assinado, verde/vermelho) e, à direita, os fluxos curtos
- * (↑ receitas / ↓ despesas). O único controle auxiliar alterna o calendário;
- * a preferência de tema fica exclusivamente em Configurações.
+ * (↑ receitas / ↓ despesas). Os controles auxiliares são criar transação
+ * (#755 — a aba não tinha nenhum caminho de criação) e o alternador de
+ * calendário; a preferência de tema fica exclusivamente em Configurações.
  * O gradiente segue o tema resolvido (mesmo padrão dos Cartões).
  *
  * @param props Período, KPIs, estado de tema/calendário e handlers.
@@ -142,6 +145,7 @@ export function TxHero({
   periodLabel,
   kpis,
   onToggleCalendar,
+  onCreate,
   calendarActive,
 }: TxHeroProps): ReactElement {
   const resolvedTheme = useResolvedTheme();
@@ -173,6 +177,12 @@ export function TxHero({
             </Paragraph>
           </YStack>
           <XStack gap="$2">
+            <HeroRoundButton
+              icon="plus"
+              accessibilityLabel="Nova transação"
+              testID="tx-hero-create-button"
+              onPress={onCreate}
+            />
             <HeroRoundButton
               icon={calendarActive ? "format-list-bulleted" : "calendar-month-outline"}
               accessibilityLabel={calendarActive ? "Ver lista" : "Ver calendário"}

--- a/features/transactions/screens/transactions-screen.test.tsx
+++ b/features/transactions/screens/transactions-screen.test.tsx
@@ -11,6 +11,7 @@ import type { TransactionViewModel } from "@/features/transactions/hooks/use-tra
 const mockSetViewMode = jest.fn();
 const mockToggleCalendar = jest.fn();
 const mockHandleOpenEdit = jest.fn();
+const mockHandleOpenCreate = jest.fn();
 const mockPush = jest.fn();
 
 let mockOverrides: Partial<TransactionsFeedController> = {};
@@ -81,7 +82,7 @@ const mockBaseController: TransactionsFeedController = {
   deletingTransactionId: null,
   duplicatingTransactionId: null,
   payingTransactionId: null,
-  handleOpenCreate: jest.fn(),
+  handleOpenCreate: mockHandleOpenCreate,
   handleOpenEdit: mockHandleOpenEdit,
   handleCloseForm: jest.fn(),
   handleSubmit: jest.fn(),
@@ -173,6 +174,19 @@ describe("TransactionsScreen", () => {
     fireEvent.press(getByTestId("tx-card-tx-1"));
     expect(getByTestId("transaction-action-sheet")).toBeTruthy();
     expect(getByTestId("action-delete")).toBeTruthy();
+  });
+
+  it("abre o formulário de criação pelo botão do herói (#755)", () => {
+    const { getByTestId } = renderScreen();
+    fireEvent.press(getByTestId("tx-hero-create-button"));
+    expect(mockHandleOpenCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("mantém o botão de criar disponível na visão de calendário (#755)", () => {
+    mockOverrides = { calendarActive: true };
+    const { getByTestId } = renderScreen();
+    fireEvent.press(getByTestId("tx-hero-create-button"));
+    expect(mockHandleOpenCreate).toHaveBeenCalledTimes(1);
   });
 
   it("alterna o calendário pelo botão do herói", () => {

--- a/features/transactions/screens/transactions-screen.tsx
+++ b/features/transactions/screens/transactions-screen.tsx
@@ -46,6 +46,7 @@ export function TransactionsScreen(): ReactElement {
         periodLabel={controller.periodLabel}
         kpis={controller.heroKpis}
         onToggleCalendar={controller.toggleCalendar}
+        onCreate={controller.handleOpenCreate}
         calendarActive={controller.calendarActive}
       />
     </RevealInView>

--- a/shared/components/app-empty-state.test.tsx
+++ b/shared/components/app-empty-state.test.tsx
@@ -37,6 +37,28 @@ describe("AppEmptyState", () => {
     expect(onPress).toHaveBeenCalledTimes(1);
   });
 
+  it("dispara a CTA secundaria sem perder a principal", () => {
+    const onPress = jest.fn();
+    const onSecondaryPress = jest.fn();
+    const { getByText } = render(
+      <AppProviders>
+        <AppEmptyState
+          illustration="transactions"
+          title="Sem transacoes"
+          cta={{ label: "Nova transacao", onPress }}
+          secondaryCta={{ label: "Importar", onPress: onSecondaryPress }}
+        />
+      </AppProviders>,
+    );
+
+    fireEvent.press(getByText("Importar"));
+    expect(onSecondaryPress).toHaveBeenCalledTimes(1);
+    expect(onPress).not.toHaveBeenCalled();
+
+    fireEvent.press(getByText("Nova transacao"));
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
   it("renderiza customIllustration quando fornecida", () => {
     const { getByText } = render(
       <AppProviders>

--- a/shared/components/app-empty-state.tsx
+++ b/shared/components/app-empty-state.tsx
@@ -51,6 +51,14 @@ export interface AppEmptyStateProps {
     readonly onPress: () => void;
   };
   /**
+   * Optional secondary call to action, rendered below the primary one.
+   * Use for alternative paths (ex.: importar em vez de criar à mão).
+   */
+  readonly secondaryCta?: {
+    readonly label: string;
+    readonly onPress: () => void;
+  };
+  /**
    * Optional custom node rendered above the title. Use to override the
    * default icon when a feature has a more bespoke visual.
    */
@@ -76,6 +84,7 @@ export function AppEmptyState({
   title,
   description,
   cta,
+  secondaryCta,
   customIllustration,
   testID,
 }: AppEmptyStateProps): ReactElement {
@@ -132,6 +141,12 @@ export function AppEmptyState({
       {cta ? (
         <AppButton onPress={cta.onPress} hapticTone="medium">
           {cta.label}
+        </AppButton>
+      ) : null}
+
+      {secondaryCta ? (
+        <AppButton tone="secondary" onPress={secondaryCta.onPress}>
+          {secondaryCta.label}
         </AppButton>
       ) : null}
     </AppStack>


### PR DESCRIPTION
Closes #755

## Resumo

A aba **Transações** não tinha nenhum caminho para criar uma transação. `handleOpenCreate`
existia no `use-transactions-screen-controller` e **nenhum componente o chamava**; o estado
vazio mandava usar um "botão central" que não existe na tab bar (removida no redesign F2).
Na prática, criar exigia sair da aba: FAB do Dashboard ou hub "Mais".

O que mudou:

- **`TxHero`**: novo botão redondo `[+]` "Nova transação" ao lado do alternador de calendário,
  ligado ao `handleOpenCreate` do controller — ou seja, ao formulário full-screen que a própria
  tela já renderiza quando `formMode !== "closed"`. Disponível também na visão de calendário.
- **Estado vazio do feed**: CTA principal "Nova transação" (mesmo handler) e copy corrigida —
  não cita mais botão inexistente.
- **`AppEmptyState`**: nova prop opcional `secondaryCta`, para o CTA de importar planilha (#749)
  continuar oferecido sem disputar a ação principal com o "criar".

Escopo deliberadamente pequeno: **não** unifica os 3 fluxos de criação (Quick Add, expense-sheet,
form full-screen) — isso é a #757, que já define a direção (expense-sheet como superfície única).
Aqui só se liga o fluxo que já está montado dentro da aba, sem introduzir um 4º caminho nem mexer
na estrutura de navegação (`core/navigation/`).

## Validação

- `npm run lint` nos arquivos tocados: 0 erros (o repo tem erros pré-existentes em
  `transaction-feed-toolbar.tsx` / `financial-calendar.tsx`, intocados aqui).
- `npm run typecheck` — OK.
- `npm run policy:check` — OK.
- `npm run contracts:check` — OK.
- `npm run codegen:check` — OK (schema sem drift).
- `npm run test:coverage` — **443 suites / 2909 testes verdes**, thresholds ≥85% mantidos.
- Testes novos (TDD, escritos antes da implementação):
  - `tx-components.test.tsx` — o `[+]` do herói dispara `onCreate`.
  - `transactions-screen.test.tsx` — o botão do herói chama `handleOpenCreate`, inclusive
    na visão de calendário.
  - `transaction-feed-empty-import-cta.test.tsx` — CTA "Nova transação" chama o controller,
    a copy não cita mais "botão central" e o import segue como ação secundária.
  - `app-empty-state.test.tsx` — `secondaryCta` dispara sem acionar a CTA principal.

Sem build EAS, sem OTA e sem submissão às lojas neste PR.

## Risco residual

- Baixo. Mudança aditiva de UI + uma prop opcional em `AppEmptyState` (nenhum call site
  existente quebra).
- O `[+]` abre o formulário full-screen, que **substitui a tela** — comportamento já conhecido
  (é o mesmo do fluxo de edição) e é justamente o que a #757 vai trocar por sheet.
- Validação visual em device fica com o dono do app; não há E2E automatizado dessa tela no CI.

## Changelog de loja

- Agora dá para criar uma transação direto na aba Transações, pelo botão [+] no topo da tela.
- A tela sem lançamentos passou a oferecer o botão "Nova transação" e um texto que aponta o caminho certo.
- Importar planilha continua disponível como ação secundária quando não há lançamentos no período.
