### PR TITLE
fix(release): tornar a publicação automática resiliente sem EAS Enterprise

### DIFF
--- a/.github/workflows/deploy-minimum.yml
+++ b/.github/workflows/deploy-minimum.yml
@@ -39,14 +39,9 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Validate detailed preview changelog
-        env:
-          STORE_RELEASE_NOTES: ${{ inputs.release_notes }}
-        run: |
-          node scripts/store-release-notes.cjs from-text \
-            --version "$(jq -r '.version' package.json)" \
-            --output-dir build/store-release
-
+      # O changelog de loja é exigido de quem publica (job `eas-preview-build`),
+      # não deste export. Todo push em `main` chega aqui sem `release_notes` e
+      # o gate derrubava o job antes de exportar qualquer coisa (#722).
       - name: Export web bundle
         env:
           CI: "1"
@@ -91,6 +86,26 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      - name: Require detailed release notes for any published build
+        env:
+          STORE_RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+          if [ -z "${STORE_RELEASE_NOTES:-}" ]; then
+            echo "::error::Informe release_notes (2+ bullets pt-BR, 100–500 caracteres) para publicar um build."
+            exit 1
+          fi
+
+      # Roda no mesmo job que dispara o build: `build/store-release/` é local ao
+      # runner e não sobrevive entre jobs (#722).
+      - name: Validate detailed preview changelog
+        env:
+          STORE_RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          node scripts/store-release-notes.cjs from-text \
+            --version "$(jq -r '.version' package.json)" \
+            --output-dir build/store-release
 
       - name: Validate EXPO_TOKEN
         env:

--- a/.github/workflows/store-release.yml
+++ b/.github/workflows/store-release.yml
@@ -33,13 +33,27 @@ concurrency:
   group: store-release
   cancel-in-progress: false
 
+# Android e iOS são jobs irmãos e independentes (#722): os dois dependem apenas
+# do `prepare`, nunca um do outro. A falha de uma loja não cancela nem invalida
+# a entrega da outra, e cada plataforma aguarda a própria submission terminar
+# antes de finalizar a release.
 jobs:
-  build-and-submit:
-    name: Build, submit and attach store changelog
+  prepare:
+    name: Resolve release, changelog and native reuse
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
+    outputs:
+      android_build_id: ${{ steps.policy.outputs.android_build_id }}
+      android_state: ${{ steps.policy.outputs.android_state }}
+      auto_submit: ${{ steps.params.outputs.auto_submit }}
+      ios_build_id: ${{ steps.policy.outputs.ios_build_id }}
+      ios_state: ${{ steps.policy.outputs.ios_state }}
+      platform: ${{ steps.params.outputs.platform }}
+      profile: ${{ steps.params.outputs.profile }}
+      states: ${{ steps.policy.outputs.states }}
+      version: ${{ steps.params.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -171,9 +185,10 @@ jobs:
             eas metadata:lint --profile production
           fi
 
-      - name: Prevent duplicate native builds
+      - name: Resolve native reuse per platform
         id: policy
         env:
+          PLATFORM: ${{ steps.params.outputs.platform }}
           PROFILE: ${{ steps.params.outputs.profile }}
           VERSION: ${{ steps.params.outputs.version }}
         run: |
@@ -191,144 +206,134 @@ jobs:
             --android-fingerprint "$android_fingerprint" \
             --ios-fingerprint "$ios_fingerprint" \
             --app-version "$VERSION" \
-            --platform "${{ steps.params.outputs.platform }}" \
+            --platform "$PLATFORM" \
             --profile "$PROFILE")"
           {
-            echo "mode=$(jq -r '.mode' <<< "$resolution")"
             echo "states=$(jq -c '.states' <<< "$resolution")"
+            echo "android_state=$(jq -r '.states.android // "skipped"' <<< "$resolution")"
+            echo "ios_state=$(jq -r '.states.ios // "skipped"' <<< "$resolution")"
             echo "android_build_id=$(jq -r '.buildIds.android // empty' <<< "$resolution")"
             echo "ios_build_id=$(jq -r '.buildIds.ios // empty' <<< "$resolution")"
           } >> "$GITHUB_OUTPUT"
 
       - name: Stop while an identical build is already running
-        if: steps.policy.outputs.mode == 'wait'
-        run: |
-          echo "::error::A build for this exact app version and native runtime is already running. Rerun after it completes."
-          exit 1
-
-      - name: Publish App Store release notes
-        if: >-
-          steps.policy.outputs.mode != 'wait' &&
-          steps.params.outputs.auto_submit == 'true' &&
-          steps.params.outputs.profile == 'production' &&
-          (steps.params.outputs.platform == 'ios' ||
-           steps.params.outputs.platform == 'all')
-        run: eas metadata:push --profile production --non-interactive
-
-      - name: Build and submit once
-        if: steps.policy.outputs.mode == 'build'
         env:
-          AUTO_SUBMIT: ${{ steps.params.outputs.auto_submit }}
-          NOTES_FILE: build/store-release/what-to-test-pt-BR.txt
-          PLATFORM: ${{ steps.params.outputs.platform }}
-          PROFILE: ${{ steps.params.outputs.profile }}
+          ANDROID_STATE: ${{ steps.policy.outputs.android_state }}
+          IOS_STATE: ${{ steps.policy.outputs.ios_state }}
         run: |
           set -euo pipefail
-          args=(
-            --platform "$PLATFORM"
-            --profile "$PROFILE"
-            --message "$(cat "$NOTES_FILE")"
-            --non-interactive
-          )
-          if [ "$AUTO_SUBMIT" = "true" ]; then
-            args+=(--auto-submit)
-          fi
-          eas build "${args[@]}"
-
-      - name: Submit reusable native builds
-        if: >-
-          steps.policy.outputs.mode == 'ota' &&
-          steps.params.outputs.auto_submit == 'true' &&
-          steps.params.outputs.profile == 'production'
-        env:
-          ANDROID_BUILD_ID: ${{ steps.policy.outputs.android_build_id }}
-          IOS_BUILD_ID: ${{ steps.policy.outputs.ios_build_id }}
-          PLATFORM: ${{ steps.params.outputs.platform }}
-        run: |
-          set -euo pipefail
-          if [ "$PLATFORM" = "android" ] || [ "$PLATFORM" = "all" ]; then
-            eas submit --platform android --id "$ANDROID_BUILD_ID" --profile production --non-interactive
-          fi
-          if [ "$PLATFORM" = "ios" ] || [ "$PLATFORM" = "all" ]; then
-            eas submit --platform ios --id "$IOS_BUILD_ID" --profile production --non-interactive
-          fi
-
-      - name: Resolve submitted iOS build number
-        id: ios
-        if: >-
-          steps.policy.outputs.mode != 'wait' &&
-          steps.params.outputs.auto_submit == 'true' &&
-          steps.params.outputs.profile == 'production' &&
-          (steps.params.outputs.platform == 'ios' ||
-           steps.params.outputs.platform == 'all')
-        env:
-          IOS_BUILD_ID: ${{ steps.policy.outputs.ios_build_id }}
-          VERSION: ${{ steps.params.outputs.version }}
-        run: |
-          set -euo pipefail
-          eas build:list --platform ios --profile production --status finished \
-            --limit 50 --json --non-interactive > "$RUNNER_TEMP/finished-ios-builds.json"
-          build_number="$(jq -r \
-            --arg build_id "$IOS_BUILD_ID" \
-            --arg sha "$GITHUB_SHA" \
-            --arg version "$VERSION" \
-            '[.[] | select(
-              (.appVersion == $version) and
-              (($build_id != "" and .id == $build_id) or
-               ($build_id == "" and .gitCommitHash == $sha))
-            )][0].appBuildVersion // empty' \
-            "$RUNNER_TEMP/finished-ios-builds.json")"
-          if [ -z "$build_number" ]; then
-            echo "::error::The finished iOS build for $GITHUB_SHA / $VERSION was not found."
+          if [ "$ANDROID_STATE" = "building" ] || [ "$IOS_STATE" = "building" ]; then
+            echo "::error::A build for this exact app version and native runtime is already running. Rerun after it completes."
             exit 1
           fi
