### PR TITLE
fix(flags): promote app.notifications.push to enabled-prod

### DIFF
--- a/config/feature-flags.json
+++ b/config/feature-flags.json
@@ -46,8 +46,8 @@
       "createdAt": "2026-05-17",
       "removeBy": "2026-12-31",
       "type": "release",
-      "status": "enabled-dev",
-      "description": "Controla o registro de push notifications nativas no app.",
+      "status": "enabled-prod",
+      "description": "Controla o registro de push notifications nativas no app. Promovido a enabled-prod em 2026-08-11 (#801); QA em dispositivo pós-merge pelo PO. Rollback: reverter para enabled-dev.",
       "repositories": ["auraxis-app", "auraxis-api"]
     },
     {


### PR DESCRIPTION
## Summary

Promove `app.notifications.push` de `enabled-dev` para `enabled-prod`, conforme #801, com o PO optando por merge primeiro e QA em dispositivo depois.

**Nota de honestidade técnica descoberta na implementação:** diferente da web, o resolver de flags do app **não tem escada de ambientes** — `shared/feature-flags/service.ts:6-11` trata `enabled-dev`, `enabled-staging` e `enabled-prod` igualmente como ativos (`service.ts:305`). Ou seja, o registro de push já estava tecnicamente habilitado em qualquer build. Esta promoção:
1. Alinha o catálogo à convenção usada na web (onde `enabled-dev` ≠ prod);
2. Documenta a intenção real da flag;
3. Previne regressão silenciosa caso o resolver do app ganhe a mesma escada da web no futuro.

O QA de ponta a ponta (permissão iOS/Android, token, recebimento em foreground/background, deep link) fica com o Italo no dispositivo, conforme combinado.

## Validation

- `npm run quality-check` completo (lint → typecheck → policy → contracts → test:coverage ≥85%) — exit 0
- Nenhum teste fixa o status desta flag

## Screenshots

Não aplicáveis: mudança de catálogo de flag, sem alteração de UI (o fluxo de permissão de push é nativo do SO).

## Residual risk

Comportamento efetivo inalterado pelo resolver atual (ver nota acima); risco real é o QA de push pendente — rastreado com o PO. Rollback: reverter para `enabled-dev` (sem efeito prático hoje) ou usar `EXPO_PUBLIC_FLAG_APP_NOTIFICATIONS_PUSH=false`.

Closes #801

## Changelog de loja

- Notificações push nativas ativadas: você passa a receber lembretes de contas a vencer direto no celular.
- Ajustes internos de configuração para preparar os próximos avisos inteligentes do aplicativo.