-          echo "build_number=$build_number" >> "$GITHUB_OUTPUT"
 
-      - name: Attach TestFlight What to Test notes
-        if: steps.ios.outputs.build_number != ''
-        env:
-          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
-          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
-          APP_STORE_CONNECT_PRIVATE_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_BASE64 }}
-        run: |
-          node scripts/app-store-connect-release-notes.cjs \
-            --app-id 6772551270 \
-            --build-number "${{ steps.ios.outputs.build_number }}" \
-            --metadata-file build/store-release/metadata.json
+      - name: Upload the validated store changelog
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: store-release-changelog
+          path: build/store-release/
+          retention-days: 14
 
-      - name: Resolve submitted Android versionCode
-        id: android
-        if: >-
-          steps.policy.outputs.mode != 'wait' &&
-          steps.params.outputs.auto_submit == 'true' &&
-          steps.params.outputs.profile == 'production' &&
-          (steps.params.outputs.platform == 'android' ||
-           steps.params.outputs.platform == 'all')
+  android-delivery:
+    name: Android build, submit and Play internal release
+    needs: prepare
+    if: >-
+      needs.prepare.outputs.platform == 'android' ||
+      needs.prepare.outputs.platform == 'all'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Download the validated store changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: store-release-changelog
+          path: build/store-release
+
+      - name: Setup Expo
+        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
+        with:
+          eas-version: 21.2.0
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      # Build e submit são passos separados de propósito: `--auto-submit`
+      # esconde o resultado da submission e acopla as duas plataformas no
+      # mesmo comando. Aqui o build termina, o submit espera (padrão do
+      # eas-cli, sem `--no-wait`) e só então a release é finalizada.
+      - name: Build the Android artifact
+        if: needs.prepare.outputs.android_state == 'missing'
         env:
-          ANDROID_BUILD_ID: ${{ steps.policy.outputs.android_build_id }}
-          VERSION: ${{ steps.params.outputs.version }}
+          NOTES_FILE: build/store-release/what-to-test-pt-BR.txt
+          PROFILE: ${{ needs.prepare.outputs.profile }}
         run: |
           set -euo pipefail
-          eas build:list --platform android --profile production --status finished \
+          eas build \
+            --platform android \
+            --profile "$PROFILE" \
+            --message "$(cat "$NOTES_FILE")" \
+            --non-interactive
+
+      - name: Resolve the finished Android build
+        id: build
+        env:
+          PROFILE: ${{ needs.prepare.outputs.profile }}
+          REUSED_BUILD_ID: ${{ needs.prepare.outputs.android_build_id }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          eas build:list --platform android --profile "$PROFILE" --status finished \
             --limit 50 --json --non-interactive > "$RUNNER_TEMP/finished-android-builds.json"
-          version_code="$(jq -r \
-            --arg build_id "$ANDROID_BUILD_ID" \
+          selection="$(jq -c \
+            --arg build_id "$REUSED_BUILD_ID" \
             --arg sha "$GITHUB_SHA" \
             --arg version "$VERSION" \
             '[.[] | select(
               (.appVersion == $version) and
               (($build_id != "" and .id == $build_id) or
                ($build_id == "" and .gitCommitHash == $sha))
-            )][0].appBuildVersion // empty' \
+            )][0] // {}' \
             "$RUNNER_TEMP/finished-android-builds.json")"
-          if [ -z "$version_code" ]; then
+          build_id="$(jq -r '.id // empty' <<< "$selection")"
+          version_code="$(jq -r '.appBuildVersion // empty' <<< "$selection")"
+          if [ -z "$build_id" ] || [ -z "$version_code" ]; then
             echo "::error::The finished Android build for $GITHUB_SHA / $VERSION was not found."
             exit 1
           fi
-          echo "version_code=$version_code" >> "$GITHUB_OUTPUT"
+          {
+            echo "build_id=$build_id"
+            echo "version_code=$version_code"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Attach Google Play notes and complete internal release
-        if: steps.android.outputs.version_code != ''
+      - name: Submit the Android build and wait for the submission
+        if: >-
+          needs.prepare.outputs.auto_submit == 'true' &&
+          needs.prepare.outputs.profile == 'production'
+        env:
+          BUILD_ID: ${{ steps.build.outputs.build_id }}
+        run: |
+          set -euo pipefail
+          eas submit \
+            --platform android \
+            --id "$BUILD_ID" \
+            --profile production \
+            --non-interactive
+
+      - name: Attach pt-BR notes and complete the internal release
+        if: >-
+          needs.prepare.outputs.auto_submit == 'true' &&
+          needs.prepare.outputs.profile == 'production'
         env:
           GOOGLE_PLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
         run: |
@@ -336,20 +341,155 @@ jobs:
             --metadata-file build/store-release/metadata.json \
             --package com.sensoriumit.auraxis \
             --track internal \
-            --version-code "${{ steps.android.outputs.version_code }}"
+            --version-code "${{ steps.build.outputs.version_code }}"
 
-      - name: Release summary
-        if: always()
+  ios-delivery:
+    name: iOS build, App Store notes and TestFlight submit
+    needs: prepare
+    if: >-
+      needs.prepare.outputs.platform == 'ios' ||
+      needs.prepare.outputs.platform == 'all'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Download the validated store changelog
+        uses: actions/download-artifact@v4
+        with:
+          name: store-release-changelog
+          path: build/store-release
+
+      - name: Setup Expo
+        uses: expo/expo-github-action@eab7a230208c952974db8c3245cfd78402c7b385 # v9
+        with:
+          eas-version: 21.2.0
+          token: ${{ secrets.EXPO_TOKEN }}
+
+      - name: Build the iOS artifact
+        if: needs.prepare.outputs.ios_state == 'missing'
         env:
-          MODE: ${{ steps.policy.outputs.mode }}
-          STATES: ${{ steps.policy.outputs.states }}
-          VERSION: ${{ steps.params.outputs.version }}
+          NOTES_FILE: build/store-release/what-to-test-pt-BR.txt
+          PROFILE: ${{ needs.prepare.outputs.profile }}
+        run: |
+          set -euo pipefail
+          eas build \
+            --platform ios \
+            --profile "$PROFILE" \
+            --message "$(cat "$NOTES_FILE")" \
+            --non-interactive
+
+      - name: Resolve the finished iOS build
+        id: build
+        env:
+          PROFILE: ${{ needs.prepare.outputs.profile }}
+          REUSED_BUILD_ID: ${{ needs.prepare.outputs.ios_build_id }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          eas build:list --platform ios --profile "$PROFILE" --status finished \
+            --limit 50 --json --non-interactive > "$RUNNER_TEMP/finished-ios-builds.json"
+          selection="$(jq -c \
+            --arg build_id "$REUSED_BUILD_ID" \
+            --arg sha "$GITHUB_SHA" \
+            --arg version "$VERSION" \
+            '[.[] | select(
+              (.appVersion == $version) and
+              (($build_id != "" and .id == $build_id) or
+               ($build_id == "" and .gitCommitHash == $sha))
+            )][0] // {}' \
+            "$RUNNER_TEMP/finished-ios-builds.json")"
+          build_id="$(jq -r '.id // empty' <<< "$selection")"
+          build_number="$(jq -r '.appBuildVersion // empty' <<< "$selection")"
+          if [ -z "$build_id" ] || [ -z "$build_number" ]; then
+            echo "::error::The finished iOS build for $GITHUB_SHA / $VERSION was not found."
+            exit 1
+          fi
+          {
+            echo "build_id=$build_id"
+            echo "build_number=$build_number"
+          } >> "$GITHUB_OUTPUT"
+
+      # O changelog público pt-BR chega ao App Store Connect ANTES do submit:
+      # `eas metadata:push` é a rota suportada no plano atual (o parâmetro de
+      # "what to test" do eas submit é exclusivo do plano Enterprise).
+      - name: Publish App Store release notes before submitting
+        if: >-
+          needs.prepare.outputs.auto_submit == 'true' &&
+          needs.prepare.outputs.profile == 'production'
+        run: eas metadata:push --profile production --non-interactive
+
+      - name: Submit the iOS build and wait for the submission
+        if: >-
+          needs.prepare.outputs.auto_submit == 'true' &&
+          needs.prepare.outputs.profile == 'production'
+        env:
+          BUILD_ID: ${{ steps.build.outputs.build_id }}
+        run: |
+          set -euo pipefail
+          eas submit \
+            --platform ios \
+            --id "$BUILD_ID" \
+            --profile production \
+            --non-interactive
+
+      - name: Attach TestFlight What to Test notes
+        if: >-
+          needs.prepare.outputs.auto_submit == 'true' &&
+          needs.prepare.outputs.profile == 'production'
+        env:
+          APP_STORE_CONNECT_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_ISSUER_ID }}
+          APP_STORE_CONNECT_KEY_ID: ${{ secrets.APP_STORE_CONNECT_KEY_ID }}
+          APP_STORE_CONNECT_PRIVATE_KEY_BASE64: ${{ secrets.APP_STORE_CONNECT_PRIVATE_KEY_BASE64 }}
+        run: |
+          node scripts/app-store-connect-release-notes.cjs \
+            --app-id 6772551270 \
+            --build-number "${{ steps.build.outputs.build_number }}" \
+            --metadata-file build/store-release/metadata.json
+
+  release-summary:
+    name: Release summary
+    needs: [prepare, android-delivery, ios-delivery]
+    if: always() && needs.prepare.result != 'skipped'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download the validated store changelog
+        if: needs.prepare.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: store-release-changelog
+          path: build/store-release
+
+      - name: Record the per-platform outcome
+        env:
+          ANDROID_RESULT: ${{ needs.android-delivery.result }}
+          IOS_RESULT: ${{ needs.ios-delivery.result }}
+          PLATFORM: ${{ needs.prepare.outputs.platform }}
+          STATES: ${{ needs.prepare.outputs.states }}
+          VERSION: ${{ needs.prepare.outputs.version }}
         run: |
           {
-            echo "### Store release ${VERSION}"
+            echo "### Store release ${VERSION:-unknown}"
             echo
-            echo "- Native decision: \`${MODE:-not-evaluated}\`"
-            echo "- Platform states: \`${STATES:-not-evaluated}\`"
+            echo "- Target platform: \`${PLATFORM:-not-evaluated}\`"
+            echo "- Native reuse states: \`${STATES:-not-evaluated}\`"
+            echo "- Android delivery: \`${ANDROID_RESULT}\`"
+            echo "- iOS delivery: \`${IOS_RESULT}\`"
+            echo
+            echo "Plataformas são independentes: uma loja pode concluir enquanto a outra falha."
             if [ -f build/store-release/metadata.json ]; then
               echo
               echo "#### Changelog pt-BR"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -20,11 +20,16 @@ merge na main
 
 tag vX.Y.Z
   └─ store-release.yml, uma execução por vez
-      ├─ gera changelog a partir dos PRs da versão
-      ├─ valida versão + credenciais + duplicidade
-      ├─ build e submit Android/iOS
-      ├─ App Store/TestFlight recebe What to Test + release notes
-      └─ Google Play draft recebe release notes e só então vira completed
+      ├─ job prepare
+      │   ├─ gera changelog a partir dos PRs da versão
+      │   ├─ valida versão + credenciais + duplicidade
+      │   └─ publica o changelog validado como artifact da execução
+      ├─ job android-delivery (independente)
+      │   ├─ build → submit (aguarda a submission)
+      │   └─ Google Play draft recebe release notes e só então vira completed
+      └─ job ios-delivery (independente)
+          ├─ build → eas metadata:push (release notes) → submit (aguarda)
+          └─ TestFlight recebe What to Test pela API do App Store Connect
 ```
 
 O PR mecânico `chore(main): release X.Y.Z` não cria outro preview ou build. A
@@ -102,6 +107,78 @@ tempo:
 Todas as execuções de loja compartilham a mesma fila de concorrência. Um
 dispatch manual e uma tag não podem mais iniciar builds em paralelo.
 
+## Isolamento por plataforma
+
+Android e iOS são jobs irmãos: os dois dependem só do `prepare` e nunca um do
+outro. Consequências práticas:
+
+- a falha de uma loja não cancela nem invalida a entrega da outra;
+- cada plataforma faz `eas build` e `eas submit` em passos separados. O
+  `--auto-submit` foi removido: ele acopla as duas plataformas no mesmo comando
+  e esconde o resultado da submission;
+- nenhuma submissão usa `--no-wait`. A finalização (notas do Play, What to Test)
+  só começa depois que a submission daquela plataforma terminou;
+- o changelog validado é gerado uma única vez no `prepare` e distribuído como
+  artifact. Nenhum job revalida ou regenera o texto, então as duas lojas
+  recebem exatamente os mesmos bytes.
+
+O gate `scripts/check-store-release-workflow.cjs` (dentro de
+`npm run policy:check`) congela esse formato: ele falha se os jobs voltarem a
+ser um só, se um depender do outro, se um flag proibido reaparecer ou se a
+ordem submit → finalização for invertida.
+
+### Recuperação de falha parcial
+
+Uma execução com Android verde e iOS vermelho (ou o inverso) **não deve ser
+re-executada inteira**. Use `Re-run failed jobs`: o `prepare` já concluiu e o
+job da plataforma que passou não é refeito. Se o build da plataforma que falhou
+já existir no EAS, o `prepare` o classifica como `ready` e a nova execução só
+submete, sem consumir outro build.
+
+Recuperação manual, na ordem em que o pipeline faria:
+
+```bash
+eas build:list --platform ios --profile production --status finished --limit 5 --json --non-interactive
+eas metadata:push --profile production --non-interactive          # notas pt-BR antes do submit
+eas submit --platform ios --id <BUILD_ID> --profile production --non-interactive
+node scripts/app-store-connect-release-notes.cjs \
+  --app-id 6772551270 --build-number <BUILD_NUMBER> \
+  --metadata-file build/store-release/metadata.json
+```
+
+```bash
+eas submit --platform android --id <BUILD_ID> --profile production --non-interactive
+node scripts/google-play-release.cjs \
+  --metadata-file build/store-release/metadata.json \
+  --package com.sensoriumit.auraxis --track internal --version-code <VERSION_CODE>
+```
+
+O `metadata.json` está no artifact `store-release-changelog` da execução.
+
+## Limitações do plano EAS
+
+O plano atual não é Enterprise. Isso proíbe, de forma permanente:
+
+- passar o texto de "what to test" ao `eas submit` — o parâmetro existe apenas
+  no Enterprise e aborta o comando nos demais planos. O What to Test é gravado
+  pela API oficial do App Store Connect (`betaBuildLocalizations`);
+- depender de qualquer automação que exija esse parâmetro para concluir.
+
+O que continua disponível e é usado: `eas build`, `eas submit`, `eas update`,
+`eas metadata:lint` e `eas metadata:push`.
+
+## Deploy Minimum
+
+`deploy-minimum.yml` tem dois jobs com exigências diferentes:
+
+- `web-baseline-artifact` roda em todo push de `main` e apenas exporta o bundle
+  web. Ele **não** exige changelog de loja: pushes não carregam o input
+  `release_notes` e o gate derrubava o job antes de exportar qualquer coisa;
+- `eas-preview-build` só roda por `workflow_dispatch` com
+  `run_eas_build = true`. Esse job exige e valida o changelog detalhado no
+  próprio runner, porque `build/store-release/` é local ao job e não sobrevive
+  entre jobs.
+
 ## Google Play internal
 
 O EAS Submit envia somente o AAB. Ele não administra release notes. Por isso o
@@ -116,7 +193,10 @@ Depois que o submit termina:
 3. localiza exatamente esse `versionCode` no track `internal`;
 4. grava nome da release e `releaseNotes` em `pt-BR`;
 5. muda somente essa release de `draft` para `completed`;
-6. commita o edit.
+6. commita o edit;
+7. abre um edit somente-leitura, relê o track e confirma que o Google Play
+   reporta `completed`, com o nome `versão (versionCode)` e as notas pt-BR
+   exatas. Só então o passo é considerado bem-sucedido.
 
 Qualquer falha mantém o draft não distribuído. A promoção
 `internal → production` continua manual no Play Console.

--- a/docs/wiki/store-release-platform-isolation-2026-08-02.md
+++ b/docs/wiki/store-release-platform-isolation-2026-08-02.md
@@ -1,0 +1,91 @@
+# Entrega de loja resiliente sem EAS Enterprise (2026-08-02)
+
+## Relato
+
+A release `1.13.7`, disparada pela tag `v1.13.7`, produziu as builds Android e
+iOS corretamente, mas o workflow não concluiu o fluxo sem intervenção manual.
+
+Run de referência:
+[30098991202](https://github.com/italofelipe/auraxis-app/actions/runs/30098991202).
+Issue de correção:
+[#722](https://github.com/italofelipe/auraxis-app/issues/722).
+
+## Causa raiz
+
+1. **Parâmetro exclusivo do plano Enterprise.** O envio iOS recebeu o texto de
+   "what to test" pelo `eas submit`. Esse parâmetro só existe no plano
+   Enterprise e aborta o comando nos demais planos.
+2. **Plataformas acopladas.** Android e iOS viviam no mesmo job, em passos
+   sequenciais. A falha do agendamento iOS interrompeu o job inteiro e impediu a
+   finalização do Android — que já tinha um AAB pronto e aceito.
+3. **`Deploy Minimum` exigia changelog em push.** O job de export web validava
+   `## Changelog de loja` mesmo em `push` para `main`, evento que não carrega o
+   input `release_notes`. Todo push falhava antes de exportar qualquer coisa.
+4. **`build/store-release/` compartilhado entre jobs.** O job de preview lia um
+   `metadata.json` gerado em outro job, que nunca existiu no runner dele.
+
+## Correção
+
+### Isolamento por plataforma
+
+`store-release.yml` passou a ter quatro jobs:
+
+| Job | Papel |
+|---|---|
+| `prepare` | changelog validado, versão, credenciais, dedup por fingerprint; publica o artifact `store-release-changelog` |
+| `android-delivery` | build → submit (aguarda) → notas pt-BR + `completed` no track interno |
+| `ios-delivery` | build → `eas metadata:push` → submit (aguarda) → What to Test |
+| `release-summary` | roda com `always()` e registra o resultado de cada loja |
+
+`android-delivery` e `ios-delivery` dependem **apenas** de `prepare`, nunca um
+do outro. Uma loja pode concluir enquanto a outra falha.
+
+### Comandos sem dependência de Enterprise
+
+- `--auto-submit` foi removido: build e submit são passos separados, o que
+  permite isolar plataformas e ler o resultado da submission;
+- nenhuma submissão usa `--no-wait`: a finalização só começa quando a
+  submission daquela plataforma termina;
+- o texto de "what to test" nunca vai para o `eas submit`. As notas públicas
+  vão por `eas metadata:push` **antes** do submit e o What to Test é gravado
+  pela API oficial do App Store Connect depois do upload.
+
+### Evidência no Google Play
+
+Depois de commitar o edit, `scripts/google-play-release.cjs` abre um edit
+somente-leitura e relê o track: exige `status: completed`, nome
+`versão (versionCode)` e as notas pt-BR idênticas às validadas. "A API aceitou
+o edit" deixou de contar como entrega concluída.
+
+### Deploy Minimum
+
+O export web não exige mais changelog de loja — ele não publica nada. A
+validação passou para o job que dispara o build EAS, no mesmo runner que
+consome o `metadata.json`.
+
+## Recuperação de falha parcial
+
+1. Use **Re-run failed jobs**, não re-run completo: `prepare` e a plataforma
+   verde não são refeitos.
+2. Se o build da plataforma que falhou já existir no EAS, o `prepare` o
+   classifica como `ready` e a nova execução só submete — sem consumir outro
+   build.
+3. Para recuperação manual, baixe o artifact `store-release-changelog` e siga a
+   sequência documentada em [`docs/release-process.md`](../release-process.md)
+   (seção "Recuperação de falha parcial").
+
+## Gate permanente
+
+`scripts/check-store-release-workflow.cjs`, dentro de `npm run policy:check`,
+falha o CI se:
+
+- `store-release.yml` voltar a colapsar as plataformas em um job;
+- um job de plataforma passar a depender do outro;
+- reaparecer um flag proibido (`--what-to-test`, `--auto-submit`, `--no-wait`);
+- a ordem submit → finalização for invertida, ou as notas da App Store deixarem
+  de preceder o submit;
+- `deploy-minimum.yml` voltar a exigir changelog em um job que roda em push.
+
+Comentários que citam um flag proibido não contam como uso — o gate ignora
+linhas de comentário de propósito, para que a regra possa ser documentada onde
+ela vale.

--- a/scripts/check-store-release-workflow.cjs
+++ b/scripts/check-store-release-workflow.cjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+
+/**
+ * Governance for the store delivery workflows (#722).
+ *
+ * The 1.13.7 release proved three failure modes that a green unit suite never
+ * catches, because they live in YAML:
+ *
+ * 1. an EAS Enterprise-only flag aborted the iOS submission;
+ * 2. Android and iOS shared a single job, so the iOS failure took Android down
+ *    with it;
+ * 3. `Deploy Minimum` demanded a store changelog on every push to `main`,
+ *    where no changelog input exists, and died before publishing anything.
+ *
+ * These checks freeze the shape that fixed each one.
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const STORE_RELEASE_WORKFLOW = ".github/workflows/store-release.yml";
+const MINIMUM_DEPLOY_WORKFLOW = ".github/workflows/deploy-minimum.yml";
+
+const PREPARE_JOB = "prepare";
+const ANDROID_JOB = "android-delivery";
+const IOS_JOB = "ios-delivery";
+
+/**
+ * Flags the store pipeline must never reintroduce.
+ *
+ * - `--what-to-test` only exists on the EAS Enterprise plan;
+ * - `--auto-submit` hides the submission result inside the build command and
+ *   couples both platforms into one step;
+ * - `--no-wait` returns before the submission finishes, so the finalization
+ *   would run against a build the store has not accepted yet.
+ */
+const FORBIDDEN_DELIVERY_FLAGS = ["--what-to-test", "--auto-submit", "--no-wait"];
+
+const readWorkflow = (rootDirectory, relativePath) => {
+  const absolutePath = path.join(rootDirectory, relativePath);
+  return fs.existsSync(absolutePath) ? fs.readFileSync(absolutePath, "utf8") : "";
+};
+
+/**
+ * Drops comment-only lines so documenting a forbidden flag ("we never pass
+ * --auto-submit") is not read as using it.
+ */
+const stripComments = (workflow) => {
+  return String(workflow ?? "")
+    .split("\n")
+    .filter((line) => !/^\s*#/u.test(line))
+    .join("\n");
+};
+
+/** Splits a workflow into `{ jobId: blockText }` using the 2-space job indent. */
+const splitWorkflowJobs = (workflow) => {
+  const lines = String(workflow ?? "").split("\n");
+  const jobsIndex = lines.findIndex((line) => /^jobs:\s*$/u.test(line));
+
+  if (jobsIndex === -1) {
+    return {};
+  }
+
+  const blocks = new Map();
+  let current = null;
+
+  for (const line of lines.slice(jobsIndex + 1)) {
+    const jobStart = /^ {2}([A-Za-z0-9_-]+):\s*$/u.exec(line);
+
+    if (jobStart) {
+      current = jobStart[1];
+      blocks.set(current, []);
+      continue;
+    }
+
+    if (line.trim() !== "" && !/^\s/u.test(line)) {
+      break;
+    }
+
+    if (current) {
+      blocks.get(current).push(line);
+    }
+  }
+
+  return Object.fromEntries([...blocks].map(([id, body]) => [id, body.join("\n")]));
+};
+
+/** Reads a job's `needs`, supporting both the inline and the list syntax. */
+const readJobNeeds = (jobBlock) => {
+  // `[ \t]*` and not `\s*`: `\s` swallows the newline and would capture the
+  // first item of the list syntax as if it were an inline value.
+  const inline = /^ {4}needs:[ \t]*(.*)$/mu.exec(String(jobBlock ?? ""));
+
+  if (!inline) {
+    return [];
+  }
+
+  const value = inline[1].trim();
+
+  if (value.startsWith("[")) {
+    return value
+      .slice(1, value.endsWith("]") ? -1 : undefined)
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  if (value !== "") {
+    return [value];
+  }
+
+  return [...String(jobBlock).matchAll(/^ {6}-\s*([A-Za-z0-9_-]+)\s*$/gmu)].map(
+    (match) => match[1],
+  );
+};
+
+const runsBefore = (block, first, second) => {
+  const firstIndex = block.indexOf(first);
+  const secondIndex = block.indexOf(second);
+  return firstIndex !== -1 && secondIndex !== -1 && firstIndex < secondIndex;
+};
+
+const validateStoreReleaseWorkflow = (workflow) => {
+  const errors = [];
+  const executable = stripComments(workflow);
+  const jobs = splitWorkflowJobs(executable);
+
+  for (const jobId of [PREPARE_JOB, ANDROID_JOB, IOS_JOB]) {
+    if (!jobs[jobId]) {
+      errors.push(`${STORE_RELEASE_WORKFLOW} must define the "${jobId}" job`);
+    }
+  }
+
+  const platformJobs = [
+    { id: ANDROID_JOB, sibling: IOS_JOB },
+    { id: IOS_JOB, sibling: ANDROID_JOB },
+  ];
+
+  for (const { id, sibling } of platformJobs) {
+    const block = jobs[id];
+
+    if (!block) {
+      continue;
+    }
+
+    const needs = readJobNeeds(block);
+
+    if (!needs.includes(PREPARE_JOB)) {
+      errors.push(`"${id}" must depend on "${PREPARE_JOB}"`);
+    }
+
+    if (needs.includes(sibling)) {
+      errors.push(`"${id}" must not depend on "${sibling}": a failing store cannot block the other`);
+    }
+  }
+
+  for (const flag of FORBIDDEN_DELIVERY_FLAGS) {
+    if (executable.includes(flag)) {
+      errors.push(`${STORE_RELEASE_WORKFLOW} must not use the "${flag}" delivery flag`);
+    }
+  }
+
+  if (jobs[ANDROID_JOB] && !runsBefore(jobs[ANDROID_JOB], "eas submit", "google-play-release.cjs")) {
+    errors.push("Android must submit and wait before completing the Play internal release");
+  }
+
+  if (jobs[IOS_JOB] && !runsBefore(jobs[IOS_JOB], "eas metadata:push", "eas submit")) {
+    errors.push("iOS must push the pt-BR App Store notes before submitting the build");
+  }
+
+  if (
+    jobs[IOS_JOB] &&
+    !runsBefore(jobs[IOS_JOB], "eas submit", "app-store-connect-release-notes.cjs")
+  ) {
+    errors.push("iOS must submit and wait before attaching the TestFlight notes");
+  }
+
+  return errors;
+};
+
+const validateMinimumDeployWorkflow = (workflow) => {
+  const errors = [];
+  const jobs = splitWorkflowJobs(stripComments(workflow));
+  const validationJobs = Object.entries(jobs).filter(([, block]) =>
+    block.includes("store-release-notes.cjs from-text"),
+  );
+
+  if (validationJobs.length === 0) {
+    errors.push(`${MINIMUM_DEPLOY_WORKFLOW} must validate detailed release notes before publishing`);
+    return errors;
+  }
+
+  for (const [id, block] of validationJobs) {
+    if (!/inputs\.run_eas_build == 'true'/u.test(block)) {
+      errors.push(
+        `"${id}" validates the store changelog but runs outside a published build: pushes have no release_notes input`,
+      );
+    }
+  }
+
+  return errors;
+};
+
+const findStoreReleaseWorkflowViolations = (rootDirectory) => {
+  return [
+    ...validateStoreReleaseWorkflow(readWorkflow(rootDirectory, STORE_RELEASE_WORKFLOW)),
+    ...validateMinimumDeployWorkflow(readWorkflow(rootDirectory, MINIMUM_DEPLOY_WORKFLOW)),
+  ];
+};
+
+const main = () => {
+  const violations = findStoreReleaseWorkflowViolations(process.cwd());
+
+  if (violations.length > 0) {
+    process.stderr.write("[store-release-workflow] FAILED\n");
+    violations.forEach((violation) => {
+      process.stderr.write(` - ${violation}\n`);
+    });
+    process.exit(1);
+  }
+
+  process.stdout.write("[store-release-workflow] OK\n");
+};
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  ANDROID_JOB,
+  FORBIDDEN_DELIVERY_FLAGS,
+  IOS_JOB,
+  PREPARE_JOB,
+  findStoreReleaseWorkflowViolations,
+  readJobNeeds,
+  splitWorkflowJobs,
+  stripComments,
+  validateMinimumDeployWorkflow,
+  validateStoreReleaseWorkflow,
+};

--- a/scripts/check-store-release-workflow.test.ts
+++ b/scripts/check-store-release-workflow.test.ts
@@ -1,0 +1,175 @@
+import path from "node:path";
+
+import {
+  findStoreReleaseWorkflowViolations,
+  readJobNeeds,
+  splitWorkflowJobs,
+  stripComments,
+  validateMinimumDeployWorkflow,
+  validateStoreReleaseWorkflow,
+} from "./check-store-release-workflow.cjs";
+
+const REPOSITORY_ROOT = path.resolve(__dirname, "..");
+
+const isolatedStoreWorkflow = `name: Store Release
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    steps:
+      - run: node scripts/store-release-notes.cjs from-text
+  android-delivery:
+    needs: prepare
+    steps:
+      - run: eas build --platform android --profile production --non-interactive
+      - run: eas submit --platform android --id "$BUILD_ID" --non-interactive
+      - run: node scripts/google-play-release.cjs --track internal
+  ios-delivery:
+    needs: prepare
+    steps:
+      - run: eas build --platform ios --profile production --non-interactive
+      - run: eas metadata:push --profile production --non-interactive
+      - run: eas submit --platform ios --id "$BUILD_ID" --non-interactive
+      - run: node scripts/app-store-connect-release-notes.cjs --app-id 1
+`;
+
+const guardedMinimumWorkflow = `name: Deploy Minimum
+jobs:
+  web-baseline-artifact:
+    steps:
+      - run: npx expo export --platform web
+  eas-preview-build:
+    if: github.event_name == 'workflow_dispatch' && inputs.run_eas_build == 'true'
+    steps:
+      - run: node scripts/store-release-notes.cjs from-text --version 1.0.0
+      - run: eas build --profile preview
+`;
+
+describe("check-store-release-workflow", () => {
+  test("the real store workflows already satisfy the delivery contract", () => {
+    expect(findStoreReleaseWorkflowViolations(REPOSITORY_ROOT)).toEqual([]);
+  });
+
+  test("accepts a pipeline where each platform owns its own job", () => {
+    expect(validateStoreReleaseWorkflow(isolatedStoreWorkflow)).toEqual([]);
+  });
+
+  test("rejects an iOS job chained to the Android job", () => {
+    const coupled = isolatedStoreWorkflow.replace(
+      "  ios-delivery:\n    needs: prepare",
+      "  ios-delivery:\n    needs: [prepare, android-delivery]",
+    );
+
+    expect(validateStoreReleaseWorkflow(coupled)).toContain(
+      "\"ios-delivery\" must not depend on \"android-delivery\": a failing store cannot block the other",
+    );
+  });
+
+  test("rejects a pipeline that collapses both platforms into one job", () => {
+    const single = isolatedStoreWorkflow
+      .replace("  android-delivery:", "  build-and-submit:")
+      .replace("  ios-delivery:\n    needs: prepare\n", "");
+
+    const errors = validateStoreReleaseWorkflow(single);
+    expect(errors).toContain(
+      ".github/workflows/store-release.yml must define the \"android-delivery\" job",
+    );
+    expect(errors).toContain(
+      ".github/workflows/store-release.yml must define the \"ios-delivery\" job",
+    );
+  });
+
+  test.each([
+    ["--what-to-test", "eas submit --platform ios --what-to-test notes.txt"],
+    ["--auto-submit", "eas build --platform android --auto-submit"],
+    ["--no-wait", "eas submit --platform android --no-wait"],
+  ])("rejects the %s delivery flag", (flag, command) => {
+    const withFlag = isolatedStoreWorkflow.replace(
+      "      - run: eas submit --platform android --id \"$BUILD_ID\" --non-interactive",
+      `      - run: ${command}`,
+    );
+
+    expect(validateStoreReleaseWorkflow(withFlag)).toContain(
+      `.github/workflows/store-release.yml must not use the "${flag}" delivery flag`,
+    );
+  });
+
+  test("documenting a forbidden flag in a comment is not using it", () => {
+    const documented = isolatedStoreWorkflow.replace(
+      "  android-delivery:",
+      "  # nunca usar --auto-submit nem --no-wait aqui\n  android-delivery:",
+    );
+
+    expect(validateStoreReleaseWorkflow(documented)).toEqual([]);
+  });
+
+  test("requires the Play release to be completed only after the submission", () => {
+    const inverted = isolatedStoreWorkflow.replace(
+      "      - run: eas submit --platform android --id \"$BUILD_ID\" --non-interactive\n      - run: node scripts/google-play-release.cjs --track internal",
+      "      - run: node scripts/google-play-release.cjs --track internal\n      - run: eas submit --platform android --id \"$BUILD_ID\" --non-interactive",
+    );
+
+    expect(validateStoreReleaseWorkflow(inverted)).toContain(
+      "Android must submit and wait before completing the Play internal release",
+    );
+  });
+
+  test("requires the App Store notes to be pushed before the iOS submit", () => {
+    const inverted = isolatedStoreWorkflow.replace(
+      "      - run: eas metadata:push --profile production --non-interactive\n      - run: eas submit --platform ios --id \"$BUILD_ID\" --non-interactive",
+      "      - run: eas submit --platform ios --id \"$BUILD_ID\" --non-interactive\n      - run: eas metadata:push --profile production --non-interactive",
+    );
+
+    const errors = validateStoreReleaseWorkflow(inverted);
+    expect(errors).toContain("iOS must push the pt-BR App Store notes before submitting the build");
+  });
+
+  test("accepts the minimum deploy workflow when only published builds demand notes", () => {
+    expect(validateMinimumDeployWorkflow(guardedMinimumWorkflow)).toEqual([]);
+  });
+
+  test("rejects gating a push-triggered job on a changelog it can never receive", () => {
+    const ungated = guardedMinimumWorkflow.replace(
+      "  web-baseline-artifact:\n    steps:\n      - run: npx expo export --platform web",
+      "  web-baseline-artifact:\n    steps:\n      - run: node scripts/store-release-notes.cjs from-text --version 1.0.0",
+    );
+
+    expect(validateMinimumDeployWorkflow(ungated)).toContain(
+      "\"web-baseline-artifact\" validates the store changelog but runs outside a published build: pushes have no release_notes input",
+    );
+  });
+
+  test("rejects a minimum deploy workflow that publishes without any changelog", () => {
+    const withoutNotes = guardedMinimumWorkflow.replace(
+      "      - run: node scripts/store-release-notes.cjs from-text --version 1.0.0\n",
+      "",
+    );
+
+    expect(validateMinimumDeployWorkflow(withoutNotes)).toContain(
+      ".github/workflows/deploy-minimum.yml must validate detailed release notes before publishing",
+    );
+  });
+
+  test("splits jobs and reads both needs syntaxes", () => {
+    const jobs = splitWorkflowJobs(`jobs:
+  first:
+    needs: prepare
+  second:
+    needs:
+      - prepare
+      - first
+`);
+
+    expect(Object.keys(jobs)).toEqual(["first", "second"]);
+    expect(readJobNeeds(jobs.first)).toEqual(["prepare"]);
+    expect(readJobNeeds(jobs.second)).toEqual(["prepare", "first"]);
+    expect(readJobNeeds("    runs-on: ubuntu-latest")).toEqual([]);
+  });
+
+  test("stripComments keeps executable lines untouched", () => {
+    expect(stripComments("# comment\n  run: eas build\n")).toBe("  run: eas build\n");
+  });
+
+  test("a workflow without a jobs block yields no jobs", () => {
+    expect(splitWorkflowJobs("name: nothing\n")).toEqual({});
+  });
+});

--- a/scripts/google-play-release.cjs
+++ b/scripts/google-play-release.cjs
@@ -149,6 +149,94 @@ const publishGooglePlayRelease = async ({
   return updatedTrack;
 };
 
+const findPublishedRelease = ({ track, versionCode }) => {
+  const releases = (track.releases ?? []).filter((release) =>
+    release.versionCodes?.includes(String(versionCode)),
+  );
+
+  if (releases.length !== 1) {
+    throw new Error(
+      `Expected one ${track.track} release for versionCode ${versionCode}, found ${releases.length}`,
+    );
+  }
+
+  return releases[0];
+};
+
+/**
+ * A release only counts as delivered when Google Play itself reports it as
+ * `completed`, carrying the human name and the pt-BR notes we pushed. Reading
+ * the track back is what turns "the API accepted the edit" into evidence.
+ */
+const assertPublishedRelease = ({ release, releaseNotes, version, versionCode }) => {
+  const expectedName = `${version} (${versionCode})`;
+  const notes = (release.releaseNotes ?? []).find((entry) => entry.language === "pt-BR");
+  const problems = [];
+
+  if (release.status !== "completed") {
+    problems.push(`status is "${release.status}" instead of "completed"`);
+  }
+
+  if (release.name !== expectedName) {
+    problems.push(`name is "${release.name}" instead of "${expectedName}"`);
+  }
+
+  if (!notes) {
+    problems.push("pt-BR release notes are missing");
+  } else if (notes.text !== releaseNotes) {
+    problems.push("pt-BR release notes do not match the validated changelog");
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      `Google Play internal release ${expectedName} was not published as expected: ${problems.join("; ")}`,
+    );
+  }
+
+  return release;
+};
+
+const verifyGooglePlayRelease = async ({
+  accessToken,
+  fetchImpl = fetch,
+  packageName,
+  releaseNotes,
+  trackName = "internal",
+  version,
+  versionCode,
+}) => {
+  const applicationUrl = `${GOOGLE_API_ROOT}/applications/${packageName}`;
+  const edit = await googleRequest({
+    accessToken,
+    fetchImpl,
+    method: "POST",
+    url: `${applicationUrl}/edits`,
+  });
+
+  try {
+    const track = await googleRequest({
+      accessToken,
+      fetchImpl,
+      url: `${applicationUrl}/edits/${edit.id}/tracks/${trackName}`,
+    });
+    return assertPublishedRelease({
+      release: findPublishedRelease({ track, versionCode }),
+      releaseNotes,
+      version,
+      versionCode,
+    });
+  } finally {
+    // Read-only edit: dropping it keeps the app free of dangling edits even
+    // when the assertion above fails.
+    await googleRequest({
+      accessToken,
+      fetchImpl,
+      method: "DELETE",
+      url: `${applicationUrl}/edits/${edit.id}`,
+    }).catch(() => undefined);
+  }
+};
+
 const parseArguments = (argv) => {
   const values = {};
 
@@ -165,14 +253,17 @@ const run = async () => {
   const metadata = JSON.parse(fs.readFileSync(args["metadata-file"], "utf8"));
   const accessToken = await requestAccessToken({ credentials });
 
-  await publishGooglePlayRelease({
+  const releaseInput = {
     accessToken,
     packageName: args.package,
     releaseNotes: metadata.releaseNotes,
     trackName: args.track ?? "internal",
     version: metadata.version,
     versionCode: args["version-code"],
-  });
+  };
+
+  await publishGooglePlayRelease(releaseInput);
+  await verifyGooglePlayRelease(releaseInput);
   process.stdout.write(
     `Google Play ${args.track ?? "internal"} release ${metadata.version} (${args["version-code"]}) completed with pt-BR notes.\n`,
   );
@@ -189,9 +280,12 @@ module.exports = {
   ANDROID_PUBLISHER_SCOPE,
   GOOGLE_API_ROOT,
   GOOGLE_TOKEN_URL,
+  assertPublishedRelease,
   createServiceAccountAssertion,
+  findPublishedRelease,
   publishGooglePlayRelease,
   requestAccessToken,
   updateRelease,
   updateTrackForVersion,
+  verifyGooglePlayRelease,
 };

--- a/scripts/google-play-release.test.ts
+++ b/scripts/google-play-release.test.ts
@@ -1,10 +1,13 @@
 import {
   GOOGLE_API_ROOT,
   GOOGLE_TOKEN_URL,
+  assertPublishedRelease,
   createServiceAccountAssertion,
+  findPublishedRelease,
   publishGooglePlayRelease,
   requestAccessToken,
   updateTrackForVersion,
+  verifyGooglePlayRelease,
 } from "./google-play-release.cjs";
 import { generateKeyPairSync } from "node:crypto";
 
@@ -151,5 +154,130 @@ describe("google-play-release", () => {
       `${applicationUrl}/edits/edit-123:commit`,
       expect.objectContaining({ method: "POST" }),
     );
+  });
+
+});
+
+describe("google-play-release — evidência pós-commit", () => {
+  test("reads the committed track back and drops the read-only edit", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(response({ id: "edit-999" }))
+      .mockResolvedValueOnce(
+        response({
+          track: "internal",
+          releases: [
+            {
+              name: "1.13.7 (41)",
+              releaseNotes: [{ language: "pt-BR", text: releaseNotes }],
+              status: "completed",
+              versionCodes: ["41"],
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(response({}, 204));
+
+    await expect(
+      verifyGooglePlayRelease({
+        accessToken: "access-token",
+        fetchImpl,
+        packageName: "com.sensoriumit.auraxis",
+        releaseNotes,
+        version: "1.13.7",
+        versionCode: "41",
+      }),
+    ).resolves.toEqual(expect.objectContaining({ status: "completed" }));
+
+    expect(fetchImpl).toHaveBeenNthCalledWith(
+      3,
+      `${GOOGLE_API_ROOT}/applications/com.sensoriumit.auraxis/edits/edit-999`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  test("fails when Google Play kept the release as a draft", async () => {
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce(response({ id: "edit-999" }))
+      .mockResolvedValueOnce(
+        response({
+          track: "internal",
+          releases: [
+            {
+              name: "1.13.7 (41)",
+              releaseNotes: [{ language: "pt-BR", text: releaseNotes }],
+              status: "draft",
+              versionCodes: ["41"],
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(response({}, 204));
+
+    await expect(
+      verifyGooglePlayRelease({
+        accessToken: "access-token",
+        fetchImpl,
+        packageName: "com.sensoriumit.auraxis",
+        releaseNotes,
+        version: "1.13.7",
+        versionCode: "41",
+      }),
+    ).rejects.toThrow("status is \"draft\" instead of \"completed\"");
+
+    // Mesmo falhando, o edit temporário é descartado.
+    expect(fetchImpl).toHaveBeenCalledTimes(3);
+  });
+
+  test("names the exact drift when the published release does not match", () => {
+    expect(() =>
+      assertPublishedRelease({
+        release: {
+          name: "1.13.6 (40)",
+          releaseNotes: [{ language: "pt-BR", text: "outro texto" }],
+          status: "completed",
+          versionCodes: ["41"],
+        },
+        releaseNotes,
+        version: "1.13.7",
+        versionCode: "41",
+      }),
+    ).toThrow(
+      "Google Play internal release 1.13.7 (41) was not published as expected: " +
+        "name is \"1.13.6 (40)\" instead of \"1.13.7 (41)\"; " +
+        "pt-BR release notes do not match the validated changelog",
+    );
+  });
+
+  test("fails when the pt-BR notes never landed", () => {
+    expect(() =>
+      assertPublishedRelease({
+        release: {
+          name: "1.13.7 (41)",
+          releaseNotes: [{ language: "en-US", text: releaseNotes }],
+          status: "completed",
+          versionCodes: ["41"],
+        },
+        releaseNotes,
+        version: "1.13.7",
+        versionCode: "41",
+      }),
+    ).toThrow("pt-BR release notes are missing");
+  });
+
+  test("refuses to validate an ambiguous versionCode", () => {
+    expect(() =>
+      findPublishedRelease({
+        track: {
+          track: "internal",
+          releases: [
+            { status: "completed", versionCodes: ["41"] },
+            { status: "draft", versionCodes: ["41"] },
+          ],
+        },
+        versionCode: "41",
+      }),
+    ).toThrow("Expected one internal release for versionCode 41, found 2");
   });
 });

--- a/scripts/governance-all.cjs
+++ b/scripts/governance-all.cjs
@@ -42,6 +42,11 @@ const GOVERNANCE_CHECKS = [
     script: "scripts/check-runtime-release-governance.cjs",
   },
   {
+    id: "store-release-workflow",
+    label: "Store delivery workflow shape",
+    script: "scripts/check-store-release-workflow.cjs",
+  },
+  {
     id: "client-security",
     label: "Client security",
     script: "scripts/check-client-security-governance.cjs",

--- a/scripts/governance-all.test.ts
+++ b/scripts/governance-all.test.ts
@@ -14,6 +14,7 @@ describe("governance-all", () => {
       "openapi-secret-hygiene",
       "sonar-config",
       "runtime-release",
+      "store-release-workflow",
       "client-security",
       "client-logging",
       "new-feature-flags",


### PR DESCRIPTION
Closes #722

## Resumo

A release `1.13.7` buildou Android e iOS corretamente e mesmo assim não terminou sozinha
([run 30098991202](https://github.com/italofelipe/auraxis-app/actions/runs/30098991202)):
o envio iOS recebeu um parâmetro de "what to test" que só existe no plano EAS Enterprise,
abortou o comando e derrubou o job — que era também o dono da finalização do Android, já
com AAB aceito. Em paralelo, o `Deploy Minimum` falhava em **todo push de `main`**.

O que mudou:

- **Isolamento por plataforma** — `store-release.yml` passa de um job monolítico para
  quatro: `prepare` (changelog validado, versão, credenciais, dedup por fingerprint e
  artifact `store-release-changelog`), `android-delivery` e `ios-delivery` — irmãos,
  dependendo **apenas** do `prepare`, nunca um do outro — e `release-summary` com
  `always()` registrando o resultado de cada loja. Uma loja pode concluir enquanto a
  outra falha.
- **Submissão explícita e aguardada** — `--auto-submit` foi removido (acopla as
  plataformas no mesmo comando e esconde o resultado da submission); build e submit são
  passos separados e nenhuma submissão usa `--no-wait`. A finalização (notas do Play,
  What to Test) só começa depois que a submission daquela plataforma terminou.
- **App Store antes do submit** — `eas metadata:push` (notas públicas pt-BR) roda no job
  iOS **antes** do `eas submit`; o What to Test continua indo pela API oficial do App
  Store Connect depois do upload. Nenhum comando depende de recurso Enterprise.
- **Google Play com evidência** — `google-play-release.cjs` abre um edit somente-leitura
  depois do commit, relê o track e exige `status: completed`, nome `versão (versionCode)`
  e as notas pt-BR idênticas às validadas. O edit temporário é descartado mesmo quando a
  asserção falha.
- **Deploy Minimum destravado** — o job de export web exigia `## Changelog de loja` num
  evento (`push`) que não carrega o input `release_notes`, então **todo push de `main`
  falhava antes de exportar** (5 dos últimos 5 runs vermelhos). A validação foi para o job
  que realmente publica (`eas-preview-build`), que também é o único runner onde
  `build/store-release/metadata.json` existe — o job de build lia um arquivo gerado em
  outro job, que nunca esteve lá.
- **Gate permanente** — novo `scripts/check-store-release-workflow.cjs` (dentro de
  `npm run policy:check`, 11 checks agora) falha o CI se os jobs voltarem a ser um só, se
  um depender do outro, se um flag proibido reaparecer, se a ordem submit → finalização
  for invertida ou se o `deploy-minimum` voltar a exigir changelog num job de push.
- **Docs** — `docs/release-process.md` ganha isolamento por plataforma, recuperação de
  falha parcial (com os comandos manuais na ordem do pipeline) e limitações do plano EAS;
  `docs/wiki/store-release-platform-isolation-2026-08-02.md` registra causa raiz,
  correção e recuperação.

## Validação

- `npm run policy:check` — OK, 11 checks (inclui o novo `store-release-workflow`).
- `npm run typecheck`, `npm run contracts:check`, `npm run codegen:check` — OK.
- `npm run test:coverage` — **444 suites / 2923 testes verdes**.
- `npx eslint` nos arquivos tocados — 0 problemas.
- Os dois workflows foram parseados como YAML para conferir a topologia real dos jobs:
  `android-delivery` e `ios-delivery` com `needs: prepare`, `release-summary` com
  `needs: [prepare, android-delivery, ios-delivery]`.
- Testes novos: 16 casos em `check-store-release-workflow.test.ts` (isolamento, jobs
  colapsados, cada flag proibido, ordenação submit → finalização, gate do deploy-minimum,
  parsing de `needs` nas duas sintaxes) + 5 casos de verificação/falha parcial em
  `google-play-release.test.ts`. Um dos testes valida os **workflows reais** do repo, não
  só fixtures.

Nenhum build EAS, OTA ou submissão foi disparado por este PR.

## Risco residual

- O caminho end-to-end só pode ser exercitado por uma tag `v*` real, que consome cota EAS
  e credenciais de loja — não dá para provar em CI. Mitigação: os comandos preservados são
  exatamente os que a recuperação manual do 1.13.7 provou funcionar, e o gate estático
  impede a regressão de forma.
- `--auto-submit` some do pipeline: quem estiver acostumado com um único passo agora vê
  build e submit separados por plataforma (comportamento pretendido).
- O primeiro `Deploy Minimum` após o merge deve voltar a ficar verde em push de `main`;
  se algum outro passo estiver quebrado, ele vai aparecer agora que o gate errado saiu da
  frente.

## Changelog de loja

- A publicação automática nas lojas passou a tratar Android e iOS de forma independente, então uma falha não bloqueia a outra.
- O aplicativo Android só é liberado no canal interno depois que a loja confirma a versão e as notas em português.
- As notas em português chegam à App Store antes do envio do build, evitando releases sem descrição do que mudou.
